### PR TITLE
feat(app): adopt Syrtis product identity

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,8 @@
        numeric assembly/file version intentionally remains 0.1.0.0 across the
        v0.1.0-preview.1 prerelease and the v0.1.0 stable package. -->
   <PropertyGroup>
-    <TbProductName>TokenBar</TbProductName>
+    <TbProductName>Syrtis</TbProductName>
+    <Product>$(TbProductName)</Product>
     <TbSemanticVersion>0.1.0</TbSemanticVersion>
     <TbAssemblyVersion>0.1.0.0</TbAssemblyVersion>
     <Version>$(TbSemanticVersion)</Version>

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,6 +19,16 @@ transaction 契約與已完成的 Phase 10 outcome。它描述版本來源、鎖
 dependency/toolchain、產物、evidence，以及哪些檢查必須在 Windows 主機
 完成。這次發布不包含簽署、installer、updater 或 Velopack。
 
+> **這份文件是已封存的紀錄，不是當前的 build 說明。** 文件內所有
+> `TokenBar` 產品名、`TokenBar-App-0.1.0-win-<rid>.zip` 產物名與
+> `TokenBar.App.exe` 命令，都是 `v0.1.0`（tag 指向 `aa671e0`，當時
+> `TbProductName=TokenBar`）實際發佈的歷史事實，稽核與重現該次發布時應以
+> 這些名稱為準。產品名之後改為 `Syrtis`，`build-app-artifact.ps1` 一律從
+> `TbProductName` 推導名稱，所以**今天**執行同一條命令會得到
+> `Syrtis-App-<version>-win-<rid>.zip` 與 `Syrtis.App.exe`。下一次發布屬於
+> Phase 11（Velopack installer/updater），會有自己的 release contract 文件；
+> 本文件不再更新為當前命名。
+
 Preview history: [`v0.1.0-preview.1` published prerelease](https://github.com/Nanako0129/TokenBar-Windows/releases/tag/v0.1.0-preview.1).
 
 > **核心原則：** Hosted CI 可以證明結構、版本、PE architecture 與 hash，

--- a/src/TokenBar.App/AutostartService.cs
+++ b/src/TokenBar.App/AutostartService.cs
@@ -15,7 +15,7 @@ internal static class AutostartService
     private const string RunKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
     private const string ApprovedKey =
         @"Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run";
-    private const string ValueName = "TokenBar";
+    private static readonly string ValueName = ProductIdentity.Name;
 
     public static bool IsEnabled
     {

--- a/src/TokenBar.App/DashboardView.xaml
+++ b/src/TokenBar.App/DashboardView.xaml
@@ -15,10 +15,10 @@
         <StackPanel Grid.Row="0" Spacing="6">
             <Grid>
                 <TextBlock
+                    x:Name="ProductTitle"
                     FontSize="15"
                     FontWeight="SemiBold"
-                    VerticalAlignment="Center"
-                    Text="TokenBar" />
+                    VerticalAlignment="Center" />
                 <StackPanel
                     Orientation="Horizontal"
                     Spacing="6"

--- a/src/TokenBar.App/DashboardView.xaml.cs
+++ b/src/TokenBar.App/DashboardView.xaml.cs
@@ -54,6 +54,7 @@ public sealed partial class DashboardView : UserControl
     public DashboardView()
     {
         InitializeComponent();
+        ProductTitle.Text = ProductIdentity.Name;
         // WinUI otherwise synthesizes a tooltip containing "Esc" for the
         // dashboard-wide Escape accelerator whenever the pointer rests over
         // the graph. The accelerator remains active; only its automatic

--- a/src/TokenBar.App/ProductIdentity.cs
+++ b/src/TokenBar.App/ProductIdentity.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+
+namespace TokenBar.App;
+
+internal static class ProductIdentity
+{
+    internal static string Name { get; } = GetName();
+
+    private static string GetName()
+    {
+        var product = typeof(ProductIdentity).Assembly
+            .GetCustomAttribute<AssemblyProductAttribute>()?.Product;
+
+        return string.IsNullOrWhiteSpace(product)
+            ? throw new InvalidOperationException("Assembly product identity is missing.")
+            : product;
+    }
+}

--- a/src/TokenBar.App/SettingsWindow.cs
+++ b/src/TokenBar.App/SettingsWindow.cs
@@ -67,7 +67,7 @@ public sealed class SettingsWindow : Window
     {
         _quota = quota;
         _graph = graph;
-        Title = "TokenBar Settings";
+        Title = $"{ProductIdentity.Name} Settings";
         SystemBackdrop = new MicaBackdrop();
         var root = new Grid();
         root.ColumnDefinitions.Add(new ColumnDefinition

--- a/src/TokenBar.App/TrayService.cs
+++ b/src/TokenBar.App/TrayService.cs
@@ -35,7 +35,7 @@ public sealed class TrayService : IDisposable
     {
         _icon = new TaskbarIcon
         {
-            ToolTipText = "TokenBar",
+            ToolTipText = ProductIdentity.Name,
         };
         _flyout = flyout;
         _icon.LeftClickCommand = new RelayCommand(flyout.ToggleFlyout);
@@ -104,7 +104,7 @@ public sealed class TrayService : IDisposable
         var menu = new Microsoft.UI.Xaml.Controls.MenuFlyout();
         menu.Items.Add(new Microsoft.UI.Xaml.Controls.MenuFlyoutItem
         {
-            Text = "Open TokenBar",
+            Text = $"Open {ProductIdentity.Name}",
             Command = new RelayCommand(_flyout.ShowFlyout),
         });
         menu.Items.Add(new Microsoft.UI.Xaml.Controls.MenuFlyoutSeparator());
@@ -202,12 +202,12 @@ public sealed class TrayService : IDisposable
     {
         if (_feed.VisibleTotals is not { } totals)
         {
-            return "TokenBar — loading…";
+            return $"{ProductIdentity.Name} — loading…";
         }
 
         var lines = new List<string>
         {
-            "TokenBar",
+            ProductIdentity.Name,
             $"Today {Format.CompactTokens(totals.TodayTokens)} · {Format.Usd(totals.TodayCost)}",
             $"All time {Format.CompactTokens(totals.TotalTokens)} · {Format.Usd(totals.TotalCost)}",
         };

--- a/src/TokenBar.Core.Tests/ProductIdentityTests.cs
+++ b/src/TokenBar.Core.Tests/ProductIdentityTests.cs
@@ -1,0 +1,12 @@
+using TokenBar.App;
+
+namespace TokenBar.Core.Tests;
+
+public class ProductIdentityTests
+{
+    [Fact]
+    public void NameIsSyrtis()
+    {
+        Assert.Equal("Syrtis", ProductIdentity.Name);
+    }
+}

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\TokenBar.App\ProductIdentity.cs" Link="ProductIdentity.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TokenBar.Core\TokenBar.Core.csproj" />
     <ProjectReference Include="..\TokenBar.Interop\TokenBar.Interop.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- set the shared MSBuild product identity to `Syrtis`
- derive UI labels and the per-user autostart registry value from assembly product metadata
- link the same identity source into tests so metadata and runtime naming cannot drift

## Scope

This keeps the existing version, assembly suffix, registry operations, and package/release boundaries. It does not migrate an existing `TokenBar` autostart value, add an installer or updater, rename Core/Interop assemblies, or publish a release.

## Verification

- macOS: 287/287 tests passed
- Windows: 287/287 tests passed
- Windows x64 build/publish: PE machine `0x8664`, self-contained `Syrtis.App.exe`, ProductName `Syrtis`, 3 compiled XBF resources
- immutable verification manifest SHA-256: `d96ec43d5fd4c8f8581f032978944964cdf4755e15f49b8b0c4462dd86143509`
- independent macOS and Windows verification: `CONFIRMED`
