### PR TITLE
chore(release): prepare v0.1.0 stable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   <!-- Phase 10: one source of truth for product, package, and assembly identity. The
-       numeric assembly/file version intentionally remains 0.1.0.0 for both
-       this preview and the future 0.1.0 stable package. -->
+       numeric assembly/file version intentionally remains 0.1.0.0 across the
+       v0.1.0-preview.1 prerelease and the v0.1.0 stable package. -->
   <PropertyGroup>
     <TbProductName>TokenBar</TbProductName>
-    <TbSemanticVersion>0.1.0-preview.1</TbSemanticVersion>
+    <TbSemanticVersion>0.1.0</TbSemanticVersion>
     <TbAssemblyVersion>0.1.0.0</TbAssemblyVersion>
     <Version>$(TbSemanticVersion)</Version>
     <PackageVersion>$(TbSemanticVersion)</PackageVersion>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Windows port of [TokenBar](https://github.com/Nanako0129/TokenBar) — the
 menu-bar/tray AI coding-agent token-usage monitor. Same Rust parsing core,
 a native WinUI 3 shell.
 
-> **Status: pre-alpha, under active development.** See the progress table
-> below. The macOS app is the shipping reference implementation.
+> **Status: v0.1.0 stable release candidate.** Phase 10 is the current unsigned
+> portable release transaction; stable publication is not claimed. See the
+> [`release contract`](docs/release.md) and the published
+> [`v0.1.0-preview.1` prerelease](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0-preview.1).
 
 ## Architecture
 
@@ -55,7 +57,7 @@ dotnet build src/TokenBar.App/TokenBar.App.csproj -c Release -p:Platform=ARM64 -
 dotnet publish src/TokenBar.Smoke/TokenBar.Smoke.csproj -c Release -r win-arm64 --self-contained -o out/smoke-win-arm64 --no-restore
 ```
 
-The private, unsigned App package command performs the locked restore, native
+The unsigned portable App package command performs the locked restore, native
 build, publish, ZIP creation, and structure/version/PE/hash checks. Use a clean
 Git checkout and a new empty output root on a Windows host or CI runner:
 
@@ -84,9 +86,14 @@ ARM64 gate on 2026-07-27: 351 Rust tests, 12 provider-v3 CrossCheck cases, PE
 checks, and synthetic WinUI startup were recorded in [the public issue
 comment](https://github.com/Nanako0129/TokenBar/issues/45#issuecomment-5091092629).
 That result does not satisfy or replace the Phase 10 published-artifact x64 and
-ARM64 gates; any new startup-smoke result must use a disposable Windows
-VM/account snapshot with production credentials absent and outbound network
-blocked.
+ARM64 gates. The published `v0.1.0-preview.1` x64/ARM64 startup-smoke used the
+active `Nanako` profile with outbound blocked under explicit approval; it was a
+non-disposable exception, not disposable isolation. For stable, the default is
+a disposable Windows VM/account with production credentials absent and outbound
+blocked; a non-disposable exception needs separate explicit authorization, must
+be labelled, and must never be called isolated. The current `v0.1.0` stable
+transaction is explicitly authorized to use the active `Nanako` profile with
+outbound blocked under those non-disposable terms.
 
 Prereqs: Rust `1.96.1`, .NET SDK `10.0.301`, PowerShell `7.0+`; on Windows the
 MSVC toolchain.
@@ -117,9 +124,10 @@ debt is tracked separately.
 | 6 | Remaining five lenses | ✅ 2026-07-02 — lens router with 160ms crossfade transitions; Models (full list + pricing hint), Daily (tap drill-down), Hourly (Timeline/Profile + show-more), Stats, Agents; lazy report loading. Verified by the user against the full synced history (5.6B tokens / 70 days). Cold first paint 11.1s → **3.8s** (warm 3.2s) after the EcoQoS/priority fix + mac-parity slow lane: schtasks-launched processes inherit BELOW_NORMAL and Windows 11 throttles tray apps (EcoQoS) — the app now parses at normal QoS and returns to power-friendly throttling when idle; graph ∥ modelReport run concurrently and agentUsage no longer gates the first snapshot (both mirror the macOS DashboardModel) |
 | 7 | Settings + tray extras | 🔶 feature-complete (macOS parity) — settings store (`%APPDATA%\TokenBar\settings.json`, atomic, unit-tested) with the year filter, chart persistence, manual-refresh spinner; tray: seven modes with the value drawn into the icon (tooltip carries the full string), bars/ring/popsicle gauges (macOS geometry verbatim), cat/parrot animation (HICON-cached, ~0.5% of a core at idle), full context menu with live quota sources; Mica settings window (ten sections, live keys, autostart via HKCU Run honoring StartupApproved); flyout footer gear+Quit; in-flyout Ctrl-shortcut set. Global `RegisterHotKey` dropped: the macOS reference ships no global shortcut, so it's not a parity gap (parked as an optional Windows-only nicety in Phase 9). Verification: icon gallery + live tray screenshots + synthesized input on the x64 box; the non-quota Settings flow passed the 125% DPI interactive gate on 2026-07-17, including live 520→600 DIP flyout resizing, persistence, singleton hide/reopen, autostart restoration, and the 48ms entrance-animation race. The separate 150% pass also passed on 2026-07-17 in an isolated RDP session: both windows reported 144 DPI, 520→600 DIP mapped immediately to 780→900 physical px, and the persisted height survived a process restart. A 33-active-day synthetic fixture supported user-checked 3D hover/orbit/zoom/Fit/Reset, and the Flyout Acrylic was subsequently verified with loaded 3D content in both light and dark themes at 200% DPI |
 | 8 | 3D integration | ✅ 2026-07-17 — product card renders the real contribution grid with macOS-parity colors/lighting (sRGB-correct opaque faces), 4× MSAA, render-on-demand orbit/pan/zoom, persisted `tokenbar.orbit.v1`, Fit/Reset, custom ray-picked tooltip, and a persisted 2D/3D toggle. Real x64 checks include corrected pointer/DPI alignment, 2D↔3D in 6.7–20.1ms, a 241-frame drag trace, idle no-present, the 50-cycle lifecycle gate, and a retained 60-minute soak: 8230 cycles, `created=8230 released=8230 removed=0 errors=0`, 3600.7s elapsed, with private-memory and handle thresholds passing. Fresh review confirmed the lifecycle and cleanup result |
-| 9 | Polish + parity + shared-core sync | 🔶 shared-engine consumer migration pins the reviewed public `tokscale-core` commit used by Native; non-quota client tabs remain complete (2026-07-17). **Provider pace v3 reconciliation completed 2026-07-19** against the exact macOS `1e00e7b` tree: Codex, Claude, Grok, Antigravity, and Copilot recurring percentage cards use stable `cardId`, opaque account scope, exact/observed duration, typed lifecycle states, and backend-owned coherent history; Windows adds CNG-backed installation identity, protected DACLs, reparse/file-ID checks, locking, capacity bounds, and atomic replacement. Strict C# decoding, `clientId|cardId` selection retention/migration, shared Dashboard/Settings row semantics, responsive Full layout, Classic/Off suppression, and typed learning/unavailable previews are active. Verification includes 275 .NET tests; the latest Windows x64 `tb_core_ffi` release suite with 300 tests; macOS and Windows x64 workspace/App/synthetic-smoke gates; ARM64 release build, 15 native security/history tests, 12 provider cases, and WinUI startup; Swift↔C# zero-difference checks across 12 provider-v3 and 116 legacy cases; light/dark responsive UI checks at 100%, 150%, and 200% DPI; sanitized production-profile preservation; and fresh focused/end-to-end verifiers. Windows runtime follow-ups resolve provider homes without `HOME`, hide and cache the Claude version probe, and discover/probe every Antigravity language server without visible console windows. Provider compatibility closure on 2026-07-20 adds Windows Antigravity OAuth-client artifact discovery, proves the installed scanner against Antigravity 2.3.1, accepts Grok's unified-billing schema as a separate non-recurring financial cap, and completes sanitized Codex/Grok/Antigravity live gates. Final review fixes unify Antigravity local/remote history scope through verified Google Email and bind the tray last-good gauge to its effective selection. This completes the pace contract only; broader quota-source ordering/visibility and new Agent-limits feature scope remain unopened · backlog: demo mode; optional Windows-only global hotkey to toggle the flyout (no macOS equivalent — needs a key-binding UI) |
-| 10 | Private unsigned App artifact contract | 🔶 `0.1.0-preview.1` contract implemented; clean CI and the Windows disposable-host startup gate remain required before any release claim. See [`docs/release.md`](docs/release.md) |
-| 11–12 | Velopack → winget/Scoop | — |
+| 9 | Polish + parity + shared-core sync | ⏸️ **Paused.** Shared-engine consumer migration pins the reviewed public `tokscale-core` commit used by Native; non-quota client tabs remain complete (2026-07-17). **Provider pace v3 reconciliation completed 2026-07-19** against the exact macOS `1e00e7b` tree: Codex, Claude, Grok, Antigravity, and Copilot recurring percentage cards use stable `cardId`, opaque account scope, exact/observed duration, typed lifecycle states, and backend-owned coherent history; Windows adds CNG-backed installation identity, protected DACLs, reparse/file-ID checks, locking, capacity bounds, and atomic replacement. Strict C# decoding, `clientId|cardId` selection retention/migration, shared Dashboard/Settings row semantics, responsive Full layout, Classic/Off suppression, and typed learning/unavailable previews are active. Verification includes 275 .NET tests; the latest Windows x64 `tb_core_ffi` release suite with 300 tests; macOS and Windows x64 workspace/App/synthetic-smoke gates; ARM64 release build, 15 native security/history tests, 12 provider cases, and WinUI startup; Swift↔C# zero-difference checks across 12 provider-v3 and 116 legacy cases; light/dark responsive UI checks at 100%, 150%, and 200% DPI; sanitized production-profile preservation; and fresh focused/end-to-end verifiers. Windows runtime follow-ups resolve provider homes without `HOME`, hide and cache the Claude version probe, and discover/probe every Antigravity language server without visible console windows. Provider compatibility closure on 2026-07-20 adds Windows Antigravity OAuth-client artifact discovery, proves the installed scanner against Antigravity 2.3.1, accepts Grok's unified-billing schema as a separate non-recurring financial cap, and completes sanitized Codex/Grok/Antigravity live gates. Final review fixes unify Antigravity local/remote history scope through verified Google Email and bind the tray last-good gauge to its effective selection. This completes the pace contract only; broader quota-source ordering/visibility and new Agent-limits feature scope remain unopened · backlog: demo mode; optional Windows-only global hotkey to toggle the flyout (no macOS equivalent — needs a key-binding UI) |
+| 10 | v0.1.0 stable portable release transaction | 🔶 Current release-candidate state: unsigned portable `v0.1.0` contract prepared; stable publication/tag/assets are not claimed. See [`docs/release.md`](docs/release.md) and the published [`v0.1.0-preview.1` prerelease](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0-preview.1) history. |
+| 11 | Velopack/signing/installer/updater | ⏭️ Next priority; unopened. |
+| 12 | winget/Scoop | — Unopened. |
 
 ### Provider runtime validation
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,16 +7,19 @@
 - [Version and toolchain locks](#version-and-toolchain-locks)
 - [Build command and outputs](#build-command-and-outputs)
 - [Verification evidence](#verification-evidence)
-- [Private startup gate](#private-startup-gate)
+- [Startup gate](#startup-gate)
 - [CI and authority gates](#ci-and-authority-gates)
 - [Phase 11/12 non-goals](#phase-1112-non-goals)
 
 ## 文件目的
 
-這份文件定義 Windows App `0.1.0-preview.1` 的私有、未簽署 release-artifact
-契約。它描述版本來源、鎖定的 dependency/toolchain、產物與 evidence，以及
-哪些檢查必須在獨立的 Windows 主機完成；它不是公開下載頁，也不授權簽署、
-上傳或套用 Velopack。
+這份文件定義 Windows App `v0.1.0` stable、未簽署、portable release-candidate
+transaction 契約。它描述版本來源、鎖定的 dependency/toolchain、產物與
+evidence，以及哪些檢查必須在 Windows 主機完成。`v0.1.0-preview.1` 已作為
+公開的未簽署 prerelease 發布；stable 尚未宣稱發布，也不授權簽署、公開
+publication、tag、assets 或套用 Velopack。
+
+Preview history: [`v0.1.0-preview.1` published prerelease](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0-preview.1).
 
 > **核心原則：** Hosted CI 可以證明結構、版本、PE architecture 與 hash，
 > 但不能把 x64 runner 上的 cross-build 說成 ARM64 runtime 或互動式 WinUI
@@ -24,10 +27,11 @@
 
 ## Release boundary
 
-Phase 10 的產物是 repo-owned PowerShell command 產生的 version/RID-labelled
+Phase 10 的 stable 產物是 repo-owned PowerShell command 產生的 version/RID-labelled
 App ZIP、SHA-256 checksum 與 sanitized JSON evidence。ZIP 保留在 private
-runner/host output root；GitHub Actions 只上傳 evidence 與 checksum，絕不把
-App ZIP、EXE 或 DLL 當成 CI artifact 或 release asset。
+runner/host output root；hosted CI 只上傳 evidence 與 checksum，絕不把
+App ZIP、EXE 或 DLL 當成 CI artifact 或 release asset。Stable public
+publication/tag/assets remain a separate explicit authority gate.
 
 ```mermaid
 flowchart TD
@@ -35,8 +39,8 @@ flowchart TD
     RESTORE --> NATIVE["BuildTbNative + cargo --locked"]
     NATIVE --> PUBLISH["dotnet publish for one RID"]
     PUBLISH --> CHECK["Structure + version + PE + hash checks"]
-    CHECK --> PRIVATE["Private ZIP + checksum + evidence"]
-    PRIVATE --> HOST["Disposable Windows VM startup-smoke"]
+    CHECK --> PRIVATE["Stable unsigned portable ZIP + checksum + evidence"]
+    PRIVATE --> HOST["Windows VM/account startup-smoke"]
     PRIVATE --> CI["Hosted CI evidence only"]
 ```
 
@@ -52,15 +56,18 @@ literal and the props file.
 | Contract item | Locked value | Authority or behavior |
 |---|---|---|
 | Product name | `TokenBar` | `TbProductName`; App assembly/executable and artifact basename derive from this property |
-| Package SemVer | `0.1.0-preview.1` | `TbSemanticVersion`, `Version`, `PackageVersion` |
-| InformationalVersion | `0.1.0-preview.1` | Exact About/sentinel value; source-revision suffix disabled |
-| AssemblyVersion | `0.1.0.0` | Preview and future `0.1.0` stable use the same numeric identity |
+| Package SemVer | `0.1.0` | `TbSemanticVersion`, `Version`, `PackageVersion` |
+| InformationalVersion | `0.1.0` | Exact About/sentinel value; source-revision suffix disabled |
+| AssemblyVersion | `0.1.0.0` | `v0.1.0-preview.1` and stable `v0.1.0` use the same numeric identity |
 | FileVersion | `0.1.0.0` | PE/file metadata |
 | Win32 manifest version | `0.1.0.0` | `src/TokenBar.App/app.manifest`; verifier rejects drift |
 | .NET SDK | `10.0.301` | [`global.json`](../global.json), roll-forward disabled |
 | Rust toolchain | `1.96.1`, minimal profile | [`rust-toolchain.toml`](../rust-toolchain.toml) |
 | NuGet graph | Lock files required | `RestorePackagesWithLockFile=true`; release restore uses `--locked-mode` |
 | Cargo graph | `Cargo.lock` required | Native build uses `cargo ... --locked` |
+
+The published `v0.1.0-preview.1` remains the recorded unsigned prerelease
+history; it is not the stable publication.
 
 The App direct package versions are intentionally exact: Windows App SDK
 `1.8.260710003`, Windows SDK BuildTools `10.0.28000.2526`, H.NotifyIcon.WinUI
@@ -99,8 +106,8 @@ native source/publish byte equality.
 
 | Output | Purpose | Upload policy |
 |---|---|---|
-| `TokenBar-App-0.1.0-preview.1-win-<rid>.zip` | Private unsigned App package | Never uploaded by hosted CI |
-| `TokenBar-App-0.1.0-preview.1-win-<rid>.zip.sha256` | ZIP SHA-256 and filename | Uploaded as sanitized CI evidence |
+| `TokenBar-App-0.1.0-win-<rid>.zip` | Stable unsigned portable App package | Never uploaded by hosted CI |
+| `TokenBar-App-0.1.0-win-<rid>.zip.sha256` | ZIP SHA-256 and filename | Uploaded as sanitized CI evidence |
 | `evidence.json` | Version, RID, toolchain, git SHA, inventory, hashes, gate boundary | Uploaded as sanitized CI evidence |
 | `publish/` | Staging files used for checks and ZIP creation | Private command output only |
 
@@ -121,7 +128,7 @@ below.
 | `rustc.release` | `1.96.1` |
 | `rustc.commitHash` | Concrete rustc commit hash, not `unknown` |
 | `rid` | `win-x64` or `win-arm64` |
-| `semanticVersion` / `informationalVersion` | `0.1.0-preview.1` |
+| `semanticVersion` / `informationalVersion` | `0.1.0` |
 | `assemblyVersion` / `manifestVersion` | `0.1.0.0` |
 | `artifact.sha256` | SHA-256 of the labelled ZIP |
 | `inventory[].path` | Relative path with no drive or profile prefix |
@@ -132,10 +139,10 @@ failures. The command does not fabricate a lock graph when restore inputs are
 unavailable; the generated `packages.lock.json` files must be produced by an
 authorized Windows restore and committed before release CI can pass.
 
-## Private startup gate
+## Startup gate
 
-The bounded probe is a separate host action after the published package has
-passed structure checks:
+The bounded probe is a separate host action after the package has passed
+structure checks:
 
 ```powershell
 TokenBar.App.exe --startup-smoke C:\phase10\sentinel.json
@@ -148,11 +155,21 @@ Missing, invalid or already-existing paths are hard failures. The process sets
 `ExitCode` and routes shutdown through `TrayService.QuitApp` so feed/timer/tray
 and GDI cleanup runs before `Application.Exit`.
 
-The gate runs only in a separately provided disposable Windows VM/account
-snapshot with production credentials absent and outbound network blocked. An
-environment-variable reassignment or a different working directory alone is
-not isolation. Hosted CI does not execute this probe and must not describe its
-evidence as an interactive startup pass.
+The published `v0.1.0-preview.1` x64 and ARM64 startup-smoke runs used the active
+`Nanako` profile with outbound network blocked under explicit approval. This was
+a non-disposable exception for the prerelease, not disposable isolation, and it
+must never be described as isolated. Both runs reached `tray-ready` and exited
+with task result `0`.
+
+For stable, the default gate is a separately provided disposable Windows
+VM/account snapshot with production credentials absent and outbound network
+blocked. An environment-variable reassignment or a different working directory
+alone is not isolation. A non-disposable exception requires separate explicit
+authorization, must be labelled as a non-disposable exception, and must never
+be called isolated. The current `v0.1.0` stable transaction is explicitly
+authorized to use the active `Nanako` profile with outbound blocked under those
+non-disposable terms. Hosted CI does not execute this probe and must not
+describe its evidence as an interactive startup pass.
 
 The M19-B1 historical real-ARM64 result (2026-07-27: 351 Rust tests, 12
 provider-v3 CrossCheck cases, PE checks and synthetic WinUI startup) is recorded
@@ -168,17 +185,18 @@ published-artifact x64/ARM64 gates.
 | Native/App build | Run exact SDK/Rust, `cargo --locked`, `BuildTbNative`, and both RIDs | Preserve `src/Directory.Build.targets` mapping and native verifier |
 | Artifact command | Exercise the repo-owned command in runner temp for x64 and ARM64 | Keep ZIP/EXE/DLL private; upload only evidence/checksums |
 | PE/version/hash | Check inventory, architecture, version mapping and stale-DLL equality | Treat any mismatch as a release blocker |
-| Interactive startup | No hosted claim | Run the bounded probe on the disposable Windows VM/account snapshot |
-| Public release | No CI publication or signing | Requires an explicit later authority decision |
+| Interactive startup | No hosted claim | Run the bounded probe on the default disposable host or an explicitly authorized, labelled non-disposable exception; `v0.1.0` uses the active `Nanako` profile with outbound blocked |
+| Public stable release | No CI publication, signing, tag, or asset upload | Requires a separate explicit authority decision |
 
 ## Phase 11/12 non-goals
 
-Phase 10 does not add Velopack packaging, signing credentials, public App
-uploads, winget/Scoop manifests, general logger or DI rewrites, settings
-migrations, network-suppression seams, or a replacement for the existing native
-build plumbing. Those are Phase 11/12 scope and remain unopened until a later
-authority gate explicitly approves them.
+Phase 10 does not add Velopack packaging, signing credentials, automated
+publication from hosted CI, winget/Scoop manifests, general logger or DI
+rewrites, settings migrations, network-suppression seams, or a replacement for
+the existing native build plumbing. Velopack/signing/installer/updater is the
+next Phase 11 priority; winget/Scoop is Phase 12 and remains unopened until a
+later authority gate explicitly approves it.
 
-The release command is therefore a private, unsigned evidence producer. A
-successful hosted job or historical ARM64 VM result alone is not permission to
-publish a package, attach an App binary, or claim stable-release readiness.
+The release command is therefore a stable unsigned portable evidence producer.
+A successful hosted job or historical ARM64 VM result alone is not permission to
+publish stable artifacts, attach an App binary, or claim stable publication.

--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -25,7 +25,7 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$ExpectedSemanticVersion = "0.1.0-preview.1"
+$ExpectedSemanticVersion = "0.1.0"
 $ExpectedAssemblyVersion = "0.1.0.0"
 $ExpectedDotnetVersion = "10.0.301"
 $ExpectedRustVersion = "1.96.1"

--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -416,7 +416,7 @@ $evidence = [ordered]@{
     inventory = $inventory
     startupSmoke = [ordered]@{
         command = "$appExecutableName --startup-smoke <new-sentinel-path>"
-        hostGate = "explicitly authorized non-disposable active Nanako profile with outbound network blocked; not isolated"
+        hostGate = "explicitly authorized non-disposable active user profile with outbound network blocked; not isolated"
         hostedCi = "structure/version/PE/hash checks only; no interactive WinUI startup claim"
     }
 }

--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -416,7 +416,7 @@ $evidence = [ordered]@{
     inventory = $inventory
     startupSmoke = [ordered]@{
         command = "$appExecutableName --startup-smoke <new-sentinel-path>"
-        hostGate = "private disposable Windows VM/account snapshot with production credentials absent and outbound network blocked"
+        hostGate = "explicitly authorized non-disposable active Nanako profile with outbound network blocked; not isolated"
         hostedCi = "structure/version/PE/hash checks only; no interactive WinUI startup claim"
     }
 }

--- a/src/TokenBar.App/packages.lock.json
+++ b/src/TokenBar.App/packages.lock.json
@@ -220,7 +220,7 @@
       "tokenbar.core": {
         "type": "Project",
         "dependencies": {
-          "TokenBar.Interop": "[0.1.0-preview.1, )"
+          "TokenBar.Interop": "[0.1.0, )"
         }
       },
       "tokenbar.interop": {

--- a/src/TokenBar.Core.Tests/packages.lock.json
+++ b/src/TokenBar.Core.Tests/packages.lock.json
@@ -102,7 +102,7 @@
       "tokenbar.core": {
         "type": "Project",
         "dependencies": {
-          "TokenBar.Interop": "[0.1.0-preview.1, )"
+          "TokenBar.Interop": "[0.1.0, )"
         }
       },
       "tokenbar.interop": {

--- a/src/TokenBar.CrossCheck/packages.lock.json
+++ b/src/TokenBar.CrossCheck/packages.lock.json
@@ -5,7 +5,7 @@
       "tokenbar.core": {
         "type": "Project",
         "dependencies": {
-          "TokenBar.Interop": "[0.1.0-preview.1, )"
+          "TokenBar.Interop": "[0.1.0, )"
         }
       },
       "tokenbar.interop": {


### PR DESCRIPTION
## Summary

- promote the authoritative package and informational SemVer from `0.1.0-preview.1` to `0.1.0` while preserving the TokenBar identity and numeric `0.1.0.0` assembly/file/manifest identity
- align the existing fail-closed artifact command with stable-labelled x64 and ARM64 portable outputs
- close out the published preview history and record the explicitly approved non-disposable `Nanako` profile startup-smoke terms for the stable transaction
- pause Phase 9, make Phase 11 the next priority, and leave Phase 12 unopened

## Boundary

This PR prepares a stable unsigned portable release candidate. It does not change app/runtime behavior, dependencies, lock files, the `tokscale-core` pin, CI, signing, installers, updaters, or package-manager publication. It does not claim that `v0.1.0` has been built, tagged, or published; those remain later gated steps.

Hosted CI remains evidence/checksum-only for App packaging and does not upload App ZIP, EXE, or DLL binaries.

## Verification

- exact base `26492a5b615fed9378034e7bb56bc5aeccf5d368`
- exact `tokscale-core` pin `b31e39425859393504a2d56cb5af7c93e6461c7d`
- four-file scope and clean worktree diff checks
- XML product/version/manifest contract validation
- PowerShell parser validation on the existing Windows PowerShell host
- fresh outcome verifier: `CONFIRMED`, with no surviving P0-P4 finding

Windows x64/ARM64 artifact builds and native startup smoke are intentionally deferred until after merge and remain prerequisites for any stable release.