### PR TITLE
chore(version): move the version contract to 0.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,16 @@
 <Project>
-  <!-- Phase 10: one source of truth for product, package, and assembly identity. The
-       numeric assembly/file version intentionally remains 0.1.0.0 across the
-       v0.1.0-preview.1 prerelease and the v0.1.0 stable package. -->
+  <!-- One source of truth for product, package, and assembly identity. Phase 11
+       moves to 0.2.0 for the first installed (Velopack) release; v0.1.0 was the
+       portable TokenBar package and stays where it is. Velopack compares
+       releases by SemVer, so once an installed release ships this only ever
+       moves forward. Keep the numeric version in src/TokenBar.App/app.manifest
+       and the version contract in scripts/build-app-artifact.ps1 in step with
+       these two properties; the packaging command rejects any drift. -->
   <PropertyGroup>
     <TbProductName>Syrtis</TbProductName>
     <Product>$(TbProductName)</Product>
-    <TbSemanticVersion>0.1.0</TbSemanticVersion>
-    <TbAssemblyVersion>0.1.0.0</TbAssemblyVersion>
+    <TbSemanticVersion>0.2.0</TbSemanticVersion>
+    <TbAssemblyVersion>0.2.0.0</TbAssemblyVersion>
     <Version>$(TbSemanticVersion)</Version>
     <PackageVersion>$(TbSemanticVersion)</PackageVersion>
     <InformationalVersion>$(TbSemanticVersion)</InformationalVersion>

--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -25,8 +25,8 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$ExpectedSemanticVersion = "0.1.0"
-$ExpectedAssemblyVersion = "0.1.0.0"
+$ExpectedSemanticVersion = "0.2.0"
+$ExpectedAssemblyVersion = "0.2.0.0"
 $ExpectedDotnetVersion = "10.0.301"
 $ExpectedRustVersion = "1.96.1"
 

--- a/src/TokenBar.App/app.manifest
+++ b/src/TokenBar.App/app.manifest
@@ -2,7 +2,7 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <!-- Keep this checked template literal aligned with Directory.Build.props;
        the Phase 10 artifact verifier rejects drift. -->
-  <assemblyIdentity version="0.1.0.0" name="TokenBar.App" />
+  <assemblyIdentity version="0.2.0.0" name="TokenBar.App" />
 
   <!-- Without this the process runs DPI-virtualized: AppWindow coordinates
        live in a scaled-down space while the screen (and the low-level mouse


### PR DESCRIPTION
First slice of Phase 11 (Velopack installer/updater). Version only — no Velopack dependency, no packaging, no app code.

## What

`TbSemanticVersion` → `0.2.0`, `TbAssemblyVersion` → `0.2.0.0`, the Win32 `assemblyIdentity` version in `src/TokenBar.App/app.manifest` → `0.2.0.0`, and `$ExpectedSemanticVersion` / `$ExpectedAssemblyVersion` in `scripts/build-app-artifact.ps1` → the same pair.

These are one interlocked contract. `build-app-artifact.ps1` rejects drift between its expected pair and `Directory.Build.props`, requires the derived version properties to stay derived, and rejects a manifest numeric version that does not match. Both CI jobs invoke that command, so all three move together or the build fails.

## Why 0.2.0

`v0.1.0` shipped as the unsigned portable package. `0.2.0` is the version of the first *installed* release. Velopack compares releases by SemVer, and an installed release cannot later be given a lower version without breaking the update path for anyone who installed it, so this only moves forward from here. `1.0.0` is reserved for when signing and winget/Scoop are in place.

## Deliberately unchanged

- The manifest identity name `TokenBar.App` — part of the preserved technical identity (data paths, mutex, namespaces also stay `TokenBar`).
- Every `v0.1.0` reference in `README.md` and `docs/release.md` — those are statements about what was actually published, and `docs/release.md` is an archived record of that release.

## Verification

Managed suite on macOS: **287 passed, 1 failed**. The failure is `ProbeTests.ProbeLoadsNativeLibraryAndReturnsOk`, which P/Invokes `tb_probe` and needs the Rust `libtb_core_ffi` that this checkout has never built; CI runs `cargo build --release --locked` before `dotnet test`. The 287 passing tests exercise the edited `Directory.Build.props` through a real build. The version-contract checks themselves are Windows-only and are covered by CI.