### PR TITLE
fix(usage): honor session environment roots consistently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,23 +38,88 @@ jobs:
           TB_SMOKE_SKIP_NETWORK: "1"
           TOKSCALE_CONFIG_DIR: ${{ runner.temp }}\tb-smoke-config
           TOKSCALE_PRICING_CACHE_ONLY: "1"
-      # Hermetic runtime check: point HOME at a synthetic ~/.claude/projects
-      # tree and assert the engine actually parses messages on Windows —
-      # "compiles + doesn't crash" alone can't tell a dead parser from an
-      # empty machine.
-      - name: hermetic parse smoke (synthetic Claude session)
+      # Hermetic runtime check: point HOME at a synthetic Claude tree and put
+      # one valid Codex session under a different CODEX_HOME root. The strict
+      # client assertions make a pre-A1 binary fail instead of silently passing
+      # with only the HOME-backed Claude messages.
+      - name: hermetic parse smoke (isolated Claude, relocated Codex)
         shell: pwsh
         run: |
           $fx = Join-Path $env:RUNNER_TEMP "tb-home"
-          New-Item -ItemType Directory -Force -Path "$fx\.claude\projects\ci" | Out-Null
-          @'
-          {"type":"assistant","timestamp":"2026-04-01T10:00:01.000Z","requestId":"req_ci1","message":{"id":"msg_ci1","model":"claude-sonnet-4","usage":{"input_tokens":123,"output_tokens":45}}}
-          {"type":"assistant","timestamp":"2026-04-01T10:00:02.000Z","requestId":"req_ci2","message":{"id":"msg_ci2","model":"claude-sonnet-4","usage":{"input_tokens":10,"output_tokens":5}}}
-          '@ | Set-Content -Path "$fx\.claude\projects\ci\session.jsonl" -Encoding utf8
+          $codex = Join-Path $env:RUNNER_TEMP "tb-codex-root"
+          @($fx, $codex) | ForEach-Object {
+            Remove-Item -LiteralPath $_ -Recurse -Force -ErrorAction SilentlyContinue
+          }
+          $appData = Join-Path $fx "appdata"
+          $localAppData = Join-Path $fx "local-appdata"
+          $xdgData = Join-Path $fx "xdg-data"
+          $config = Join-Path $fx "config"
+          $emptyRoots = @(
+            (Join-Path $fx "grok"),
+            (Join-Path $fx "gemini"),
+            (Join-Path $fx "hermes"),
+            (Join-Path $fx "codebuff"),
+            (Join-Path $fx "jcode"),
+            (Join-Path $fx "gjc"),
+            (Join-Path $fx "goose"),
+            (Join-Path $fx "headless")
+          )
+          @(
+            "$fx\.claude\projects\ci",
+            "$codex\sessions\ci",
+            $appData,
+            $localAppData,
+            $xdgData,
+            $config
+          ) + $emptyRoots | ForEach-Object {
+            New-Item -ItemType Directory -Force -Path $_ | Out-Null
+          }
+          # dirs::data_local_dir uses the Windows Known Folder API rather than
+          # LOCALAPPDATA. A hosted runner must have no host Zed DB to ingest.
+          $hostZed = Join-Path `
+            ([Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)) `
+            "Zed\threads\threads.db"
+          if (Test-Path -LiteralPath $hostZed) {
+            throw "host profile contains a Zed session DB: $hostZed"
+          }
+          $now = [DateTime]::UtcNow
+          # Only Codex is inside the live 10-minute window, so the aggregate
+          # token rate must equal the Codex trace rate. Claude remains visible
+          # to graph/model/hourly/agents and the strict filter-delta checks.
+          $t1 = $now.AddHours(-2).AddSeconds(-20).ToString("yyyy-MM-ddTHH:mm:ss.fffZ", [Globalization.CultureInfo]::InvariantCulture)
+          $t2 = $now.AddHours(-2).AddSeconds(-10).ToString("yyyy-MM-ddTHH:mm:ss.fffZ", [Globalization.CultureInfo]::InvariantCulture)
+          $t3 = $now.AddSeconds(-10).ToString("yyyy-MM-ddTHH:mm:ss.fffZ", [Globalization.CultureInfo]::InvariantCulture)
+          @"
+          {"type":"assistant","timestamp":"$t1","requestId":"req_ci1","message":{"id":"msg_ci1","model":"claude-sonnet-4","usage":{"input_tokens":123,"output_tokens":45}}}
+          "@ | Set-Content -Path "$fx\.claude\projects\ci\session-1.jsonl" -Encoding utf8
+          @"
+          {"type":"assistant","timestamp":"$t2","requestId":"req_ci2","message":{"id":"msg_ci2","model":"claude-sonnet-4","usage":{"input_tokens":10,"output_tokens":5}}}
+          "@ | Set-Content -Path "$fx\.claude\projects\ci\session-2.jsonl" -Encoding utf8
+          @"
+          {"timestamp":"$t3","type":"session_meta","payload":{"id":"01900000-0000-7000-8000-000000000001","source":"interactive","model_provider":"openai","cwd":"C:/ci/codex"}}
+          {"timestamp":"$t3","type":"turn_context","payload":{"model":"gpt-5.4"}}
+          {"timestamp":"$t3","type":"event_msg","payload":{"type":"user_message","message":"ci smoke"}}
+          {"timestamp":"$t3","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":40,"reasoning_output_tokens":10},"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":40,"reasoning_output_tokens":10}}}}
+          "@ | Set-Content -Path "$codex\sessions\ci\session.jsonl" -Encoding utf8
           $env:HOME = $fx
