### PR TITLE
build(native): package the RID-matched Rust DLL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
             provider-quota-pace-v3
       - name: compare CrossCheck outputs
         shell: bash
+        env:
+          PYTHONUTF8: "1"
         run: python3 crosscheck/diff.py crosscheck/swift-out crosscheck/csharp-out
       # Hermetic runtime check: point HOME at a synthetic Claude tree and put
       # one valid Codex session under a different CODEX_HOME root. The strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
               "$TOKENBAR_WINDOWS/crosscheck/fixtures" \
               "$TOKENBAR_WINDOWS/crosscheck/swift-out"
           )
+          (
+            cd "$TOKENBAR_MAC_CANONICAL"
+            TZ=Asia/Taipei swift run crosscheck-harness \
+              "$TOKENBAR_WINDOWS/crosscheck/fixtures" \
+              "$TOKENBAR_WINDOWS/crosscheck/swift-out" \
+              provider-quota-pace-v3
+          )
       - uses: actions/upload-artifact@v4
         with:
           name: crosscheck-swift-out
@@ -95,6 +102,12 @@ jobs:
             -c Release -- \
             crosscheck/fixtures \
             crosscheck/csharp-out
+          TZ=Asia/Taipei dotnet run \
+            --project src/TokenBar.CrossCheck \
+            -c Release -- \
+            crosscheck/fixtures \
+            crosscheck/csharp-out \
+            provider-quota-pace-v3
       - name: compare CrossCheck outputs
         shell: bash
         run: python3 crosscheck/diff.py crosscheck/swift-out crosscheck/csharp-out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,53 @@ on:
       - "**.md"
 
 jobs:
+  crosscheck-swift:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: Nanako0129/TokenBar
+          ref: 1e00e7b769a1b0d20b2de077b0a3aab52a24c088
+          path: tokenbar-mac
+      - uses: actions/checkout@v6
+        with:
+          path: tokenbar-windows
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tokenbar-mac -> target
+      - name: build Swift expected outputs (canonical SHA)
+        shell: bash
+        env:
+          TOKENBAR_WINDOWS: ${{ github.workspace }}/tokenbar-windows
+          TOKENBAR_MAC_CANONICAL: ${{ github.workspace }}/tokenbar-mac
+        run: |
+          (
+            cd "$TOKENBAR_MAC_CANONICAL"
+            cargo build --release
+          )
+          rm -rf "$TOKENBAR_WINDOWS/crosscheck/swift-out"
+          mkdir -p "$TOKENBAR_WINDOWS/crosscheck/swift-out"
+          (
+            cd "$TOKENBAR_MAC_CANONICAL"
+            TZ=Asia/Taipei swift run crosscheck-harness \
+              "$TOKENBAR_WINDOWS/crosscheck/fixtures" \
+              "$TOKENBAR_WINDOWS/crosscheck/swift-out"
+          )
+      - uses: actions/upload-artifact@v4
+        with:
+          name: crosscheck-swift-out
+          path: tokenbar-windows/crosscheck/swift-out
+
   build:
+    needs: crosscheck-swift
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          name: crosscheck-swift-out
+          path: crosscheck/swift-out
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-dotnet@v5
@@ -46,12 +89,15 @@ jobs:
       - name: CrossCheck (no Platform or RID)
         shell: bash
         run: |
-          tzutil.exe /s "Taipei Standard Time"
+          MSYS_NO_PATHCONV=1 tzutil.exe /s "Taipei Standard Time"
           TZ=Asia/Taipei dotnet run \
             --project src/TokenBar.CrossCheck \
             -c Release -- \
             crosscheck/fixtures \
             crosscheck/csharp-out
+      - name: compare CrossCheck outputs
+        shell: bash
+        run: python3 crosscheck/diff.py crosscheck/swift-out crosscheck/csharp-out
       # Hermetic runtime check: point HOME at a synthetic Claude tree and put
       # one valid Codex session under a different CODEX_HOME root. The strict
       # client assertions make a pre-A1 binary fail instead of silently passing
@@ -182,6 +228,11 @@ jobs:
           $env:TB_SMOKE_MIN_MESSAGES = "3"
           $env:TB_SMOKE_EXPECT_CLIENT = "codex"
           $env:TB_SMOKE_SKIP_NETWORK = "1"
