### PR TITLE
feat(app): take over the entry point for Velopack

### DIFF
--- a/src/TokenBar.App/Program.cs
+++ b/src/TokenBar.App/Program.cs
@@ -1,0 +1,44 @@
+using Velopack;
+
+namespace TokenBar.App;
+
+/// <summary>
+/// Replaces the XAML-generated entry point so Velopack runs before any WinUI
+/// initialisation. <c>DisableXamlGeneratedMain</c> removes the generated
+/// <c>Program</c>, so everything the generated <c>Main</c> did must be
+/// reproduced here, in the same order.
+///
+/// Velopack's install, update and uninstall operations re-launch this
+/// executable with hook arguments and wait for it to exit. Building and
+/// running <see cref="VelopackApp"/> first is therefore required: behind
+/// <c>Application.Start</c> the hook would sit behind the UI event loop and
+/// the operation would block until it times out.
+/// </summary>
+public static class Program
+{
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        VelopackApp.Build()
+            // Runs before the install directory is removed, with a 30 second
+            // budget. Deleting our own Run value is a single registry
+            // operation, so it comfortably fits.
+            .OnBeforeUninstallFastCallback(_ => AutostartService.SetEnabled(false))
+            .Run();
+
+        // Everything below mirrors the Main that Microsoft.UI.Xaml.Markup.Compiler
+        // 3.0.0.2607 emits into App.g.i.cs for the pinned WindowsAppSDK
+        // 1.8.260710003, action for action.
+        WinRT.ComWrappersSupport.InitializeComWrappers();
+        Microsoft.UI.Xaml.Application.Start(p =>
+        {
+            // FlyoutWindow resumes on the UI thread after awaiting and then
+            // touches AppWindow; without this context those continuations
+            // would land off-thread.
+            var context = new Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext(
+                Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread());
+            System.Threading.SynchronizationContext.SetSynchronizationContext(context);
+            new App();
+        });
+    }
+}

--- a/src/TokenBar.App/TokenBar.App.csproj
+++ b/src/TokenBar.App/TokenBar.App.csproj
@@ -18,12 +18,20 @@
     <AssemblyName>$(TbProductName).App</AssemblyName>
     <RootNamespace>TokenBar.App</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <!-- Phase 11: Program.cs replaces the generated entry point so Velopack's
+         install/update/uninstall hooks run before any WinUI initialisation.
+         The XAML compiler guards its generated Program with
+         "#if !DISABLE_XAML_GENERATED_MAIN"; nothing in the WindowsAppSDK
+         targets reads an MSBuild property for this, so the symbol itself must
+         be defined. -->
+    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260710003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
     <PackageReference Include="H.NotifyIcon.WinUI" Version="2.4.1" />
+    <PackageReference Include="Velopack" Version="1.2.0" />
     <!-- Phase 8 Gate 0: 3D contribution graph on D3D11, mirroring the Phase 2
          spike's Vortice stack. DXGI is explicit (composition swapchain +
          IDXGIFactory2.CreateSwapChainForComposition live here). -->

--- a/src/TokenBar.App/packages.lock.json
+++ b/src/TokenBar.App/packages.lock.json
@@ -35,6 +35,12 @@
           "Microsoft.WindowsAppSDK.WinUI": "[1.8.260709004]"
         }
       },
+      "Velopack": {
+        "type": "Direct",
+        "requested": "[1.2.0, )",
+        "resolved": "1.2.0",
+        "contentHash": "Rz67gJL619fSBS6omaSINUxyDuwhIxkm5mmubf7uLd5Qgi6LLKaKCha+QFP6n+Bw/UjA0vutnH4JQfYzn6ANtw=="
+      },
       "Vortice.D3DCompiler": {
         "type": "Direct",
         "requested": "[3.8.3, )",
@@ -220,7 +226,7 @@
       "tokenbar.core": {
         "type": "Project",
         "dependencies": {
-          "TokenBar.Interop": "[0.1.0, )"
+          "TokenBar.Interop": "[0.2.0, )"
         }
       },
       "tokenbar.interop": {


### PR DESCRIPTION
Phase 11 S1. Entry point only — no packaging, no updater, no release.

## Why the entry point has to move

Velopack drives install/update/uninstall by re-launching the installed executable with hook arguments and waiting for it to exit. `VelopackApp` must run before any WinUI initialisation; behind `Application.Start` the hook sits behind the UI event loop and the operation blocks until it times out. The XAML-generated entry point offers no insertion point.

## The property does not exist

`DisableXamlGeneratedMain` is **not** a WindowsAppSDK property. The generated `Program` in `App.g.i.cs` is wrapped in `#if !DISABLE_XAML_GENERATED_MAIN`, and a recursive search of `Microsoft.WindowsAppSDK` 1.8.260710003 and `Microsoft.WindowsAppSDK.WinUI` 1.8.260709004 for either spelling returns nothing. Setting the property builds a second `Program` and fails with CS0101/CS0111 — confirmed on Windows before switching to `DefineConstants`.

## What `Program.Main` reproduces

In order, exactly what `Microsoft.UI.Xaml.Markup.Compiler` 3.0.0.2607 emits for this project:

| Step | Why |
|---|---|
| `[STAThread]` | as generated |
| `ComWrappersSupport.InitializeComWrappers()` | WinRT activation/marshalling |
| `Application.Start(callback)` | as generated |
| `DispatcherQueueSynchronizationContext` set inside the callback | load-bearing: `FlyoutWindow`s animation path awaits and then touches `AppWindow` |
| `new App()` inside the callback | as generated |

`VelopackApp.Build()...Run()` goes ahead of all of it. Nothing else from the generated file needs reproducing: `App` wires its own `UnhandledException`, `InitializeComponent` runs via the `App` constructor, and PerMonitorV2 comes from `app.manifest`.

`OnBeforeUninstallFastCallback` disables autostart before the install directory is removed, so uninstalling cannot leave a `Run` value pointing at a deleted executable. It is one registry delete, well inside the hooks 30s budget. No legacy `TokenBar` value is migrated — deliberately out of scope.

## Lock file

Semantically one addition. Parsed comparison against the previous lock: base TFM section gains `Velopack`, both RID sections untouched, nothing removed, no resolved version changed. The large textual diff is reordering by the newer restore.

## Verification

- Clean rebuild on Windows x64 after defining the symbol: **0 warnings, 0 errors**. That is itself the evidence the generated `Program` is excluded — leaving it in produces duplicate-definition errors.
- Release self-contained publish produces `Syrtis.App.exe`, `tb_core_ffi.dll` at verified PE machine `0x8664`, and `Velopack.dll`.
- **Interactive startup is not claimed here.** Running the published exe over SSH fails with `0xC000027B` because that session has no interactive desktop. A control run of the unmodified generated-main build in the same session fails with the identical code and also writes no log, so the failure is the session, not this change. The interactive gate runs on the desktop separately.