-          $env:TOKSCALE_CONFIG_DIR = Join-Path $fx ".config\tokscale"
+          $env:CODEX_HOME = $codex
+          $env:APPDATA = $appData
+          $env:LOCALAPPDATA = $localAppData
+          $env:XDG_DATA_HOME = $xdgData
+          $env:TOKSCALE_CONFIG_DIR = $config
+          $env:GROK_HOME = $emptyRoots[0]
+          $env:GEMINI_CLI_HOME = $emptyRoots[1]
+          $env:HERMES_HOME = $emptyRoots[2]
+          $env:CODEBUFF_DATA_DIR = $emptyRoots[3]
+          $env:JCODE_HOME = $emptyRoots[4]
+          $env:GJC_CODING_AGENT_DIR = $emptyRoots[5]
+          $env:GOOSE_PATH_ROOT = $emptyRoots[6]
+          $env:TOKSCALE_HEADLESS_DIR = $emptyRoots[7]
+          $env:TOKSCALE_EXTRA_DIRS = ""
+          $env:COPILOT_OTEL_FILE_EXPORTER_PATH = Join-Path $fx "missing-copilot.jsonl"
           $env:TOKSCALE_PRICING_CACHE_ONLY = "1"
-          $env:TB_SMOKE_MIN_MESSAGES = "2"
+          $env:TB_SMOKE_MIN_MESSAGES = "3"
+          $env:TB_SMOKE_EXPECT_CLIENT = "codex"
           $env:TB_SMOKE_SKIP_NETWORK = "1"
           dotnet run --project src/TokenBar.Smoke -c Release --no-build
       # Self-contained smoke bundle (runtime + native dll included): lets a

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ Prereqs: Rust (stable), .NET 10 SDK; on Windows the MSVC toolchain.
 
 Windows CI now blocks on the full Rust workspace release tests, the WinUI App
 x64 Release build, solution build/tests, isolated P/Invoke and synthetic parse
-smokes, a self-contained win-x64 smoke bundle, and the ARM64 Rust release
-cross-build. The provider-pace branch passed local command-equivalent x64 and
-ARM64 gates plus fresh review on 2026-07-19; GitHub PR #3 preserves its remote
-CI and review record. `cargo fmt` is not currently a repository CI gate; its
-existing workspace-wide formatting debt is tracked separately.
+smokes (including strict relocated-`CODEX_HOME` coverage across every local
+usage surface and pre-aggregation client filters), a self-contained win-x64
+smoke bundle, and the ARM64 Rust release cross-build. The provider-pace branch
+passed local command-equivalent x64 and ARM64 gates plus fresh review on
+2026-07-19; GitHub PR #3 preserves its remote CI and review record. `cargo fmt`
+is not currently a repository CI gate; its existing workspace-wide formatting
+debt is tracked separately.
 
 ## Progress
 
