### PR TITLE
docs(release): close Phase 10 after v0.1.0 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Windows port of [TokenBar](https://github.com/Nanako0129/TokenBar) — the
 menu-bar/tray AI coding-agent token-usage monitor. Same Rust parsing core,
 a native WinUI 3 shell.
 
-> **Status: v0.1.0 stable release candidate.** Phase 10 is the current unsigned
-> portable release transaction; stable publication is not claimed. See the
-> [`release contract`](docs/release.md) and the published
-> [`v0.1.0-preview.1` prerelease](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0-preview.1).
+> **Status: v0.1.0 stable released.** Phase 10 completed the unsigned portable
+> release transaction. Download the
+> [`v0.1.0` stable release](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0),
+> or see the [`release contract`](docs/release.md) and
+> [`v0.1.0-preview.1` prerelease history](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0-preview.1).
 
 ## Architecture
 
@@ -77,8 +78,8 @@ TZ=Asia/Taipei dotnet run \
 ```
 
 CI publishes only short-retention Smoke test-harness artifacts and sanitized
-Phase 10 App evidence/checksums. App ZIP/EXE/DLL files are never uploaded. The
-hosted runners perform structure, version, PE, and hash checks; they do not
+Phase 10 App evidence/checksums. Hosted CI never uploads App ZIP/EXE/DLL files.
+The hosted runners perform structure, version, PE, and hash checks; they do not
 claim an interactive WinUI startup gate.
 
 The M19-B1 real-ARM64 result is historical evidence from a separate Windows
@@ -91,9 +92,10 @@ active `Nanako` profile with outbound blocked under explicit approval; it was a
 non-disposable exception, not disposable isolation. For stable, the default is
 a disposable Windows VM/account with production credentials absent and outbound
 blocked; a non-disposable exception needs separate explicit authorization, must
-be labelled, and must never be called isolated. The current `v0.1.0` stable
-transaction is explicitly authorized to use the active `Nanako` profile with
-outbound blocked under those non-disposable terms.
+be labelled, and must never be called isolated. The published `v0.1.0` stable
+x64/ARM64 startup-smoke used the separately authorized active `Nanako` profile
+with executable-specific outbound blocking under those non-disposable terms;
+both runs reached `tray-ready` and exited with task result `0`.
 
 Prereqs: Rust `1.96.1`, .NET SDK `10.0.301`, PowerShell `7.0+`; on Windows the
 MSVC toolchain.
@@ -125,7 +127,7 @@ debt is tracked separately.
 | 7 | Settings + tray extras | 🔶 feature-complete (macOS parity) — settings store (`%APPDATA%\TokenBar\settings.json`, atomic, unit-tested) with the year filter, chart persistence, manual-refresh spinner; tray: seven modes with the value drawn into the icon (tooltip carries the full string), bars/ring/popsicle gauges (macOS geometry verbatim), cat/parrot animation (HICON-cached, ~0.5% of a core at idle), full context menu with live quota sources; Mica settings window (ten sections, live keys, autostart via HKCU Run honoring StartupApproved); flyout footer gear+Quit; in-flyout Ctrl-shortcut set. Global `RegisterHotKey` dropped: the macOS reference ships no global shortcut, so it's not a parity gap (parked as an optional Windows-only nicety in Phase 9). Verification: icon gallery + live tray screenshots + synthesized input on the x64 box; the non-quota Settings flow passed the 125% DPI interactive gate on 2026-07-17, including live 520→600 DIP flyout resizing, persistence, singleton hide/reopen, autostart restoration, and the 48ms entrance-animation race. The separate 150% pass also passed on 2026-07-17 in an isolated RDP session: both windows reported 144 DPI, 520→600 DIP mapped immediately to 780→900 physical px, and the persisted height survived a process restart. A 33-active-day synthetic fixture supported user-checked 3D hover/orbit/zoom/Fit/Reset, and the Flyout Acrylic was subsequently verified with loaded 3D content in both light and dark themes at 200% DPI |
 | 8 | 3D integration | ✅ 2026-07-17 — product card renders the real contribution grid with macOS-parity colors/lighting (sRGB-correct opaque faces), 4× MSAA, render-on-demand orbit/pan/zoom, persisted `tokenbar.orbit.v1`, Fit/Reset, custom ray-picked tooltip, and a persisted 2D/3D toggle. Real x64 checks include corrected pointer/DPI alignment, 2D↔3D in 6.7–20.1ms, a 241-frame drag trace, idle no-present, the 50-cycle lifecycle gate, and a retained 60-minute soak: 8230 cycles, `created=8230 released=8230 removed=0 errors=0`, 3600.7s elapsed, with private-memory and handle thresholds passing. Fresh review confirmed the lifecycle and cleanup result |
 | 9 | Polish + parity + shared-core sync | ⏸️ **Paused.** Shared-engine consumer migration pins the reviewed public `tokscale-core` commit used by Native; non-quota client tabs remain complete (2026-07-17). **Provider pace v3 reconciliation completed 2026-07-19** against the exact macOS `1e00e7b` tree: Codex, Claude, Grok, Antigravity, and Copilot recurring percentage cards use stable `cardId`, opaque account scope, exact/observed duration, typed lifecycle states, and backend-owned coherent history; Windows adds CNG-backed installation identity, protected DACLs, reparse/file-ID checks, locking, capacity bounds, and atomic replacement. Strict C# decoding, `clientId|cardId` selection retention/migration, shared Dashboard/Settings row semantics, responsive Full layout, Classic/Off suppression, and typed learning/unavailable previews are active. Verification includes 275 .NET tests; the latest Windows x64 `tb_core_ffi` release suite with 300 tests; macOS and Windows x64 workspace/App/synthetic-smoke gates; ARM64 release build, 15 native security/history tests, 12 provider cases, and WinUI startup; Swift↔C# zero-difference checks across 12 provider-v3 and 116 legacy cases; light/dark responsive UI checks at 100%, 150%, and 200% DPI; sanitized production-profile preservation; and fresh focused/end-to-end verifiers. Windows runtime follow-ups resolve provider homes without `HOME`, hide and cache the Claude version probe, and discover/probe every Antigravity language server without visible console windows. Provider compatibility closure on 2026-07-20 adds Windows Antigravity OAuth-client artifact discovery, proves the installed scanner against Antigravity 2.3.1, accepts Grok's unified-billing schema as a separate non-recurring financial cap, and completes sanitized Codex/Grok/Antigravity live gates. Final review fixes unify Antigravity local/remote history scope through verified Google Email and bind the tray last-good gauge to its effective selection. This completes the pace contract only; broader quota-source ordering/visibility and new Agent-limits feature scope remain unopened · backlog: demo mode; optional Windows-only global hotkey to toggle the flyout (no macOS equivalent — needs a key-binding UI) |
-| 10 | v0.1.0 stable portable release transaction | 🔶 Current release-candidate state: unsigned portable `v0.1.0` contract prepared; stable publication/tag/assets are not claimed. See [`docs/release.md`](docs/release.md) and the published [`v0.1.0-preview.1` prerelease](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0-preview.1) history. |
+| 10 | v0.1.0 stable portable release transaction | ✅ 2026-07-29 — [`v0.1.0`](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0) published as the unsigned portable x64/ARM64 stable release from `aa671e0`, with eight checksum/evidence/smoke/package assets and native `tray-ready` startup evidence under the explicitly approved non-disposable active-profile boundary. See [`docs/release.md`](docs/release.md). |
 | 11 | Velopack/signing/installer/updater | ⏭️ Next priority; unopened. |
 | 12 | winget/Scoop | — Unopened. |
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,6 +3,7 @@
 ## 目錄
 
 - [文件目的](#文件目的)
+- [Published stable outcome](#published-stable-outcome)
 - [Release boundary](#release-boundary)
 - [Version and toolchain locks](#version-and-toolchain-locks)
 - [Build command and outputs](#build-command-and-outputs)
@@ -13,11 +14,10 @@
 
 ## 文件目的
 
-這份文件定義 Windows App `v0.1.0` stable、未簽署、portable release-candidate
-transaction 契約。它描述版本來源、鎖定的 dependency/toolchain、產物與
-evidence，以及哪些檢查必須在 Windows 主機完成。`v0.1.0-preview.1` 已作為
-公開的未簽署 prerelease 發布；stable 尚未宣稱發布，也不授權簽署、公開
-publication、tag、assets 或套用 Velopack。
+這份文件定義 Windows App `v0.1.0` stable、未簽署、portable release
+transaction 契約與已完成的 Phase 10 outcome。它描述版本來源、鎖定的
+dependency/toolchain、產物、evidence，以及哪些檢查必須在 Windows 主機
+完成。這次發布不包含簽署、installer、updater 或 Velopack。
 
 Preview history: [`v0.1.0-preview.1` published prerelease](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0-preview.1).
 
@@ -25,13 +25,34 @@ Preview history: [`v0.1.0-preview.1` published prerelease](https://github.com/Na
 > 但不能把 x64 runner 上的 cross-build 說成 ARM64 runtime 或互動式 WinUI
 > startup gate。
 
+## Published stable outcome
+
+[`v0.1.0`](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0)
+was published on 2026-07-29 as the public, non-prerelease Latest release. Its
+lightweight tag points directly to
+`aa671e0730ecb2581415e6571842ad086ab06e47`. The release has eight assets: one
+ZIP, checksum, sanitized build-evidence JSON, and startup-smoke sentinel for
+each of `win-x64` and `win-arm64`.
+
+| RID | Published ZIP SHA-256 | Native startup result |
+|---|---|---|
+| `win-x64` | `ce04b5c1ce0797d5d3fc6ad3a19f8cba227600632b1f509eb6131180703a3fab` | `X64`, `tray-ready`, task result `0` |
+| `win-arm64` | `4c46b1e6b1a3e206363343d2023dd48ac8623baeca6bca5ea3414f6fa4f3333d` | `Arm64`, `tray-ready`, task result `0` |
+
+Both startup runs used the separately authorized active `Nanako` profile with
+an executable-specific outbound block. This was a labelled non-disposable
+exception, not an isolated-host claim. The eight public asset names, byte
+lengths, and GitHub SHA-256 digests matched the locally verified release set,
+and each unauthenticated download returned HTTP 200 after publication.
+
 ## Release boundary
 
 Phase 10 的 stable 產物是 repo-owned PowerShell command 產生的 version/RID-labelled
 App ZIP、SHA-256 checksum 與 sanitized JSON evidence。ZIP 保留在 private
 runner/host output root；hosted CI 只上傳 evidence 與 checksum，絕不把
-App ZIP、EXE 或 DLL 當成 CI artifact 或 release asset。Stable public
-publication/tag/assets remain a separate explicit authority gate.
+App ZIP、EXE 或 DLL 當成 CI artifact，也不負責建立 tag 或 GitHub Release。
+`v0.1.0` 的 public tag/assets 是在 separate explicit authority gate 後手動
+發布；future publication remains a separate authority gate.
 
 ```mermaid
 flowchart TD
@@ -42,6 +63,7 @@ flowchart TD
     CHECK --> PRIVATE["Stable unsigned portable ZIP + checksum + evidence"]
     PRIVATE --> HOST["Windows VM/account startup-smoke"]
     PRIVATE --> CI["Hosted CI evidence only"]
+    HOST --> RELEASE["Manual public release after explicit authority"]
 ```
 
 `--startup-smoke` is opt-in. Launches without that flag follow the existing
@@ -67,7 +89,8 @@ literal and the props file.
 | Cargo graph | `Cargo.lock` required | Native build uses `cargo ... --locked` |
 
 The published `v0.1.0-preview.1` remains the recorded unsigned prerelease
-history; it is not the stable publication.
+history; stable is the separate published `v0.1.0` tag at the exact source SHA
+recorded above.
 
 The App direct package versions are intentionally exact: Windows App SDK
 `1.8.260710003`, Windows SDK BuildTools `10.0.28000.2526`, H.NotifyIcon.WinUI
@@ -166,10 +189,11 @@ VM/account snapshot with production credentials absent and outbound network
 blocked. An environment-variable reassignment or a different working directory
 alone is not isolation. A non-disposable exception requires separate explicit
 authorization, must be labelled as a non-disposable exception, and must never
-be called isolated. The current `v0.1.0` stable transaction is explicitly
-authorized to use the active `Nanako` profile with outbound blocked under those
-non-disposable terms. Hosted CI does not execute this probe and must not
-describe its evidence as an interactive startup pass.
+be called isolated. The published `v0.1.0` stable x64 and ARM64 runs used that
+separately authorized active `Nanako` exception with executable-specific
+outbound blocking. Both reached `tray-ready`, exited with task result `0`, and
+produced the attached startup-smoke sentinels. Hosted CI does not execute this
+probe and must not describe its evidence as an interactive startup pass.
 
 The M19-B1 historical real-ARM64 result (2026-07-27: 351 Rust tests, 12
 provider-v3 CrossCheck cases, PE checks and synthetic WinUI startup) is recorded
@@ -183,10 +207,10 @@ published-artifact x64/ARM64 gates.
 |---|---|---|
 | Dependency restore | Restore every required project with `--locked-mode` | Commit generated lock files; do not hand-edit graph contents |
 | Native/App build | Run exact SDK/Rust, `cargo --locked`, `BuildTbNative`, and both RIDs | Preserve `src/Directory.Build.targets` mapping and native verifier |
-| Artifact command | Exercise the repo-owned command in runner temp for x64 and ARM64 | Keep ZIP/EXE/DLL private; upload only evidence/checksums |
+| Artifact command | Exercise the repo-owned command in runner temp for x64 and ARM64 | Keep ZIP/EXE/DLL out of CI artifacts; public attachment requires separate release authority |
 | PE/version/hash | Check inventory, architecture, version mapping and stale-DLL equality | Treat any mismatch as a release blocker |
 | Interactive startup | No hosted claim | Run the bounded probe on the default disposable host or an explicitly authorized, labelled non-disposable exception; `v0.1.0` uses the active `Nanako` profile with outbound blocked |
-| Public stable release | No CI publication, signing, tag, or asset upload | Requires a separate explicit authority decision |
+| Public stable release | No CI publication, signing, tag, or asset upload | `v0.1.0` was published manually after its separate explicit authority decision; future publication still requires its own gate |
 
 ## Phase 11/12 non-goals
 
@@ -198,5 +222,7 @@ next Phase 11 priority; winget/Scoop is Phase 12 and remains unopened until a
 later authority gate explicitly approves it.
 
 The release command is therefore a stable unsigned portable evidence producer.
-A successful hosted job or historical ARM64 VM result alone is not permission to
-publish stable artifacts, attach an App binary, or claim stable publication.
+A successful hosted job or historical ARM64 VM result alone is not permission
+to publish future artifacts, attach an App binary, or claim publication.
+`v0.1.0` was published only after its separate explicit authority and
+published-artifact startup gates completed.


### PR DESCRIPTION
## Summary

- mark the public `v0.1.0` unsigned portable stable release and Phase 10 milestone as complete
- record the lightweight tag at `aa671e0730ecb2581415e6571842ad086ab06e47`, the eight x64/ARM64 release assets, published ZIP hashes, and native startup-smoke results
- preserve the explicitly authorized active-profile smoke as a labelled non-disposable exception with executable-specific outbound blocking
- clarify that hosted CI remains evidence-only and that Phase 11/12 plus future publication remain separate authority gates

## Verification

- `git diff --check`
- stale release-candidate claim search across `README.md` and `docs/release.md`
- live GitHub tag ref equals `aa671e0730ecb2581415e6571842ad086ab06e47`
- `v0.1.0` is the public non-prerelease Latest release with exactly eight assets
- all eight GitHub asset names, byte sizes, and SHA-256 digests match the locally verified release set
- release page and all eight unauthenticated asset download URLs return HTTP 200

## Scope

Documentation only. This does not open or implement Phase 11 Velopack/signing/installer/updater, Phase 12 winget/Scoop, a Windows product rename, or future release automation.