+          $now = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", [Globalization.CultureInfo]::InvariantCulture)
+          $codexSession = Join-Path $codex "sessions\ci\session.jsonl"
+          $codexJsonl = Get-Content -LiteralPath $codexSession -Raw
+          $codexJsonl = $codexJsonl -replace '"timestamp":"[^"]+"', ('"timestamp":"{0}"' -f $now)
+          Set-Content -LiteralPath $codexSession -Value $codexJsonl -Encoding utf8
           Push-Location (Join-Path $env:GITHUB_WORKSPACE "out\smoke-win-x64")
           try {
             & ".\TokenBar.Smoke.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,29 +20,43 @@ jobs:
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
-      - name: cargo build (cdylib)
-        run: cargo build --release
+      # Directory.Build.targets owns the only Platform/RID to Rust-target
+      # mapping and produces the native source consumed by managed builds.
+      - name: build native DLL (x64 via shared mapping)
+        run: dotnet msbuild src/TokenBar.Smoke/TokenBar.Smoke.csproj -t:BuildTbNative -p:Configuration=Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64
       - name: cargo test (workspace)
         run: cargo test --workspace --release
-      - name: dotnet build
-        run: dotnet build src/TokenBar.slnx -c Release
-      - name: dotnet build (WinUI App x64)
-        run: dotnet build src/TokenBar.App -c Release -p:Platform=x64
-      - name: dotnet test
-        run: dotnet test src/TokenBar.slnx -c Release --no-build
-      - name: P/Invoke smoke (all entry points)
-        run: dotnet run --project src/TokenBar.Smoke -c Release --no-build
+      - name: build Core.Tests (x64)
+        run: dotnet build src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj -c Release -p:Platform=x64
+      - name: test Core.Tests (x64)
+        run: dotnet test src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj -c Release -p:Platform=x64 --no-build
+      - name: build WinUI App (x64)
+        run: dotnet build src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64
+      - name: build Smoke (x64)
+        run: dotnet build src/TokenBar.Smoke/TokenBar.Smoke.csproj -c Release -p:Platform=x64
+      - name: P/Invoke smoke (all entry points; x64 runtime)
+        run: dotnet run --project src/TokenBar.Smoke -c Release -p:Platform=x64 --no-build
         env:
           # Keep credential-bound agent usage and live pricing refreshes out of
           # deterministic CI; their decode paths are covered on dev machines.
           TB_SMOKE_SKIP_NETWORK: "1"
           TOKSCALE_CONFIG_DIR: ${{ runner.temp }}\tb-smoke-config
           TOKSCALE_PRICING_CACHE_ONLY: "1"
+      # CrossCheck is platform-neutral and deliberately has no Platform/RID.
+      - name: CrossCheck (no Platform or RID)
+        shell: bash
+        run: |
+          tzutil.exe /s "Taipei Standard Time"
+          TZ=Asia/Taipei dotnet run \
+            --project src/TokenBar.CrossCheck \
+            -c Release -- \
+            crosscheck/fixtures \
+            crosscheck/csharp-out
       # Hermetic runtime check: point HOME at a synthetic Claude tree and put
       # one valid Codex session under a different CODEX_HOME root. The strict
       # client assertions make a pre-A1 binary fail instead of silently passing
       # with only the HOME-backed Claude messages.
-      - name: hermetic parse smoke (isolated Claude, relocated Codex)
+      - name: hermetic parse smoke (isolated Claude, relocated Codex; x64 runtime)
         shell: pwsh
         run: |
           $fx = Join-Path $env:RUNNER_TEMP "tb-home"
@@ -121,19 +135,70 @@ jobs:
           $env:TB_SMOKE_MIN_MESSAGES = "3"
           $env:TB_SMOKE_EXPECT_CLIENT = "codex"
           $env:TB_SMOKE_SKIP_NETWORK = "1"
-          dotnet run --project src/TokenBar.Smoke -c Release --no-build
+          dotnet run --project src/TokenBar.Smoke -c Release -p:Platform=x64 --no-build
       # Self-contained smoke bundle (runtime + native dll included): lets a
       # bare Windows verification box run the full entry-point sweep with
       # nothing installed.
       - name: publish smoke bundle (win-x64 self-contained)
-        run: dotnet publish src/TokenBar.Smoke -c Release -r win-x64 --self-contained -o out/smoke-win-x64
+        run: dotnet publish src/TokenBar.Smoke/TokenBar.Smoke.csproj -c Release -r win-x64 --self-contained -o out/smoke-win-x64
+      # Execute the published file itself, with the same isolated fixture and
+      # network skip as the x64 build smoke; this is the published-runtime gate.
+      - name: run published smoke bundle (win-x64 runtime)
+        shell: pwsh
+        run: |
+          $fx = Join-Path $env:RUNNER_TEMP "tb-home"
+          $codex = Join-Path $env:RUNNER_TEMP "tb-codex-root"
+          $appData = Join-Path $fx "appdata"
+          $localAppData = Join-Path $fx "local-appdata"
+          $xdgData = Join-Path $fx "xdg-data"
+          $config = Join-Path $fx "config"
+          $emptyRoots = @(
+            (Join-Path $fx "grok"),
+            (Join-Path $fx "gemini"),
+            (Join-Path $fx "hermes"),
+            (Join-Path $fx "codebuff"),
+            (Join-Path $fx "jcode"),
+            (Join-Path $fx "gjc"),
+            (Join-Path $fx "goose"),
+            (Join-Path $fx "headless")
+          )
+          $env:HOME = $fx
+          $env:CODEX_HOME = $codex
+          $env:APPDATA = $appData
+          $env:LOCALAPPDATA = $localAppData
+          $env:XDG_DATA_HOME = $xdgData
+          $env:TOKSCALE_CONFIG_DIR = $config
+          $env:GROK_HOME = $emptyRoots[0]
+          $env:GEMINI_CLI_HOME = $emptyRoots[1]
+          $env:HERMES_HOME = $emptyRoots[2]
+          $env:CODEBUFF_DATA_DIR = $emptyRoots[3]
+          $env:JCODE_HOME = $emptyRoots[4]
+          $env:GJC_CODING_AGENT_DIR = $emptyRoots[5]
+          $env:GOOSE_PATH_ROOT = $emptyRoots[6]
+          $env:TOKSCALE_HEADLESS_DIR = $emptyRoots[7]
+          $env:TOKSCALE_EXTRA_DIRS = ""
+          $env:COPILOT_OTEL_FILE_EXPORTER_PATH = Join-Path $fx "missing-copilot.jsonl"
+          $env:TOKSCALE_PRICING_CACHE_ONLY = "1"
+          $env:TB_SMOKE_MIN_MESSAGES = "3"
+          $env:TB_SMOKE_EXPECT_CLIENT = "codex"
+          $env:TB_SMOKE_SKIP_NETWORK = "1"
+          Push-Location (Join-Path $env:GITHUB_WORKSPACE "out\smoke-win-x64")
+          try {
+            & ".\TokenBar.Smoke.exe"
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }
+          finally {
+            Pop-Location
+          }
       - uses: actions/upload-artifact@v4
         with:
           name: smoke-win-x64
           path: out/smoke-win-x64
 
-  # The ARM64 verification box is a Win11 ARM VM; cross-build the Rust core so
-  # arm64 breakage blocks the same change that introduced it.
+  # Cross-build/package only. This x64 runner never executes ARM64 binaries;
+  # real ARM64 runtime coverage remains a merge gate on the ARM64 VM.
   arm64-cross:
     runs-on: windows-latest
     steps:
@@ -144,5 +209,22 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: arm64
-      - name: cargo build (aarch64 cdylib)
-        run: cargo build --release --target aarch64-pc-windows-msvc
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+      - name: build native DLL (ARM64 cross-build only)
+        run: dotnet msbuild src/TokenBar.Smoke/TokenBar.Smoke.csproj -t:BuildTbNative -p:Configuration=Release -p:Platform=ARM64 -p:RuntimeIdentifier=win-arm64
+      - name: build WinUI App (ARM64 cross-build only)
+        run: dotnet build src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=ARM64 -p:RuntimeIdentifier=win-arm64
+      - name: publish Smoke bundle (win-arm64 cross-package validation)
+        run: dotnet publish src/TokenBar.Smoke/TokenBar.Smoke.csproj -c Release -r win-arm64 --self-contained -o out/smoke-win-arm64
+      - name: publish App bundle (win-arm64 cross-package validation)
+        run: dotnet publish src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=ARM64 -r win-arm64 -o out/app-win-arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: smoke-win-arm64
+          path: out/smoke-win-arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: app-win-arm64
+          path: out/app-win-arm64

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ a native WinUI 3 shell.
 | C ABI contract | `include/ctb.h` | 10 entry points, `{"ok":true,"data":…}` / `{"ok":false,"err":…}` |
 | Interop | `src/TokenBar.Interop` | `net10.0`, platform-neutral — P/Invoke facade + envelope decode |
 | Logic | `src/TokenBar.Core` | `net10.0`, platform-neutral — C# port of the macOS `TokenBarCore` |
-| Shell | `src/TokenBar.App` | WinUI 3, unpackaged. Windows-only build (not in the slnx): `dotnet build src/TokenBar.App -c Release -p:Platform=x64` |
+| Shell | `src/TokenBar.App` | WinUI 3, unpackaged. Windows-only build (not in the slnx): `dotnet build src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64` |
+| Windows native packaging | `src/Directory.Build.targets` | The sole `Platform`/`RuntimeIdentifier` → explicit Rust-target mapping. `BuildTbNative` produces the target-specific `tb_core_ffi.dll`; missing/conflicting tuples, wrong PE machines, and stale output/publish bytes fail fast. |
+
+Windows native packaging is opt-in for `TokenBar.App`, `TokenBar.Smoke`, and
+`TokenBar.Core.Tests`. The supported tuples are `x64`/`win-x64` →
+`x86_64-pc-windows-msvc` and `ARM64`/`win-arm64` →
+`aarch64-pc-windows-msvc`; Windows managed builds never select a default
+`target/release` DLL.
 
 ## Build
 
@@ -23,17 +30,51 @@ a native WinUI 3 shell.
 # macOS (inner loop — no Windows needed)
 scripts/check.sh
 
-# Windows
+# Windows x64: build the explicit native source, then run the x64 gates
 .\scripts\dev.ps1
+
+dotnet msbuild src/TokenBar.Smoke/TokenBar.Smoke.csproj -t:BuildTbNative -p:Configuration=Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64
+dotnet build src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj -c Release -p:Platform=x64
+dotnet test src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj -c Release -p:Platform=x64 --no-build
+dotnet build src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64
+dotnet build src/TokenBar.Smoke/TokenBar.Smoke.csproj -c Release -p:Platform=x64
+dotnet run --project src/TokenBar.Smoke -c Release -p:Platform=x64 --no-build
+dotnet publish src/TokenBar.Smoke/TokenBar.Smoke.csproj -c Release -r win-x64 --self-contained -o out/smoke-win-x64
 ```
+
+ARM64 is cross-build/package validation only on an x64 runner:
+
+```bash
+dotnet msbuild src/TokenBar.Smoke/TokenBar.Smoke.csproj -t:BuildTbNative -p:Configuration=Release -p:Platform=ARM64 -p:RuntimeIdentifier=win-arm64
+dotnet build src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=ARM64 -p:RuntimeIdentifier=win-arm64
+dotnet publish src/TokenBar.Smoke/TokenBar.Smoke.csproj -c Release -r win-arm64 --self-contained -o out/smoke-win-arm64
+dotnet publish src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=ARM64 -r win-arm64 -o out/app-win-arm64
+```
+
+The cross-language CrossCheck stays platform-neutral and has no Platform/RID:
+
+```bash
+TZ=Asia/Taipei dotnet run \
+  --project src/TokenBar.CrossCheck \
+  -c Release -- \
+  crosscheck/fixtures \
+  crosscheck/csharp-out
+```
+
+CI publishes the ARM64 artifacts `smoke-win-arm64` and `app-win-arm64` without
+executing those binaries on the x64 runner. A real ARM64 runtime on the Windows
+VM remains the merge gate.
 
 Prereqs: Rust (stable), .NET 10 SDK; on Windows the MSVC toolchain.
 
-Windows CI now blocks on the full Rust workspace release tests, the WinUI App
-x64 Release build, solution build/tests, isolated P/Invoke and synthetic parse
-smokes (including strict relocated-`CODEX_HOME` coverage across every local
-usage surface and pre-aggregation client filters), a self-contained win-x64
-smoke bundle, and the ARM64 Rust release cross-build. The provider-pace branch
+Windows CI runs the x64 Rust workspace tests, Core.Tests, WinUI App, and Smoke
+from their project roots (the solution has no x64 configuration), then executes
+both the all-entry-point and strict relocated-`CODEX_HOME` Smoke checks with
+network and host-profile isolation. It runs the no-Platform/RID CrossCheck,
+publishes and executes the self-contained `smoke-win-x64` bundle, and uploads
+that artifact. The `arm64-cross` job only cross-builds and packages the native
+DLL, Smoke bundle, and App bundle, uploading `smoke-win-arm64` and
+`app-win-arm64`; it is not an ARM64 runtime test. The provider-pace branch
 passed local command-equivalent x64 and ARM64 gates plus fresh review on
 2026-07-19; GitHub PR #3 preserves its remote CI and review record. `cargo fmt`
 is not currently a repository CI gate; its existing workspace-wide formatting
@@ -72,7 +113,8 @@ unchanged; expected secure account-scope and v3 pace-history artifacts were
 created or updated as the provider checks progressed. Session-parser
 environment-root overrides now flow through one shared FFI source context and
 have strict relocated-`CODEX_HOME` coverage. RID-aware native-DLL selection and
-freshness remain a separate follow-up.
+freshness are complete through the shared `BuildTbNative`/`Directory.Build.targets`
+path.
 
 ## Credits
 

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,16 +1,24 @@
-# Windows-side one-shot: build Rust core + .NET solution, run tests and the
-# P/Invoke smoke. Prereqs: Rust (MSVC toolchain) + .NET 10 SDK.
+# Windows-side one-shot: build the explicit Rust target, then the managed
+# solution, WinUI app, tests, and P/Invoke smoke. Prereqs: Rust (MSVC
+# toolchain) + .NET 10 SDK.
 $ErrorActionPreference = "Stop"
 Set-Location (Join-Path $PSScriptRoot "..")
 
-cargo build --release
+# Directory.Build.targets owns the Platform/RID to Rust-target mapping.
+dotnet msbuild src/TokenBar.Smoke/TokenBar.Smoke.csproj -t:BuildTbNative -p:Configuration=Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-dotnet build src/TokenBar.slnx -c Release
+dotnet build src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj -c Release -p:Platform=x64
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-dotnet test src/TokenBar.slnx -c Release --no-build
+dotnet test src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj -c Release -p:Platform=x64 --no-build
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-dotnet run --project src/TokenBar.Smoke -c Release --no-build
+dotnet build src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+dotnet build src/TokenBar.Smoke/TokenBar.Smoke.csproj -c Release -p:Platform=x64
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+dotnet run --project src/TokenBar.Smoke -c Release -p:Platform=x64 --no-build
 exit $LASTEXITCODE

--- a/scripts/verify-native-dll.ps1
+++ b/scripts/verify-native-dll.ps1
@@ -1,0 +1,142 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedMachine,
+    [string]$CompareTo
+)
+
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-MachineValue {
+    param([string]$Value)
+
+    try {
+        if ($Value.StartsWith("0x", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $number = [Convert]::ToUInt32($Value.Substring(2), 16)
+        }
+        else {
+            $number = [Convert]::ToUInt32($Value, 10)
+        }
+    }
+    catch {
+        throw "Invalid PE machine value '$Value'. Use decimal or 0x-prefixed hexadecimal."
+    }
+
+    if ($number -gt 0xffff) {
+        throw "PE machine value '$Value' is outside the COFF UInt16 range."
+    }
+
+    return [uint16]$number
+}
+
+function Get-PeMachine {
+    param([string]$FilePath)
+
+    if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) {
+        throw "Native DLL missing: $FilePath"
+    }
+
+    $stream = $null
+    $reader = $null
+    try {
+        $stream = [System.IO.FileStream]::new(
+            $FilePath,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read)
+        $reader = [System.IO.BinaryReader]::new($stream)
+
+        if ($stream.Length -lt 0x40) {
+            throw "PE file is too short to contain a DOS header: $FilePath"
+        }
+
+        if ($reader.ReadUInt16() -ne 0x5a4d) {
+            throw "Invalid DOS signature in native DLL: $FilePath"
+        }
+
+        $stream.Position = 0x3c
+        $peOffset = $reader.ReadInt32()
+        if ($peOffset -lt 0 -or [int64]$peOffset -gt ($stream.Length - 6)) {
+            throw "Invalid DOS e_lfanew in native DLL: $FilePath"
+        }
+
+        $stream.Position = $peOffset
+        if ($reader.ReadUInt32() -ne 0x00004550) {
+            throw "Invalid PE signature in native DLL: $FilePath"
+        }
+
+        $coffHeaderStart = [int64]$peOffset + 4
+        $coffHeaderEnd = $coffHeaderStart + 20
+        if ($coffHeaderEnd -gt $stream.Length) {
+            throw "PE COFF header is truncated in native DLL: $FilePath"
+        }
+
+        $machine = [uint16]$reader.ReadUInt16()
+        $numberOfSections = [uint16]$reader.ReadUInt16()
+        if ($numberOfSections -eq 0) {
+            throw "PE file has no sections in native DLL: $FilePath"
+        }
+
+        $stream.Position = $coffHeaderStart + 16
+        $sizeOfOptionalHeader = [uint16]$reader.ReadUInt16()
+        if ($sizeOfOptionalHeader -lt 2) {
+            throw "PE optional header is missing or too short in native DLL: $FilePath"
+        }
+        if (($machine -eq 0x8664 -or $machine -eq 0xaa64) -and
+            $sizeOfOptionalHeader -lt 0xf0) {
+            throw "PE32+ optional header is truncated in native DLL: $FilePath"
+        }
+
+        $optionalHeaderStart = $coffHeaderEnd
+        $optionalHeaderEnd = $optionalHeaderStart + [int64]$sizeOfOptionalHeader
+        if ($optionalHeaderEnd -gt $stream.Length) {
+            throw "PE optional header is truncated in native DLL: $FilePath"
+        }
+
+        $sectionTableEnd = $optionalHeaderEnd + ([int64]$numberOfSections * 40)
+        if ($sectionTableEnd -gt $stream.Length) {
+            throw "PE section table is truncated in native DLL: $FilePath"
+        }
+
+        $stream.Position = $optionalHeaderStart
+        $optionalHeaderMagic = $reader.ReadUInt16()
+        if (($machine -eq 0x8664 -or $machine -eq 0xaa64) -and $optionalHeaderMagic -ne 0x020b) {
+            throw ("PE optional header magic mismatch in native DLL '{0}': expected PE32+ 0x020B, got 0x{1:X4}" -f $FilePath, $optionalHeaderMagic)
+        }
+
+        return $machine
+    }
+    finally {
+        if ($null -ne $reader) {
+            $reader.Dispose()
+        }
+        if ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+}
+
+$expected = ConvertTo-MachineValue $ExpectedMachine
+$machine = [uint16](Get-PeMachine $Path)
+if ($machine -ne $expected) {
+    throw ("PE machine mismatch for '{0}': expected 0x{1:X4}, got 0x{2:X4}" -f $Path, $expected, $machine)
+}
+
+if ($CompareTo) {
+    $compareMachine = [uint16](Get-PeMachine $CompareTo)
+    if ($compareMachine -ne $expected) {
+        throw ("PE machine mismatch for comparison file '{0}': expected 0x{1:X4}, got 0x{2:X4}" -f $CompareTo, $expected, $compareMachine)
+    }
+
+    $utilityModulePath = Join-Path $PSHOME "Modules\Microsoft.PowerShell.Utility\Microsoft.PowerShell.Utility.psd1"
+    Import-Module $utilityModulePath -ErrorAction Stop
+    $pathHash = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
+    $compareHash = (Get-FileHash -LiteralPath $CompareTo -Algorithm SHA256).Hash
+    if ($pathHash -ne $compareHash) {
+        throw ("Native DLL SHA256 mismatch: '{0}' ({1}) != '{2}' ({3})" -f $Path, $pathHash, $CompareTo, $compareHash)
+    }
+}
+
+Write-Output ("Verified PE machine 0x{0:X4}: {1}" -f $machine, $Path)

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,14 +1,9 @@
 <Project>
-  <!-- Copy the cargo-built native library next to every managed output so
-       default DllImport probing finds it (tb_core_ffi.dll / libtb_core_ffi.dylib).
-       Build the Rust side first with a cargo release build at the repo root. -->
-  <PropertyGroup>
+  <!-- Keep the existing non-Windows native declarations unchanged. -->
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <TbNativeDir>$(MSBuildThisFileDirectory)..\target\release\</TbNativeDir>
   </PropertyGroup>
-  <ItemGroup>
-    <None Include="$(TbNativeDir)tb_core_ffi.dll"
-          Condition="Exists('$(TbNativeDir)tb_core_ffi.dll')"
-          CopyToOutputDirectory="PreserveNewest" Link="tb_core_ffi.dll" Visible="false" />
+  <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
     <None Include="$(TbNativeDir)libtb_core_ffi.dylib"
           Condition="Exists('$(TbNativeDir)libtb_core_ffi.dylib')"
           CopyToOutputDirectory="PreserveNewest" Link="libtb_core_ffi.dylib" Visible="false" />
@@ -16,4 +11,82 @@
           Condition="Exists('$(TbNativeDir)libtb_core_ffi.so')"
           CopyToOutputDirectory="PreserveNewest" Link="libtb_core_ffi.so" Visible="false" />
   </ItemGroup>
+
+  <!-- This is the only Windows Platform/RID to Rust-target mapping. -->
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' and '$(TbNativePackagingEnabled)' == 'true'">
+    <TbNativeRepoDir>$(MSBuildThisFileDirectory)..</TbNativeRepoDir>
+    <TbNativeVerifier>$(MSBuildThisFileDirectory)..\scripts\verify-native-dll.ps1</TbNativeVerifier>
+
+    <TbNativeRustTarget Condition="'$(Platform)' == 'x64' and ('$(RuntimeIdentifier)' == '' or '$(RuntimeIdentifier)' == 'win-x64')">x86_64-pc-windows-msvc</TbNativeRustTarget>
+    <TbNativeExpectedMachine Condition="'$(Platform)' == 'x64' and ('$(RuntimeIdentifier)' == '' or '$(RuntimeIdentifier)' == 'win-x64')">0x8664</TbNativeExpectedMachine>
+    <TbNativeRustTarget Condition="'$(Platform)' == 'ARM64' and ('$(RuntimeIdentifier)' == '' or '$(RuntimeIdentifier)' == 'win-arm64')">aarch64-pc-windows-msvc</TbNativeRustTarget>
+    <TbNativeExpectedMachine Condition="'$(Platform)' == 'ARM64' and ('$(RuntimeIdentifier)' == '' or '$(RuntimeIdentifier)' == 'win-arm64')">0xAA64</TbNativeExpectedMachine>
+    <TbNativeRustTarget Condition="('$(Platform)' == '' or '$(Platform)' == 'AnyCPU') and '$(RuntimeIdentifier)' == 'win-x64'">x86_64-pc-windows-msvc</TbNativeRustTarget>
+    <TbNativeExpectedMachine Condition="('$(Platform)' == '' or '$(Platform)' == 'AnyCPU') and '$(RuntimeIdentifier)' == 'win-x64'">0x8664</TbNativeExpectedMachine>
+    <TbNativeRustTarget Condition="('$(Platform)' == '' or '$(Platform)' == 'AnyCPU') and '$(RuntimeIdentifier)' == 'win-arm64'">aarch64-pc-windows-msvc</TbNativeRustTarget>
+    <TbNativeExpectedMachine Condition="('$(Platform)' == '' or '$(Platform)' == 'AnyCPU') and '$(RuntimeIdentifier)' == 'win-arm64'">0xAA64</TbNativeExpectedMachine>
+
+    <TbNativeSource>$(TbNativeRepoDir)\target\$(TbNativeRustTarget)\release\tb_core_ffi.dll</TbNativeSource>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT' and '$(TbNativePackagingEnabled)' == 'true' and '$(TbNativeRustTarget)' != ''">
+    <None Include="$(TbNativeSource)"
+          CopyToOutputDirectory="Always"
+          CopyToPublishDirectory="Always"
+          Link="tb_core_ffi.dll"
+          Visible="false" />
+  </ItemGroup>
+
+  <Target Name="ValidateTbNativeConfiguration"
+          Condition="'$(OS)' == 'Windows_NT' and '$(TbNativePackagingEnabled)' == 'true'">
+    <Error Condition="'$(TbNativeRustTarget)' == ''"
+           Text="Unsupported Windows native tuple: Platform='$(Platform)', RuntimeIdentifier='$(RuntimeIdentifier)'." />
+    <Error Condition="'$(TbNativeExpectedMachine)' == ''"
+           Text="Windows native tuple did not resolve an expected PE machine: Platform='$(Platform)', RuntimeIdentifier='$(RuntimeIdentifier)'." />
+  </Target>
+
+  <Target Name="ValidateTbNativeSource"
+          DependsOnTargets="ValidateTbNativeConfiguration"
+          Condition="'$(OS)' == 'Windows_NT' and '$(TbNativePackagingEnabled)' == 'true'">
+    <Error Condition="!Exists('$(TbNativeSource)')"
+           Text="Missing Rust native DLL for $(TbNativeRustTarget): $(TbNativeSource)" />
+    <Exec Command="powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File &quot;$(TbNativeVerifier)&quot; -Path &quot;$(TbNativeSource)&quot; -ExpectedMachine &quot;$(TbNativeExpectedMachine)&quot;" />
+  </Target>
+
+  <!-- Managed Build/Publish never invoke cargo; they validate and package the
+       DLL produced by the explicit BuildTbNative target. -->
+  <Target Name="ValidateTbNativePackaging"
+          BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems;Build;Publish"
+          DependsOnTargets="ValidateTbNativeSource"
+          Condition="'$(OS)' == 'Windows_NT' and '$(TbNativePackagingEnabled)' == 'true'" />
+
+  <Target Name="BuildTbNative"
+          DependsOnTargets="ValidateTbNativeConfiguration"
+          Condition="'$(OS)' == 'Windows_NT' and '$(TbNativePackagingEnabled)' == 'true'">
+    <Exec Command="cargo build --release --target &quot;$(TbNativeRustTarget)&quot;"
+          WorkingDirectory="$(TbNativeRepoDir)" />
+    <CallTarget Targets="ValidateTbNativeSource" />
+  </Target>
+
+  <Target Name="CopyTbNativeToBuildOutput"
+          AfterTargets="Build"
+          DependsOnTargets="ValidateTbNativeSource"
+          Condition="'$(OS)' == 'Windows_NT' and '$(TbNativePackagingEnabled)' == 'true'">
+    <Copy SourceFiles="$(TbNativeSource)"
+          DestinationFiles="$(TargetDir)tb_core_ffi.dll"
+          SkipUnchangedFiles="false"
+          OverwriteReadOnlyFiles="true" />
+    <Exec Command="powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File &quot;$(TbNativeVerifier)&quot; -Path &quot;$(TargetDir)tb_core_ffi.dll&quot; -ExpectedMachine &quot;$(TbNativeExpectedMachine)&quot; -CompareTo &quot;$(TbNativeSource)&quot;" />
+  </Target>
+
+  <Target Name="CopyTbNativeToPublishOutput"
+          AfterTargets="Publish"
+          DependsOnTargets="ValidateTbNativeSource"
+          Condition="'$(OS)' == 'Windows_NT' and '$(TbNativePackagingEnabled)' == 'true'">
+    <Copy SourceFiles="$(TbNativeSource)"
+          DestinationFiles="$(PublishDir)tb_core_ffi.dll"
+          SkipUnchangedFiles="false"
+          OverwriteReadOnlyFiles="true" />
+    <Exec Command="powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File &quot;$(TbNativeVerifier)&quot; -Path &quot;$(PublishDir)tb_core_ffi.dll&quot; -ExpectedMachine &quot;$(TbNativeExpectedMachine)&quot; -CompareTo &quot;$(TbNativeSource)&quot;" />
+  </Target>
 </Project>

--- a/src/TokenBar.App/TokenBar.App.csproj
+++ b/src/TokenBar.App/TokenBar.App.csproj
@@ -12,6 +12,7 @@
     <UseWinUI>true</UseWinUI>
     <WindowsPackageType>None</WindowsPackageType>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <TbNativePackagingEnabled>true</TbNativePackagingEnabled>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>TokenBar.App</RootNamespace>

--- a/src/TokenBar.App/TokenBar.App.csproj
+++ b/src/TokenBar.App/TokenBar.App.csproj
@@ -45,7 +45,8 @@
 
   <Target Name="CopyAppWinUiAssetsAfterPublish" AfterTargets="Publish">
     <ItemGroup>
-      <AppXbf Include="$(TargetDir)**\*.xbf" />
+      <AppXbf Include="$(TargetDir)**\*.xbf"
+              Exclude="$(PublishDir)**\*.xbf" />
     </ItemGroup>
     <Error Condition="!Exists('$(TargetDir)$(AssemblyName).pri')"
            Text="Missing App PRI: $(TargetDir)$(AssemblyName).pri" />

--- a/src/TokenBar.App/TokenBar.App.csproj
+++ b/src/TokenBar.App/TokenBar.App.csproj
@@ -43,4 +43,24 @@
     <Content Include="Assets\**\*.png" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <Target Name="CopyAppWinUiAssetsAfterPublish" AfterTargets="Publish">
+    <ItemGroup>
+      <AppXbf Include="$(TargetDir)**\*.xbf" />
+    </ItemGroup>
+    <Error Condition="!Exists('$(TargetDir)$(AssemblyName).pri')"
+           Text="Missing App PRI: $(TargetDir)$(AssemblyName).pri" />
+    <Error Condition="'@(AppXbf)' == ''"
+           Text="No WinUI XBF files found under $(TargetDir)" />
+    <MakeDir Directories="$(PublishDir)" />
+    <MakeDir Directories="@(AppXbf->'$(PublishDir)%(RecursiveDir)')" />
+    <Copy SourceFiles="$(TargetDir)$(AssemblyName).pri"
+          DestinationFiles="$(PublishDir)$(AssemblyName).pri"
+          SkipUnchangedFiles="false"
+          OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="@(AppXbf)"
+          DestinationFiles="@(AppXbf->'$(PublishDir)%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="false"
+          OverwriteReadOnlyFiles="true" />
+  </Target>
+
 </Project>

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <TbNativePackagingEnabled>true</TbNativePackagingEnabled>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/TokenBar.Smoke/TokenBar.Smoke.csproj
+++ b/src/TokenBar.Smoke/TokenBar.Smoke.csproj
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <TbNativePackagingEnabled>true</TbNativePackagingEnabled>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

- make `src/Directory.Build.targets` the sole Windows Platform/RID → Rust target mapping for x64 and ARM64 native DLLs
- fail before packaging on unsupported tuples, missing sources, malformed/wrong-machine PE files, or stale output/publish bytes
- drive x64 CI through project-level build/test/runtime and published Smoke gates; cross-build/package ARM64 App and Smoke artifacts without claiming x64-hosted runtime coverage
- document the explicit native build flow and mark RID-aware DLL selection/freshness complete

## Verification

- `./scripts/check.sh` — passed, including 275 .NET tests and Rust workspace tests
- `actionlint .github/workflows/ci.yml` — passed
- YAML parse and `git diff --check` — passed
- Windows x64 physical-host gate on B1 product commit `73c544c`:
  - explicit AMD64 Rust DLL build and PE/SHA-256 verification
  - Core.Tests build/test, App build, Smoke runtime, stale-output replacement, self-contained published Smoke runtime
  - supported/conflicting tuple matrix and missing/wrong/malformed/hash-mismatch negative gates
- Windows x64 host cross-package gate:
  - explicit ARM64 Rust DLL build
  - ARM64 App build and App/Smoke publish outputs verified as PE `0xAA64` with source-equal SHA-256
- fresh B1 verifier: `CONFIRMED`
- fresh B2 verifier on head `600b36e`: `CONFIRMED`

## ARM64 runtime merge gate

The `arm64-cross` job uploads `smoke-win-arm64` and `app-win-arm64`; it does not execute them on the x64 runner. Before merge, the exact-head artifacts must pass published Smoke and App startup on the ARM64 Windows VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