@@ -68,8 +70,9 @@ separate from credential-bound live coverage. Across the staged sanitized
 manifests, the Claude and Codex credential files and legacy v1 history remained
 unchanged; expected secure account-scope and v3 pace-history artifacts were
 created or updated as the provider checks progressed. Session-parser
-environment-root overrides and RID-aware native-DLL selection/freshness remain
-separate follow-ups, not completed by PR #3.
+environment-root overrides now flow through one shared FFI source context and
+have strict relocated-`CODEX_HOME` coverage. RID-aware native-DLL selection and
+freshness remain a separate follow-up.
 
 ## Credits
 

--- a/crates/tb_core_ffi/src/agents_report.rs
+++ b/crates/tb_core_ffi/src/agents_report.rs
@@ -42,14 +42,13 @@ struct AgentsReportData {
 /// streaming scan, so an agent bucket shared across clients carries only the
 /// selected clients' tokens/cost — a membership filter downstream cannot do
 /// this because each `AgentAccumulator` folds all clients into one mixed total.
-pub fn run(year: &str, clients: Option<Vec<String>>) -> Result<Value, String> {
+pub(crate) fn run(
+    context: &crate::LocalSourceContext,
+    year: &str,
+    clients: Option<Vec<String>>,
+) -> Result<Value, String> {
     let year = normalize_year(year)?;
-
-    let options = tokscale_core::ReportOptions {
-        year,
-        clients,
-        ..Default::default()
-    };
+    let options = context.report_options(year, clients);
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/crates/tb_core_ffi/src/hourly_report.rs
+++ b/crates/tb_core_ffi/src/hourly_report.rs
@@ -40,14 +40,13 @@ struct HourlyReportData {
 /// streaming scan, so shared-hour buckets carry only the selected clients'
 /// tokens/cost — a membership filter downstream cannot do this because each
 /// `HourAggregator` folds all clients into one mixed total.
-pub fn run(year: &str, clients: Option<Vec<String>>) -> Result<Value, String> {
+pub(crate) fn run(
+    context: &crate::LocalSourceContext,
+    year: &str,
+    clients: Option<Vec<String>>,
+) -> Result<Value, String> {
     let year = normalize_year(year)?;
-
-    let options = tokscale_core::ReportOptions {
-        year,
-        clients,
-        ..Default::default()
-    };
+    let options = context.report_options(year, clients);
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/crates/tb_core_ffi/src/lib.rs
+++ b/crates/tb_core_ffi/src/lib.rs
@@ -53,6 +53,56 @@ pub(crate) fn user_home_dir() -> Option<PathBuf> {
     )
 }
 
+/// Snapshot the local source roots used by every FFI report and parse path.
+/// Environment roots are process-startup configuration: changing them requires
+/// restarting the FFI process. Cache keys intentionally do not fingerprint roots.
+#[derive(Debug, Clone)]
+pub(crate) struct LocalSourceContext {
+    home_dir: Option<PathBuf>,
+}
+
+impl LocalSourceContext {
+    pub(crate) fn current() -> Self {
+        Self {
+            home_dir: user_home_dir(),
+        }
+    }
+
+    pub(crate) fn report_options(
+        &self,
+        year: Option<String>,
+        clients: Option<Vec<String>>,
+    ) -> tokscale_core::ReportOptions {
+        tokscale_core::ReportOptions {
+            home_dir: self
+                .home_dir
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned()),
+            use_env_roots: true,
+            year,
+            clients,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn parse_options(
+        &self,
+        year: Option<String>,
+        clients: Option<Vec<String>>,
+    ) -> tokscale_core::LocalParseOptions {
+        tokscale_core::LocalParseOptions {
+            home_dir: self
+                .home_dir
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned()),
+            use_env_roots: true,
+            year,
+            clients,
+            ..Default::default()
+        }
+    }
+}
+
 /// Serve `tb_graph` from cache when the last computation is at most this old;
 /// `tb_refresh_graph` always recomputes. Mirrors the Tauri app's oneshot cache.
 const ONESHOT_MAX_AGE_SECS: u64 = 30;
@@ -208,7 +258,8 @@ fn graph_cached(year: &str, max_age: Duration) -> Option<serde_json::Value> {
     // briefly to re-stamp so the next calls inside the oneshot window skip the
     // probe entirely. A lost re-stamp (entry evicted/replaced meanwhile) just
     // degrades to the next call re-probing — benign.
-    let fresh = tokscale_core::latest_source_mtime_ms(&Default::default()).ok()?;
+    let context = LocalSourceContext::current();
+    let fresh = tokscale_core::latest_source_mtime_ms(&context.parse_options(None, None)).ok()?;
     if fresh == token {
         let mut cache = GRAPH_CACHE.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(entry) = cache.get_mut(year) {
@@ -222,9 +273,12 @@ fn graph_cached(year: &str, max_age: Duration) -> Option<serde_json::Value> {
 fn graph_compute(year: &str) -> Result<serde_json::Value, String> {
     // Probe before parsing: a write that lands mid-compute moves the mtime
     // past this token, so the next aged-out read recomputes rather than
-    // serving a graph that missed it.
-    let token = tokscale_core::latest_source_mtime_ms(&Default::default()).unwrap_or(0);
-    let data = usage_graph::run(year)?;
+    // serving a graph that missed it. Keep the same context for both paths so
+    // the mtime token and report scan observe identical source roots.
+    let context = LocalSourceContext::current();
+    let token = tokscale_core::latest_source_mtime_ms(&context.parse_options(None, None))
+        .unwrap_or(0);
+    let data = usage_graph::run(&context, year)?;
     GRAPH_CACHE
         .lock()
         .unwrap_or_else(|p| p.into_inner())
@@ -285,8 +339,8 @@ fn tail_tick_if_stale() {
 #[no_mangle]
 pub extern "C" fn tb_probe() -> *mut c_char {
     guarded("tb_probe", || {
-        let opts = tokscale_core::LocalParseOptions::default();
-        let json = match tokscale_core::parse_local_clients(opts) {
+        let context = LocalSourceContext::current();
+        let json = match tokscale_core::parse_local_clients(context.parse_options(None, None)) {
             Ok(pm) => format!(r#"{{"ok":true,"messages":{}}}"#, pm.messages.len()),
             Err(e) => serde_json::json!({"ok": false, "err": e}).to_string(),
         };
@@ -330,7 +384,8 @@ pub unsafe extern "C" fn tb_refresh_graph(year: *const c_char) -> *mut c_char {
 #[no_mangle]
 pub unsafe extern "C" fn tb_model_report(year: *const c_char) -> *mut c_char {
     guarded("tb_model_report", || {
-        envelope(unsafe { year_from(year) }.and_then(|year| model_report::run(&year)))
+        let context = LocalSourceContext::current();
+        envelope(unsafe { year_from(year) }.and_then(|year| model_report::run(&context, &year)))
     })
 }
 
@@ -347,9 +402,10 @@ pub unsafe extern "C" fn tb_hourly_report(
     clients: *const c_char,
 ) -> *mut c_char {
     guarded("tb_hourly_report", || {
+        let context = LocalSourceContext::current();
         envelope(unsafe { year_from(year) }.and_then(|year| {
             let clients = unsafe { clients_from(clients) }?;
-            hourly_report::run(&year, clients)
+            hourly_report::run(&context, &year, clients)
         }))
     })
 }
@@ -368,9 +424,10 @@ pub unsafe extern "C" fn tb_agents_report(
     clients: *const c_char,
 ) -> *mut c_char {
     guarded("tb_agents_report", || {
+        let context = LocalSourceContext::current();
         envelope(unsafe { year_from(year) }.and_then(|year| {
             let clients = unsafe { clients_from(clients) }?;
-            agents_report::run(&year, clients)
+            agents_report::run(&context, &year, clients)
         }))
     })
 }
@@ -465,6 +522,29 @@ mod tests {
     #[test]
     fn select_user_home_returns_none_without_candidates() {
         assert_eq!(select_user_home(None, None), None);
+    }
+
+    #[test]
+    fn local_source_context_builders_preserve_home_filters_and_env_roots() {
+        let platform_home = PathBuf::from("platform-home");
+        let context = LocalSourceContext {
+            home_dir: select_user_home(None, Some(platform_home.clone())),
+        };
+        let year = Some("2026".to_string());
+        let clients = Some(vec!["claude".to_string(), "codex".to_string()]);
+
+        let report = context.report_options(year.clone(), clients.clone());
+        let parse = context.parse_options(year.clone(), clients.clone());
+        let expected_home = Some(platform_home.to_string_lossy().into_owned());
+
+        assert_eq!(report.home_dir, expected_home);
+        assert_eq!(parse.home_dir, expected_home);
+        assert!(report.use_env_roots);
+        assert!(parse.use_env_roots);
+        assert_eq!(report.year, year);
+        assert_eq!(parse.year, year);
+        assert_eq!(report.clients, clients);
+        assert_eq!(parse.clients, clients);
     }
 
     /// Read a heap JSON pointer into an owned String and free it — the test-side

--- a/crates/tb_core_ffi/src/model_report.rs
+++ b/crates/tb_core_ffi/src/model_report.rs
@@ -47,13 +47,12 @@ struct ModelReportData {
 }
 
 /// Build the per-model report for `year` (empty string = all time).
-pub fn run(year: &str) -> Result<Value, String> {
+pub(crate) fn run(
+    context: &crate::LocalSourceContext,
+    year: &str,
+) -> Result<Value, String> {
     let year = normalize_year(year)?;
-
-    let options = tokscale_core::ReportOptions {
-        year,
-        ..Default::default()
-    };
+    let options = context.report_options(year, None);
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/crates/tb_core_ffi/src/usage_graph.rs
+++ b/crates/tb_core_ffi/src/usage_graph.rs
@@ -103,13 +103,12 @@ struct TokenContributionData {
 /// the async `generate_local_graph_report`. That entry point uses cached
 /// pricing with a graceful offline fallback, and `PricingService` is a process
 /// -wide `OnceCell`, so the network fetch happens at most once per launch.
-pub fn run(year: &str) -> Result<Value, String> {
+pub(crate) fn run(
+    context: &crate::LocalSourceContext,
+    year: &str,
+) -> Result<Value, String> {
     let year = normalize_year(year)?;
-
-    let options = tokscale_core::ReportOptions {
-        year,
-        ..Default::default()
-    };
+    let options = context.report_options(year, None);
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/crates/tb_core_ffi/src/usage_tail.rs
+++ b/crates/tb_core_ffi/src/usage_tail.rs
@@ -84,11 +84,10 @@ impl UsageTailer {
         // only files active within the window — plus a small margin for write
         // latency and clock skew — are re-parsed each tick.
         let window_reach_ms = (EVENT_WINDOW_SECS + 300) * 1000;
-        let options = tokscale_core::LocalParseOptions {
-            since: Some(since),
-            modified_after: Some((now_ms() - window_reach_ms) as u64),
-            ..Default::default()
-        };
+        let context = crate::LocalSourceContext::current();
+        let mut options = context.parse_options(None, None);
+        options.since = Some(since);
+        options.modified_after = Some((now_ms() - window_reach_ms) as u64);
 
         // No source changed since the last parse → the window is already
         // correct; skip the parse. Probe failure falls through to a parse.

--- a/src/TokenBar.Smoke/Program.cs
+++ b/src/TokenBar.Smoke/Program.cs
@@ -9,6 +9,8 @@ using TokenBar.Interop;
 //                          (CI points HOME at a hermetic fixture tree)
 //   TB_SMOKE_SKIP_NETWORK  "1" skips tb_agent_usage (network-bound, ~30s
 //                          worst case; useless on hosts with no credentials)
+//   TB_SMOKE_EXPECT_CLIENT assert that every local report exposes this client
+//                          (CI uses "codex" to prove relocated roots are read)
 
 var minRaw = Environment.GetEnvironmentVariable("TB_SMOKE_MIN_MESSAGES");
 long min = 0;
@@ -21,7 +23,11 @@ if (!string.IsNullOrEmpty(minRaw) && !long.TryParse(minRaw, out min))
 }
 
 var skipNetwork = Environment.GetEnvironmentVariable("TB_SMOKE_SKIP_NETWORK") == "1";
+var expectedClient = Environment.GetEnvironmentVariable("TB_SMOKE_EXPECT_CLIENT")?.Trim();
+if (string.IsNullOrEmpty(expectedClient))
+    expectedClient = null;
 var failed = 0;
+double? expectedClientTokensPerMin = null;
 
 void Step(string name, Func<string> body)
 {
@@ -47,6 +53,9 @@ Step("tb_probe", () =>
 Step("tb_graph", () =>
 {
     var g = TbCore.Graph();
+    if (expectedClient is not null && !g.Summary.Clients.Contains(expectedClient))
+        throw new InvalidOperationException(
+            $"tb_graph expected client '{expectedClient}' in Summary.Clients");
     return $"ok days={g.Contributions.Count} activeDays={g.Summary.ActiveDays} " +
            $"totalTokens={g.Summary.TotalTokens} totalCost={g.Summary.TotalCost:F2}";
 });
@@ -60,6 +69,9 @@ Step("tb_refresh_graph", () =>
 Step("tb_model_report", () =>
 {
     var r = TbCore.ModelReport();
+    if (expectedClient is not null && !r.Entries.Any(e => e.Client == expectedClient))
+        throw new InvalidOperationException(
+            $"tb_model_report expected client '{expectedClient}' in Entries");
     return $"ok entries={r.Entries.Count} totalCost={r.TotalCost:F2} " +
            $"pricingUpdatedAt={(r.PricingUpdatedAt?.ToString() ?? "-")}";
 });
@@ -73,6 +85,19 @@ Step("tb_hourly_report", () =>
     if (filtered.TotalCost > r.TotalCost)
         throw new InvalidOperationException(
             $"filtered cost {filtered.TotalCost} exceeds unfiltered {r.TotalCost}");
+    if (expectedClient is not null &&
+        !r.Entries.SelectMany(e => e.Clients).Contains(expectedClient))
+        throw new InvalidOperationException(
+            $"tb_hourly_report expected client '{expectedClient}' in Entries[].Clients");
+    if (expectedClient is not null)
+    {
+        var allMessages = r.Entries.Sum(e => e.MessageCount);
+        var claudeMessages = filtered.Entries.Sum(e => e.MessageCount);
+        if (claudeMessages >= allMessages)
+            throw new InvalidOperationException(
+                $"tb_hourly_report expected client '{expectedClient}'; " +
+                $"Claude-only MessageCount {claudeMessages} must be less than unfiltered {allMessages}");
+    }
     return $"ok entries={r.Entries.Count} totalCost={r.TotalCost:F2} " +
            $"claudeOnlyCost={filtered.TotalCost:F2}";
 });
@@ -84,6 +109,14 @@ Step("tb_agents_report", () =>
     if (filtered.TotalMessages > r.TotalMessages)
         throw new InvalidOperationException(
             $"filtered messages {filtered.TotalMessages} exceed unfiltered {r.TotalMessages}");
+    if (expectedClient is not null &&
+        !r.Entries.SelectMany(e => e.Clients).Contains(expectedClient))
+        throw new InvalidOperationException(
+            $"tb_agents_report expected client '{expectedClient}' in Entries[].Clients");
+    if (expectedClient is not null && filtered.TotalMessages >= r.TotalMessages)
+        throw new InvalidOperationException(
+            $"tb_agents_report expected client '{expectedClient}'; " +
+            $"Claude-only TotalMessages {filtered.TotalMessages} must be less than unfiltered {r.TotalMessages}");
     return $"ok entries={r.Entries.Count} totalMessages={r.TotalMessages} " +
            $"claudeOnlyMessages={filtered.TotalMessages}";
 });
@@ -91,10 +124,45 @@ Step("tb_agents_report", () =>
 Step("tb_usage_trace", () =>
 {
     var buckets = TbCore.UsageTrace(600);
+    if (expectedClient is not null)
+    {
+        var matching = buckets.Where(b => b.Client == expectedClient).ToList();
+        if (matching.Count == 0)
+            throw new InvalidOperationException(
+                $"tb_usage_trace expected client '{expectedClient}' in current window");
+        var unexpectedClients = buckets
+            .Where(b => b.Client != expectedClient)
+            .Select(b => b.Client)
+            .Distinct()
+            .ToList();
+        if (unexpectedClients.Count > 0)
+            throw new InvalidOperationException(
+                $"tb_usage_trace expected only client '{expectedClient}' in current window; " +
+                $"found {string.Join(", ", unexpectedClients)}");
+        expectedClientTokensPerMin = matching.Sum(b => b.TokensPerMin);
+        if (expectedClientTokensPerMin is not > 0)
+            throw new InvalidOperationException(
+                $"tb_usage_trace expected client '{expectedClient}' with TokensPerMin > 0");
+    }
     return $"ok buckets={buckets.Count}";
 });
 
-Step("tb_tokens_per_min", () => $"ok rate={TbCore.TokensPerMin():F1}");
+Step("tb_tokens_per_min", () =>
+{
+    var rate = TbCore.TokensPerMin();
+    if (expectedClient is not null)
+    {
+        if (expectedClientTokensPerMin is not > 0)
+            throw new InvalidOperationException(
+                $"tb_tokens_per_min expected a positive '{expectedClient}' trace rate");
+        var tolerance = Math.Max(0.1, Math.Abs(expectedClientTokensPerMin.Value) * 0.000001);
+        if (!(rate > 0) || Math.Abs(rate - expectedClientTokensPerMin.Value) > tolerance)
+            throw new InvalidOperationException(
+                $"tb_tokens_per_min rate {rate:F1} does not match " +
+                $"'{expectedClient}' trace rate {expectedClientTokensPerMin.Value:F1}");
+    }
+    return $"ok rate={rate:F1}";
+});
 
 if (skipNetwork)
 {


### PR DESCRIPTION
## Summary

- route every local session/token usage FFI surface through one `LocalSourceContext`
- use `crate::user_home_dir()` plus tokscale's existing environment-root semantics for report, parse, mtime, cache, and tail paths
- add a strict hermetic Smoke/CI fixture that proves a relocated `CODEX_HOME` reaches graph, model, hourly, agents, trace, and rate outputs while client filters still apply before aggregation
- document the completed environment-root follow-up; RID-aware native-DLL packaging remains separate

## Runtime contract

Environment roots are process-startup configuration. Changing them requires restarting TokenBar; this change intentionally does not add root fingerprints to graph or tail cache keys.

No `vendor/tokscale-core` production code or quota connector code is changed.

## Verification

- `cargo test -p tb_core_ffi --release` — 260 passed
- `cargo test -p tokscale-core clients::tests --release -- --test-threads=1` — 28 passed
- `cargo test -p tokscale-core scanner::tests --release -- --test-threads=1` — 90 passed
- `cargo test --workspace --release`
- `cargo build --release`
- `scripts/check.sh` — Rust workspace, 275 .NET tests, all-entry-point Smoke
- `dotnet build src/TokenBar.slnx -c Release`
- `dotnet test src/TokenBar.slnx -c Release --no-build` — 275 passed
- local strict positive Smoke — 3 messages; Codex present on every asserted surface; Claude-only hourly/agents counts strictly lower; aggregate rate equals the Codex trace rate
- local no-Codex negative Smoke — graph/model/hourly/agents/trace/rate sentinels all fail, including the rate step independently of the final message-count check
- Windows AMD64 `scripts/dev.ps1`, WinUI App x64 build, and exact `pwsh` strict workflow Smoke — passed
- Windows-hosted `cargo build --release --target aarch64-pc-windows-msvc` — passed
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

The strict workflow redirects every configurable scanner root into the fixture and fails if the hosted runner unexpectedly contains the one Windows Known Folder session path that cannot be environment-overridden.

`cargo fmt --all -- --check` remains non-blocking and reports the repository's existing workspace-wide formatting debt; this PR does not format unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
