### PR TITLE
feat(update): add user-confirmed Velopack flow

### DIFF
--- a/src/TokenBar.App/App.xaml.cs
+++ b/src/TokenBar.App/App.xaml.cs
@@ -15,6 +15,7 @@ public partial class App : Application
     private bool _startupSmokeRequested;
     private string? _startupSmokePath;
     private string? _startupSmokeError;
+    private int _updateCheckStarted;
 
     public App()
     {
@@ -90,6 +91,8 @@ public partial class App : Application
                 QueueStartupSmoke();
             }
 
+            StartUpdateCheckOnce();
+
             // Dev-only 3D panel (Phase 8 Gate 0). --graph3d mounts and shows
             // it for manual inspection; --soak3d runs the device-lifecycle
             // soak (50 cycles, or --soak3d-minutes duration mode) and exits
@@ -110,6 +113,161 @@ public partial class App : Application
             DevLog.Write($"launch FAILED: {ex}");
             throw;
         }
+    }
+
+    private void StartUpdateCheckOnce()
+    {
+        if (Interlocked.Exchange(ref _updateCheckStarted, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = Task.Run(CheckForUpdatesOnceAsync);
+        }
+        catch (Exception ex)
+        {
+            LogUpdateFailure("update-check", ex);
+        }
+    }
+
+    private async Task CheckForUpdatesOnceAsync()
+    {
+        try
+        {
+            var flow = new UpdateFlow();
+            var candidate = await flow.CheckForUpdatesAsync().ConfigureAwait(false);
+            if (candidate is null)
+            {
+                DevLog.Write("update-check: none");
+                return;
+            }
+
+            if (!QueueUpdateUi(() => PublishUpdate(flow, candidate)))
+            {
+                throw new InvalidOperationException();
+            }
+        }
+        catch (Exception ex)
+        {
+            LogUpdateFailure("update-check", ex);
+        }
+    }
+
+    private void PublishUpdate(UpdateFlow flow, UpdateCandidate candidate)
+    {
+        try
+        {
+            var tray = _tray;
+            if (tray is null || !tray.CanHandoff)
+            {
+                return;
+            }
+
+            if (tray.PublishUpdate(
+                candidate.Version,
+                () => StartUpdateDownload(flow, candidate)))
+            {
+                DevLog.Write($"update-available: v{candidate.Version}");
+            }
+        }
+        catch (Exception ex)
+        {
+            LogUpdateFailure("update-check", ex);
+        }
+    }
+
+    private void StartUpdateDownload(UpdateFlow flow, UpdateCandidate candidate)
+    {
+        try
+        {
+            _ = Task.Run(() => DownloadUpdateAsync(flow, candidate));
+        }
+        catch (Exception ex)
+        {
+            RestoreUpdateAction("update-download");
+            LogUpdateFailure("update-download", ex);
+        }
+    }
+
+    private async Task DownloadUpdateAsync(
+        UpdateFlow flow,
+        UpdateCandidate candidate)
+    {
+        DevLog.Write($"update-download: start v{candidate.Version}");
+        try
+        {
+            await flow.DownloadAndVerifyAsync(candidate).ConfigureAwait(false);
+            DevLog.Write($"update-download: verified v{candidate.Version}");
+            if (!QueueUpdateUi(() => HandoffUpdate(flow, candidate)))
+            {
+                throw new InvalidOperationException();
+            }
+        }
+        catch (Exception ex)
+        {
+            LogUpdateFailure("update-download", ex);
+            _ = QueueUpdateUi(() => RestoreUpdateAction("update-download"));
+        }
+    }
+
+    private void HandoffUpdate(UpdateFlow flow, UpdateCandidate candidate)
+    {
+        var tray = _tray;
+        if (tray is null || !tray.CanHandoff)
+        {
+            return;
+        }
+
+        try
+        {
+            var quit = TrayService.QuitApp
+                ?? throw new InvalidOperationException();
+            DevLog.Write($"update-handoff: start v{candidate.Version}");
+            if (flow.TryHandoff(
+                candidate,
+                () => tray.CanHandoff,
+                () =>
+                {
+                    tray.CompleteUpdateAction();
+                    quit();
+                }))
+            {
+                DevLog.Write($"update-handoff: started v{candidate.Version}");
+            }
+        }
+        catch (Exception ex)
+        {
+            RestoreUpdateAction("update-handoff");
+            LogUpdateFailure("update-handoff", ex);
+        }
+    }
+
+    private void RestoreUpdateAction(string stage)
+    {
+        try
+        {
+            _tray?.RestoreUpdateAction();
+        }
+        catch (Exception ex)
+        {
+            LogUpdateFailure(stage, ex);
+        }
+    }
+
+    private bool QueueUpdateUi(Action action) =>
+        _flyout?.DispatcherQueue.TryEnqueue(() => action()) == true;
+
+    private static void LogUpdateFailure(string stage, Exception exception)
+    {
+        var type = exception.GetType().Name;
+        if (type.Length > 64)
+        {
+            type = type[..64];
+        }
+
+        DevLog.Write($"{stage}: failed {type}");
     }
 
     private static (bool Requested, string? Path, string? Error)

--- a/src/TokenBar.App/PendingUpdateAction.cs
+++ b/src/TokenBar.App/PendingUpdateAction.cs
@@ -1,0 +1,154 @@
+namespace TokenBar.App;
+
+internal sealed class PendingUpdateAction : IDisposable
+{
+    internal const int MaxVersionLength = 64;
+
+    private readonly object _gate = new();
+    private PendingAction? _pending;
+    private int _generation;
+    private bool _disposed;
+
+    internal bool Publish(string version, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ValidateVersion(version);
+
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return false;
+            }
+
+            _generation++;
+            _pending = new PendingAction(this, _generation, version, action);
+            return true;
+        }
+    }
+
+    internal string? Peek()
+    {
+        lock (_gate)
+        {
+            return _disposed ? null : _pending?.Version;
+        }
+    }
+
+    internal PendingAction? Take()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return null;
+            }
+
+            var pending = _pending;
+            _pending = null;
+            return pending;
+        }
+    }
+
+    internal bool Restore(PendingAction pending)
+    {
+        ArgumentNullException.ThrowIfNull(pending);
+
+        lock (_gate)
+        {
+            if (_disposed
+                || _pending is not null
+                || pending.Owner != this
+                || pending.Generation != _generation)
+            {
+                return false;
+            }
+
+            pending.ResetForRestore();
+            _pending = pending;
+            return true;
+        }
+    }
+
+    internal void Clear()
+    {
+        lock (_gate)
+        {
+            _generation++;
+            _pending = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _generation++;
+            _pending = null;
+        }
+    }
+
+    private bool TryInvoke(PendingAction pending)
+    {
+        Action action;
+        lock (_gate)
+        {
+            if (_disposed
+                || pending.Owner != this
+                || pending.Generation != _generation
+                || pending.Invoked)
+            {
+                return false;
+            }
+
+            pending.Invoked = true;
+            action = pending.Action;
+        }
+
+        action();
+        return true;
+    }
+
+    private static void ValidateVersion(string version)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(version);
+        if (version.Length > MaxVersionLength
+            || version.Any(char.IsControl)
+            || !Version.TryParse(version, out var parsed)
+            || !string.Equals(parsed.ToString(), version, StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Version is not safe to display.", nameof(version));
+        }
+    }
+
+    internal sealed class PendingAction
+    {
+        internal PendingAction(
+            PendingUpdateAction owner,
+            int generation,
+            string version,
+            Action action)
+        {
+            Owner = owner;
+            Generation = generation;
+            Version = version;
+            Action = action;
+        }
+
+        internal PendingUpdateAction Owner { get; }
+        internal int Generation { get; }
+        internal string Version { get; }
+        internal Action Action { get; }
+        internal bool Invoked { get; set; }
+
+        internal bool TryInvoke() => Owner.TryInvoke(this);
+
+        internal void ResetForRestore() => Invoked = false;
+    }
+}

--- a/src/TokenBar.App/TrayService.cs
+++ b/src/TokenBar.App/TrayService.cs
@@ -27,6 +27,8 @@ public sealed class TrayService : IDisposable
     private readonly TrayFeed _feed;
     private readonly TrayAnimator _animator;
     private readonly Action<string> _onStoreChanged;
+    private readonly PendingUpdateAction _pendingUpdate = new();
+    private PendingUpdateAction.PendingAction? _activeUpdate;
     private string _iconSignature = "";
     private nint _hicon;
     private bool _disposed;
@@ -39,6 +41,13 @@ public sealed class TrayService : IDisposable
         };
         _flyout = flyout;
         _icon.LeftClickCommand = new RelayCommand(flyout.ToggleFlyout);
+        _icon.TrayIcon.MessageWindow.MouseEventReceived += (_, eventArgs) =>
+        {
+            if (eventArgs.MouseEvent == MouseEvent.BalloonToolTipClicked)
+            {
+                InvokePendingUpdate();
+            }
+        };
         _icon.NoLeftClickDelay = true;
         // NOT SecondWindow: that mode parks a transparent helper window over
         // the desktop, which swallowed hover/wheel input meant for the flyout.
@@ -89,6 +98,85 @@ public sealed class TrayService : IDisposable
     public void ShowSettings() => SettingsWindow.Present(
         () => _feed.Quota, () => _feed.Graph);
 
+    internal bool CanHandoff => !Volatile.Read(ref _disposed);
+
+    internal bool PublishUpdate(string version, Action action)
+    {
+        if (_disposed || !_pendingUpdate.Publish(version, action))
+        {
+            return false;
+        }
+
+        try
+        {
+            RebuildMenu();
+            _icon.ShowNotification(
+                title: ProductIdentity.Name,
+                message: $"Update to v{version}",
+                icon: NotificationIcon.Info,
+                sound: false,
+                respectQuietTime: true);
+            return true;
+        }
+        catch
+        {
+            _pendingUpdate.Clear();
+            RebuildMenu();
+            throw;
+        }
+    }
+
+    internal void RestoreUpdateAction()
+    {
+        if (_disposed || _activeUpdate is not { } active)
+        {
+            return;
+        }
+
+        if (_pendingUpdate.Restore(active))
+        {
+            _activeUpdate = null;
+            RebuildMenu();
+        }
+    }
+
+    internal void CompleteUpdateAction()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _activeUpdate = null;
+        _pendingUpdate.Clear();
+    }
+
+    private void InvokePendingUpdate()
+    {
+        if (_disposed || _pendingUpdate.Take() is not { } pending)
+        {
+            return;
+        }
+
+        _activeUpdate = pending;
+        RebuildMenu();
+        try
+        {
+            if (!pending.TryInvoke())
+            {
+                _activeUpdate = null;
+            }
+        }
+        catch (Exception ex)
+        {
+            _ = _pendingUpdate.Restore(pending);
+            _activeUpdate = null;
+            RebuildMenu();
+            var type = ex.GetType().Name;
+            DevLog.Write($"update-download: failed {type[..Math.Min(type.Length, 64)]}");
+        }
+    }
+
     /// <summary>The full context menu (macOS splits this between the
     /// status-item right-click quota menu and the settings panel; Windows
     /// keeps one battery-style menu): Open · Menu bar shows · Quota source ·
@@ -107,6 +195,14 @@ public sealed class TrayService : IDisposable
             Text = $"Open {ProductIdentity.Name}",
             Command = new RelayCommand(_flyout.ShowFlyout),
         });
+        if (_pendingUpdate.Peek() is { } updateVersion)
+        {
+            menu.Items.Add(new Microsoft.UI.Xaml.Controls.MenuFlyoutItem
+            {
+                Text = $"Update to v{updateVersion}",
+                Command = new RelayCommand(InvokePendingUpdate),
+            });
+        }
         menu.Items.Add(new Microsoft.UI.Xaml.Controls.MenuFlyoutSeparator());
 
         // Menu bar shows — the seven TrayModes as a radio group.
@@ -333,6 +429,8 @@ public sealed class TrayService : IDisposable
         }
 
         _disposed = true;
+        _pendingUpdate.Dispose();
+        _activeUpdate = null;
         AppSettings.Store.Changed -= _onStoreChanged;
         _feed.Dispose(); // stop polling before the icon it feeds goes away
         _animator.Stop();

--- a/src/TokenBar.App/TrayService.cs
+++ b/src/TokenBar.App/TrayService.cs
@@ -110,12 +110,22 @@ public sealed class TrayService : IDisposable
         try
         {
             RebuildMenu();
-            _icon.ShowNotification(
-                title: ProductIdentity.Name,
-                message: $"Update to v{version}",
-                icon: NotificationIcon.Info,
-                sound: false,
-                respectQuietTime: true);
+            try
+            {
+                _icon.ShowNotification(
+                    title: ProductIdentity.Name,
+                    message: $"Update to v{version}",
+                    icon: NotificationIcon.Info,
+                    sound: false,
+                    respectQuietTime: true);
+            }
+            catch (Exception ex)
+            {
+                var type = ex.GetType().Name;
+                DevLog.Write(
+                    $"update-notification: failed {type[..Math.Min(type.Length, 64)]}");
+            }
+
             return true;
         }
         catch

--- a/src/TokenBar.App/UpdateFlow.cs
+++ b/src/TokenBar.App/UpdateFlow.cs
@@ -1,0 +1,306 @@
+using System.IO.Compression;
+using System.Xml;
+using System.Xml.Linq;
+using Velopack;
+using Velopack.Locators;
+using Velopack.Sources;
+
+namespace TokenBar.App;
+
+internal class UpdateFlow
+{
+    internal const string RepositoryUrl =
+        "https://github.com/Nanako0129/TokenBar-Windows";
+    internal const string PackageId = "Nyanako.TokenBar";
+    private const int MaxNuspecBytes = 65_536;
+    private const long MaxCompressionRatio = 100;
+
+    private readonly ManagedUpdateManager _manager;
+    private int _downloadActive;
+
+    internal UpdateFlow(
+        IFileDownloader? downloader = null,
+        IVelopackLocator? locator = null)
+    {
+        var source = new GithubSource(
+            RepositoryUrl,
+            accessToken: null,
+            prerelease: false,
+            downloader);
+        var options = new UpdateOptions
+        {
+            ExplicitChannel = null,
+            AllowVersionDowngrade = false,
+        };
+        _manager = new ManagedUpdateManager(source, options, locator);
+    }
+
+    internal async Task<UpdateCandidate?> CheckForUpdatesAsync()
+    {
+        _ = GetInstallation();
+        var update = await _manager.CheckForUpdatesAsync().ConfigureAwait(false);
+        return update is null ? null : ValidateTarget(update);
+    }
+
+    internal async Task DownloadAndVerifyAsync(
+        UpdateCandidate candidate,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        if (Interlocked.CompareExchange(ref _downloadActive, 1, 0) != 0)
+        {
+            throw new InvalidOperationException("An update download is already active.");
+        }
+
+        try
+        {
+            var validated = ValidateCandidate(candidate);
+            await _manager.DownloadUpdatesAsync(
+                validated.Update,
+                progress: null,
+                cancellationToken).ConfigureAwait(false);
+
+            validated = ValidateCandidate(candidate);
+            await _manager.VerifyChecksumAsync(
+                validated.Target,
+                validated.PackagePath).ConfigureAwait(false);
+            ValidateNuspec(validated);
+        }
+        catch
+        {
+            _manager.CleanAllPackages();
+            throw;
+        }
+        finally
+        {
+            Volatile.Write(ref _downloadActive, 0);
+        }
+    }
+
+    internal bool TryHandoff(
+        UpdateCandidate candidate,
+        Func<bool> canHandoff,
+        Action quit)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(canHandoff);
+        ArgumentNullException.ThrowIfNull(quit);
+
+        var validated = ValidateCandidate(candidate);
+        if (!canHandoff())
+        {
+            return false;
+        }
+
+        WaitExitThenApplyUpdates(
+            validated.Target,
+            silent: false,
+            restart: true,
+            Array.Empty<string>());
+        quit();
+        return true;
+    }
+
+    protected virtual void WaitExitThenApplyUpdates(
+        VelopackAsset target,
+        bool silent,
+        bool restart,
+        string[] restartArgs)
+    {
+        _manager.WaitExitThenApplyUpdates(target, silent, restart, restartArgs);
+    }
+
+    private UpdateCandidate ValidateCandidate(UpdateCandidate candidate)
+    {
+        var validated = ValidateTarget(candidate.Update);
+        if (!ReferenceEquals(validated.Target, candidate.Target)
+            || !string.Equals(validated.Version, candidate.Version, StringComparison.Ordinal)
+            || !string.Equals(validated.Channel, candidate.Channel, StringComparison.Ordinal)
+            || !string.Equals(validated.Architecture, candidate.Architecture, StringComparison.Ordinal)
+            || !string.Equals(validated.PackagePath, candidate.PackagePath, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException("Update target changed after validation.");
+        }
+
+        return validated;
+    }
+
+    private UpdateCandidate ValidateTarget(UpdateInfo update)
+    {
+        var installation = GetInstallation();
+        var target = update.TargetFullRelease
+            ?? throw new InvalidDataException("Update target is missing.");
+        var version = target.Version?.ToNormalizedString()
+            ?? throw new InvalidDataException("Update version is missing.");
+
+        if (target.Type != VelopackAssetType.Full
+            || !string.Equals(target.PackageId, PackageId, StringComparison.Ordinal)
+            || target.Version <= installation.Version
+            || target.Version.IsPrerelease
+            || version.Length is 0 or > PendingUpdateAction.MaxVersionLength
+            || version.Any(char.IsControl)
+            || !IsSha256(target.SHA256)
+            || target.Size <= 0)
+        {
+            throw new InvalidDataException("Update target metadata is invalid.");
+        }
+
+        var fileName = $"{PackageId}-{version}-{installation.Channel}-full.nupkg";
+        if (!string.Equals(target.FileName, fileName, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException("Update filename is invalid.");
+        }
+
+        return new UpdateCandidate(
+            update,
+            target,
+            version,
+            installation.Channel,
+            installation.Architecture,
+            Path.Combine(installation.PackagesDirectory, fileName));
+    }
+
+    private Installation GetInstallation()
+    {
+        if (!_manager.IsInstalled
+            || !string.Equals(_manager.AppId, PackageId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Installed package identity is invalid.");
+        }
+
+        var version = _manager.CurrentVersion
+            ?? throw new InvalidOperationException("Installed version is missing.");
+        var channel = _manager.InstalledChannel;
+        var architecture = channel switch
+        {
+            "win-x64" => "x64",
+            "win-arm64" => "arm64",
+            _ => throw new InvalidOperationException("Installed channel is invalid."),
+        };
+        var packagesDirectory = _manager.PackagesDirectory;
+        if (string.IsNullOrWhiteSpace(packagesDirectory))
+        {
+            throw new InvalidOperationException("Installed packages path is missing.");
+        }
+
+        return new Installation(version, channel, architecture, packagesDirectory);
+    }
+
+    private static bool IsSha256(string? value) =>
+        value is { Length: 64 }
+        && value.All(c => c is >= '0' and <= '9'
+            or >= 'a' and <= 'f'
+            or >= 'A' and <= 'F');
+
+    private static void ValidateNuspec(UpdateCandidate candidate)
+    {
+        using var archive = ZipFile.OpenRead(candidate.PackagePath);
+        var entries = archive.Entries
+            .Where(entry => !entry.FullName.EndsWith("/", StringComparison.Ordinal)
+                && entry.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (entries.Length != 1)
+        {
+            throw new InvalidDataException("Package must contain exactly one nuspec.");
+        }
+
+        var entry = entries[0];
+        if (entry.Length is < 1 or > MaxNuspecBytes
+            || entry.CompressedLength is < 1 or > MaxNuspecBytes
+            || entry.Length > entry.CompressedLength * MaxCompressionRatio)
+        {
+            throw new InvalidDataException("Nuspec size is invalid.");
+        }
+
+        var bytes = new byte[MaxNuspecBytes + 1];
+        var length = 0;
+        using (var stream = entry.Open())
+        {
+            while (length < bytes.Length)
+            {
+                var read = stream.Read(bytes, length, bytes.Length - length);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                length += read;
+            }
+        }
+
+        if (length is < 1 or > MaxNuspecBytes || length != entry.Length)
+        {
+            throw new InvalidDataException("Nuspec content length is invalid.");
+        }
+
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaxNuspecBytes,
+            MaxCharactersFromEntities = 0,
+        };
+        using var input = new MemoryStream(bytes, 0, length, writable: false);
+        using var reader = XmlReader.Create(input, settings);
+        var document = XDocument.Load(reader, LoadOptions.None);
+        var root = document.Root;
+        if (root?.Name.LocalName != "package")
+        {
+            throw new InvalidDataException("Nuspec package root is invalid.");
+        }
+
+        var metadata = SingleElement(root, "metadata");
+        RequireValue(metadata, "id", PackageId);
+        RequireValue(metadata, "version", candidate.Version);
+        RequireValue(metadata, "channel", candidate.Channel);
+        RequireValue(metadata, "machineArchitecture", candidate.Architecture);
+    }
+
+    private static XElement SingleElement(XElement parent, string name)
+    {
+        var elements = parent.Elements()
+            .Where(element => element.Name.LocalName == name)
+            .ToArray();
+        return elements.Length == 1
+            ? elements[0]
+            : throw new InvalidDataException($"Nuspec {name} is invalid.");
+    }
+
+    private static void RequireValue(XElement metadata, string name, string expected)
+    {
+        var element = SingleElement(metadata, name);
+        if (!string.Equals(element.Value, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Nuspec {name} is invalid.");
+        }
+    }
+
+    private sealed class ManagedUpdateManager(
+        IUpdateSource source,
+        UpdateOptions options,
+        IVelopackLocator? locator)
+        : UpdateManager(source, options, locator)
+    {
+        internal string? InstalledChannel => Locator.Channel;
+        internal string? PackagesDirectory => Locator.PackagesDir;
+
+        internal Task VerifyChecksumAsync(VelopackAsset target, string packagePath) =>
+            VerifyPackageChecksumAsync(target, packagePath);
+
+        internal void CleanAllPackages() => CleanPackagesExcept(null);
+    }
+
+    private sealed record Installation(
+        SemanticVersion Version,
+        string Channel,
+        string Architecture,
+        string PackagesDirectory);
+}
+
+internal sealed record UpdateCandidate(
+    UpdateInfo Update,
+    VelopackAsset Target,
+    string Version,
+    string Channel,
+    string Architecture,
+    string PackagePath);

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Velopack" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
@@ -20,7 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\TokenBar.App\PendingUpdateAction.cs" Link="PendingUpdateAction.cs" />
     <Compile Include="..\TokenBar.App\ProductIdentity.cs" Link="ProductIdentity.cs" />
+    <Compile Include="..\TokenBar.App\UpdateFlow.cs" Link="UpdateFlow.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TokenBar.Core.Tests/UpdateFlowTests.cs
+++ b/src/TokenBar.Core.Tests/UpdateFlowTests.cs
@@ -1,0 +1,914 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using TokenBar.App;
+using Velopack;
+using Velopack.Locators;
+using Velopack.Sources;
+
+namespace TokenBar.Core.Tests;
+
+public class UpdateFlowTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "tokenbar-update-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    [Theory]
+    [InlineData("win-x64", "x64")]
+    [InlineData("win-arm64", "arm64")]
+    public async Task GithubSourceIsFixedStableUnauthenticatedAndDownloadsOnlyAfterClick(
+        string channel,
+        string architecture)
+    {
+        var fixture = CreateFixture(channel);
+
+        var candidate = await fixture.Flow.CheckForUpdatesAsync();
+
+        Assert.NotNull(candidate);
+        Assert.Equal("0.3.0", candidate.Version);
+        Assert.Equal(channel, candidate.Channel);
+        Assert.Equal(architecture, candidate.Architecture);
+        Assert.Equal(1, fixture.Downloader.DownloadStringCalls);
+        Assert.Equal(1, fixture.Downloader.DownloadBytesCalls);
+        Assert.Equal(0, fixture.Downloader.DownloadFileCalls);
+        Assert.Equal(
+            "https://api.github.com/repos/Nanako0129/TokenBar-Windows/releases?per_page=10&page=1",
+            fixture.Downloader.Requests[0].Url);
+        Assert.DoesNotContain(
+            fixture.Downloader.Requests,
+            request => request.Url.Contains("prerelease", StringComparison.Ordinal));
+        Assert.All(
+            fixture.Downloader.Requests,
+            request => Assert.DoesNotContain(
+                request.Headers.Keys,
+                key => string.Equals(key, "Authorization", StringComparison.OrdinalIgnoreCase)));
+
+        await fixture.Flow.DownloadAndVerifyAsync(candidate);
+
+        Assert.Equal(1, fixture.Downloader.DownloadFileCalls);
+        Assert.True(File.Exists(candidate.PackagePath));
+    }
+
+    [Theory]
+    [InlineData("wrong-id")]
+    [InlineData("wrong-type")]
+    [InlineData("wrong-filename")]
+    [InlineData("same-version")]
+    [InlineData("lower-version")]
+    [InlineData("prerelease-version")]
+    [InlineData("missing-sha256")]
+    [InlineData("bad-sha256")]
+    [InlineData("zero-size")]
+    public async Task RejectsInvalidTargetsBeforeDownload(string testCase)
+    {
+        var fixture = CreateFixture(mutateTarget: target =>
+        {
+            switch (testCase)
+            {
+                case "wrong-id":
+                    target.PackageId = "Other.Package";
+                    break;
+                case "wrong-type":
+                    target.Type = VelopackAssetType.Delta;
+                    break;
+                case "wrong-filename":
+                    target.FileName = "other.nupkg";
+                    break;
+                case "same-version":
+                    target.Version = SemanticVersion.Parse("0.2.0");
+                    target.FileName = "Nyanako.TokenBar-0.2.0-win-x64-full.nupkg";
+                    break;
+                case "lower-version":
+                    target.Version = SemanticVersion.Parse("0.1.0");
+                    target.FileName = "Nyanako.TokenBar-0.1.0-win-x64-full.nupkg";
+                    break;
+                case "prerelease-version":
+                    target.Version = SemanticVersion.Parse("0.3.0-beta.1");
+                    target.FileName = "Nyanako.TokenBar-0.3.0-beta.1-win-x64-full.nupkg";
+                    break;
+                case "missing-sha256":
+                    target.SHA256 = "";
+                    break;
+                case "bad-sha256":
+                    target.SHA256 = new string('g', 64);
+                    break;
+                case "zero-size":
+                    target.Size = 0;
+                    break;
+            }
+        });
+
+        UpdateCandidate? candidate = null;
+        var exception = await Record.ExceptionAsync(async () =>
+            candidate = await fixture.Flow.CheckForUpdatesAsync());
+
+        Assert.True(exception is not null || candidate is null);
+        Assert.Equal(0, fixture.Downloader.DownloadFileCalls);
+    }
+
+    [Theory]
+    [InlineData("Other.Package", "win-x64")]
+    [InlineData("Nyanako.TokenBar", "win")]
+    [InlineData("Nyanako.TokenBar", "linux-x64")]
+    public async Task RejectsInvalidInstalledIdentityOrChannelBeforeNetwork(
+        string appId,
+        string channel)
+    {
+        var fixture = CreateFixture(channel, appId: appId);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fixture.Flow.CheckForUpdatesAsync());
+
+        Assert.Empty(fixture.Downloader.Requests);
+    }
+
+    [Fact]
+    public async Task RejectsNotInstalledBeforeNetwork()
+    {
+        Directory.CreateDirectory(_dir);
+        var packages = Path.Combine(_dir, "packages");
+        Directory.CreateDirectory(packages);
+        var package = CreateValidPackage("win-x64", "x64");
+        var target = CreateTarget(package, "win-x64");
+        var downloader = new FakeDownloader("win-x64", target, package);
+        var locator = new NotInstalledLocator(packages);
+        var flow = new UpdateFlow(downloader, locator);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => flow.CheckForUpdatesAsync());
+
+        Assert.Empty(downloader.Requests);
+    }
+
+    [Fact]
+    public async Task ExistingCorruptedFinalPackageIsReverifiedAndDeleted()
+    {
+        var fixture = CreateFixture();
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await fixture.Flow.CheckForUpdatesAsync());
+        Directory.CreateDirectory(Path.GetDirectoryName(candidate.PackagePath)!);
+        await File.WriteAllBytesAsync(candidate.PackagePath, [1, 2, 3, 4]);
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => fixture.Flow.DownloadAndVerifyAsync(candidate));
+
+        Assert.Equal(0, fixture.Downloader.DownloadFileCalls);
+        Assert.False(File.Exists(candidate.PackagePath));
+    }
+
+    [Fact]
+    public async Task DownloadedChecksumFailureDeletesPackageAndNeverHandoffs()
+    {
+        var fixture = CreateFixture(mutateTarget: target =>
+            target.SHA256 = new string('0', 64));
+        var flow = new RecordingUpdateFlow(fixture.Downloader, fixture.Locator);
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await flow.CheckForUpdatesAsync());
+
+        var quitCalls = 0;
+        async Task DownloadThenHandoff()
+        {
+            await flow.DownloadAndVerifyAsync(candidate);
+            _ = flow.TryHandoff(candidate, () => true, () => quitCalls++);
+        }
+
+        await Assert.ThrowsAnyAsync<Exception>(DownloadThenHandoff);
+
+        Assert.Equal(1, fixture.Downloader.DownloadFileCalls);
+        Assert.False(File.Exists(candidate.PackagePath));
+        Assert.Equal(0, flow.HandoffCalls);
+        Assert.Equal(0, quitCalls);
+    }
+
+    [Theory]
+    [InlineData("no-entry")]
+    [InlineData("two-entries")]
+    [InlineData("empty")]
+    [InlineData("declared-over")]
+    [InlineData("actual-over")]
+    [InlineData("compressed-over")]
+    [InlineData("ratio")]
+    [InlineData("dtd")]
+    [InlineData("malformed")]
+    [InlineData("wrong-id")]
+    [InlineData("wrong-version")]
+    [InlineData("wrong-channel")]
+    [InlineData("wrong-architecture")]
+    public async Task RejectsAdversarialNuspecAndInvalidatesPackage(string testCase)
+    {
+        var package = CreateAdversarialPackage(testCase);
+        AssertAdversarialFixture(testCase, package);
+        var fixture = CreateFixture(packageBytes: package);
+        var flow = new RecordingUpdateFlow(fixture.Downloader, fixture.Locator);
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await flow.CheckForUpdatesAsync());
+        var quitCalls = 0;
+        async Task DownloadThenHandoff()
+        {
+            await flow.DownloadAndVerifyAsync(candidate);
+            _ = flow.TryHandoff(candidate, () => true, () => quitCalls++);
+        }
+
+        await Assert.ThrowsAnyAsync<Exception>(DownloadThenHandoff);
+
+        Assert.False(File.Exists(candidate.PackagePath));
+        Assert.Equal(0, flow.HandoffCalls);
+        Assert.Equal(0, quitCalls);
+    }
+
+    [Theory]
+    [InlineData("offline")]
+    [InlineData("404")]
+    [InlineData("403")]
+    [InlineData("429")]
+    [InlineData("malformed-api")]
+    [InlineData("malformed-feed")]
+    public async Task SourceFailuresDoNotRetryOrDownload(string testCase)
+    {
+        var fixture = CreateFixture();
+        switch (testCase)
+        {
+            case "offline":
+                fixture.Downloader.ApiException = new HttpRequestException();
+                break;
+            case "404":
+                fixture.Downloader.ApiException = new HttpRequestException(
+                    null, null, HttpStatusCode.NotFound);
+                break;
+            case "403":
+                fixture.Downloader.ApiException = new HttpRequestException(
+                    null, null, HttpStatusCode.Forbidden);
+                break;
+            case "429":
+                fixture.Downloader.ApiException = new HttpRequestException(
+                    null, null, HttpStatusCode.TooManyRequests);
+                break;
+            case "malformed-api":
+                fixture.Downloader.ApiTextOverride = "{";
+                break;
+            case "malformed-feed":
+                fixture.Downloader.FeedBytesOverride = "{"u8.ToArray();
+                break;
+        }
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => fixture.Flow.CheckForUpdatesAsync());
+
+        Assert.Equal(1, fixture.Downloader.DownloadStringCalls);
+        Assert.Equal(testCase == "malformed-feed" ? 1 : 0,
+            fixture.Downloader.DownloadBytesCalls);
+        Assert.Equal(0, fixture.Downloader.DownloadFileCalls);
+    }
+
+    [Fact]
+    public async Task DownloadFailureDoesNotRetryAndDeletesPartialPackage()
+    {
+        var fixture = CreateFixture();
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await fixture.Flow.CheckForUpdatesAsync());
+        fixture.Downloader.DownloadException = new IOException();
+
+        await Assert.ThrowsAsync<IOException>(
+            () => fixture.Flow.DownloadAndVerifyAsync(candidate));
+
+        Assert.Equal(1, fixture.Downloader.DownloadFileCalls);
+        Assert.False(File.Exists(candidate.PackagePath));
+        Assert.False(File.Exists(candidate.PackagePath + ".partial"));
+    }
+
+    [Fact]
+    public async Task LockFailureDoesNotDownloadOrHandoff()
+    {
+        Directory.CreateDirectory(_dir);
+        var packages = Path.Combine(_dir, "packages-is-a-file");
+        await File.WriteAllTextAsync(packages, "not a directory");
+        var fixture = CreateFixture(packagesDirectory: packages);
+        var flow = new RecordingUpdateFlow(fixture.Downloader, fixture.Locator);
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await flow.CheckForUpdatesAsync());
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => flow.DownloadAndVerifyAsync(candidate));
+
+        Assert.Equal(0, fixture.Downloader.DownloadFileCalls);
+        Assert.Equal(0, flow.HandoffCalls);
+    }
+
+    [Fact]
+    public async Task DownloadIsSingleFlight()
+    {
+        var fixture = CreateFixture();
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await fixture.Flow.CheckForUpdatesAsync());
+        fixture.Downloader.BlockDownload = true;
+
+        var first = fixture.Flow.DownloadAndVerifyAsync(candidate);
+        await fixture.Downloader.DownloadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => fixture.Flow.DownloadAndVerifyAsync(candidate));
+        fixture.Downloader.ReleaseDownload.TrySetResult();
+        await first;
+
+        Assert.Equal(1, fixture.Downloader.DownloadFileCalls);
+    }
+
+    [Fact]
+    public async Task HandoffUsesExactParametersAndQuitsAfterReturn()
+    {
+        var fixture = CreateFixture();
+        var flow = new RecordingUpdateFlow(fixture.Downloader, fixture.Locator);
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await flow.CheckForUpdatesAsync());
+        var events = new List<string>();
+        flow.Events = events;
+
+        var handedOff = flow.TryHandoff(
+            candidate,
+            () => true,
+            () => events.Add("quit"));
+
+        Assert.True(handedOff);
+        Assert.Equal(["handoff", "quit"], events);
+        Assert.Same(candidate.Target, flow.HandoffTarget);
+        Assert.False(flow.Silent);
+        Assert.True(flow.Restart);
+        Assert.Empty(Assert.IsType<string[]>(flow.RestartArgs));
+        Assert.Equal(1, flow.HandoffCalls);
+    }
+
+    [Fact]
+    public async Task HandoffThrowDoesNotQuit()
+    {
+        var fixture = CreateFixture();
+        var flow = new RecordingUpdateFlow(fixture.Downloader, fixture.Locator)
+        {
+            HandoffException = new InvalidOperationException(),
+        };
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await flow.CheckForUpdatesAsync());
+        var quitCalls = 0;
+
+        Assert.Throws<InvalidOperationException>(() => flow.TryHandoff(
+            candidate,
+            () => true,
+            () => quitCalls++));
+
+        Assert.Equal(1, flow.HandoffCalls);
+        Assert.Equal(0, quitCalls);
+    }
+
+    [Fact]
+    public async Task DisposedTrayGateSkipsHandoffAndQuit()
+    {
+        var fixture = CreateFixture();
+        var flow = new RecordingUpdateFlow(fixture.Downloader, fixture.Locator);
+        var candidate = Assert.IsType<UpdateCandidate>(
+            await flow.CheckForUpdatesAsync());
+        var quitCalls = 0;
+
+        var handedOff = flow.TryHandoff(
+            candidate,
+            () => false,
+            () => quitCalls++);
+
+        Assert.False(handedOff);
+        Assert.Equal(0, flow.HandoffCalls);
+        Assert.Equal(0, quitCalls);
+    }
+
+    [Fact]
+    public void PendingActionPublishAndIgnoreDoNotInvoke()
+    {
+        using var pending = new PendingUpdateAction();
+        var calls = 0;
+
+        Assert.True(pending.Publish("0.3.0", () => calls++));
+        Assert.Equal("0.3.0", pending.Peek());
+        Assert.Equal(0, calls);
+        Assert.Equal("0.3.0", pending.Peek());
+    }
+
+    [Fact]
+    public void PendingActionTakesAndInvokesOnce()
+    {
+        using var pending = new PendingUpdateAction();
+        var calls = 0;
+        Assert.True(pending.Publish("0.3.0", () => calls++));
+
+        var action = Assert.IsType<PendingUpdateAction.PendingAction>(pending.Take());
+
+        Assert.Null(pending.Take());
+        Assert.True(action.TryInvoke());
+        Assert.False(action.TryInvoke());
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void PendingActionRestoresForManualRetry()
+    {
+        using var pending = new PendingUpdateAction();
+        var calls = 0;
+        Assert.True(pending.Publish("0.3.0", () => calls++));
+        var first = Assert.IsType<PendingUpdateAction.PendingAction>(pending.Take());
+        Assert.True(first.TryInvoke());
+
+        Assert.True(pending.Restore(first));
+        var retry = Assert.IsType<PendingUpdateAction.PendingAction>(pending.Take());
+        Assert.Same(first, retry);
+        Assert.True(retry.TryInvoke());
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public void PendingActionDisposePreventsRestoreAndInvoke()
+    {
+        var pending = new PendingUpdateAction();
+        var calls = 0;
+        Assert.True(pending.Publish("0.3.0", () => calls++));
+        var action = Assert.IsType<PendingUpdateAction.PendingAction>(pending.Take());
+
+        pending.Dispose();
+
+        Assert.False(action.TryInvoke());
+        Assert.False(pending.Restore(action));
+        Assert.False(pending.Publish("0.4.0", () => calls++));
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public void PendingActionClearRemovesAndInvalidatesAction()
+    {
+        using var pending = new PendingUpdateAction();
+        var calls = 0;
+        Assert.True(pending.Publish("0.3.0", () => calls++));
+        var action = Assert.IsType<PendingUpdateAction.PendingAction>(pending.Take());
+
+        pending.Clear();
+
+        Assert.Null(pending.Peek());
+        Assert.False(action.TryInvoke());
+        Assert.Equal(0, calls);
+    }
+
+    [Theory]
+    [InlineData("0.3.0\n")]
+    [InlineData("v0.3.0")]
+    [InlineData("00.3.0")]
+    public void PendingActionRejectsNonNormalizedDisplayVersion(string version)
+    {
+        using var pending = new PendingUpdateAction();
+
+        Assert.Throws<ArgumentException>(() => pending.Publish(version, () => { }));
+    }
+
+    private Fixture CreateFixture(
+        string channel = "win-x64",
+        byte[]? packageBytes = null,
+        Action<VelopackAsset>? mutateTarget = null,
+        string appId = UpdateFlow.PackageId,
+        string installedVersion = "0.2.0",
+        string? packagesDirectory = null)
+    {
+        Directory.CreateDirectory(_dir);
+        packagesDirectory ??= Path.Combine(_dir, Guid.NewGuid().ToString("N"), "packages");
+        if (!File.Exists(packagesDirectory))
+        {
+            Directory.CreateDirectory(packagesDirectory);
+        }
+
+        var architecture = channel == "win-arm64" ? "arm64" : "x64";
+        packageBytes ??= CreateValidPackage(channel, architecture);
+        var target = CreateTarget(packageBytes, channel);
+        mutateTarget?.Invoke(target);
+        var downloader = new FakeDownloader(channel, target, packageBytes);
+        var locator = new TestVelopackLocator(
+            appId,
+            installedVersion,
+            packagesDirectory,
+            appDir: _dir,
+            rootDir: _dir,
+            updateExe: Path.Combine(_dir, "Update.exe"),
+            channel: channel);
+        return new Fixture(
+            new UpdateFlow(downloader, locator),
+            downloader,
+            locator);
+    }
+
+    private static VelopackAsset CreateTarget(byte[] package, string channel)
+    {
+        const string version = "0.3.0";
+        return new VelopackAsset
+        {
+            PackageId = UpdateFlow.PackageId,
+            Version = SemanticVersion.Parse(version),
+            Type = VelopackAssetType.Full,
+            FileName = $"{UpdateFlow.PackageId}-{version}-{channel}-full.nupkg",
+            SHA1 = Convert.ToHexString(SHA1.HashData(package)),
+            SHA256 = Convert.ToHexString(SHA256.HashData(package)),
+            Size = package.Length,
+        };
+    }
+
+    private static byte[] CreateValidPackage(
+        string channel,
+        string architecture,
+        string id = UpdateFlow.PackageId,
+        string version = "0.3.0") =>
+        CreateZip(new ZipEntrySpec(
+            $"{UpdateFlow.PackageId}.nuspec",
+            Encoding.UTF8.GetBytes(Nuspec(id, version, channel, architecture)),
+            CompressionLevel.Optimal));
+
+    private static byte[] CreateAdversarialPackage(string testCase) => testCase switch
+    {
+        "no-entry" => CreateZip(new ZipEntrySpec(
+            "content.txt", "content"u8.ToArray(), CompressionLevel.Optimal)),
+        "two-entries" => CreateZip(
+            new ZipEntrySpec("one.nuspec", "<package/>"u8.ToArray(), CompressionLevel.Optimal),
+            new ZipEntrySpec("two.nuspec", "<package/>"u8.ToArray(), CompressionLevel.Optimal)),
+        "empty" => CreateZip(new ZipEntrySpec(
+            "empty.nuspec", [], CompressionLevel.NoCompression)),
+        "declared-over" => CreateZip(new ZipEntrySpec(
+            "large.nuspec", ModeratelyCompressibleBytes(65_537), CompressionLevel.Optimal)),
+        "actual-over" => PatchDeclaredUncompressedLength(
+            CreateZip(new ZipEntrySpec(
+                "actual.nuspec", ModeratelyCompressibleBytes(65_537), CompressionLevel.Optimal)),
+            65_536),
+        "compressed-over" => CreateZip(new ZipEntrySpec(
+            "compressed.nuspec", RandomBytes(65_536), CompressionLevel.SmallestSize)),
+        "ratio" => CreateZip(new ZipEntrySpec(
+            "ratio.nuspec",
+            Encoding.UTF8.GetBytes(Nuspec(
+                UpdateFlow.PackageId,
+                "0.3.0",
+                "win-x64",
+                "x64",
+                new string('A', 60_000))),
+            CompressionLevel.SmallestSize)),
+        "dtd" => CreateZip(new ZipEntrySpec(
+            "dtd.nuspec",
+            Encoding.UTF8.GetBytes("""
+                <?xml version="1.0"?>
+                <!DOCTYPE package [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+                <package><metadata><id>&xxe;</id><version>0.3.0</version><channel>win-x64</channel><machineArchitecture>x64</machineArchitecture></metadata></package>
+                """),
+            CompressionLevel.Optimal)),
+        "malformed" => CreateZip(new ZipEntrySpec(
+            "malformed.nuspec", "<package><metadata>"u8.ToArray(), CompressionLevel.Optimal)),
+        "wrong-id" => CreateValidPackage("win-x64", "x64", id: "Other.Package"),
+        "wrong-version" => CreateValidPackage("win-x64", "x64", version: "0.4.0"),
+        "wrong-channel" => CreateValidPackage("win-arm64", "x64"),
+        "wrong-architecture" => CreateValidPackage("win-x64", "arm64"),
+        _ => throw new ArgumentOutOfRangeException(nameof(testCase)),
+    };
+
+    private static string Nuspec(
+        string id,
+        string version,
+        string channel,
+        string architecture,
+        string description = "test") => $$"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+          <metadata>
+            <id>{{id}}</id>
+            <version>{{version}}</version>
+            <description>{{description}}</description>
+            <channel>{{channel}}</channel>
+            <machineArchitecture>{{architecture}}</machineArchitecture>
+          </metadata>
+        </package>
+        """;
+
+    private static byte[] CreateZip(params ZipEntrySpec[] entries)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var spec in entries)
+            {
+                var entry = archive.CreateEntry(spec.Name, spec.Compression);
+                using var output = entry.Open();
+                output.Write(spec.Content);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] PatchDeclaredUncompressedLength(byte[] package, uint length)
+    {
+        var local = FindSignature(package, 0x04034b50, fromEnd: false);
+        var central = FindSignature(package, 0x02014b50, fromEnd: true);
+        BinaryPrimitives.WriteUInt32LittleEndian(package.AsSpan(local + 22, 4), length);
+        BinaryPrimitives.WriteUInt32LittleEndian(package.AsSpan(central + 24, 4), length);
+        return package;
+    }
+
+    private static int FindSignature(byte[] bytes, uint signature, bool fromEnd)
+    {
+        if (fromEnd)
+        {
+            for (var i = bytes.Length - 4; i >= 0; i--)
+            {
+                if (BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(i, 4)) == signature)
+                {
+                    return i;
+                }
+            }
+        }
+        else
+        {
+            for (var i = 0; i <= bytes.Length - 4; i++)
+            {
+                if (BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(i, 4)) == signature)
+                {
+                    return i;
+                }
+            }
+        }
+
+        throw new InvalidDataException("ZIP signature not found.");
+    }
+
+    private static byte[] ModeratelyCompressibleBytes(int length)
+    {
+        var bytes = RandomBytes(length);
+        for (var i = 0; i < bytes.Length; i += 8)
+        {
+            bytes[i] = 0;
+        }
+        return bytes;
+    }
+
+    private static byte[] RandomBytes(int length)
+    {
+        var bytes = new byte[length];
+        new Random(42).NextBytes(bytes);
+        return bytes;
+    }
+
+    private static void AssertAdversarialFixture(string testCase, byte[] package)
+    {
+        if (testCase is not ("declared-over" or "actual-over" or "compressed-over" or "ratio"))
+        {
+            return;
+        }
+
+        using var stream = new MemoryStream(package);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+        var entry = Assert.Single(archive.Entries);
+        switch (testCase)
+        {
+            case "declared-over":
+                Assert.True(entry.Length > 65_536);
+                Assert.InRange(entry.CompressedLength, 1, 65_536);
+                break;
+            case "actual-over":
+                Assert.Equal(65_536, entry.Length);
+                Assert.InRange(entry.CompressedLength, 1, 65_536);
+                Assert.True(entry.Length <= entry.CompressedLength * 100);
+                break;
+            case "compressed-over":
+                Assert.InRange(entry.Length, 1, 65_536);
+                Assert.True(entry.CompressedLength > 65_536);
+                break;
+            case "ratio":
+                Assert.InRange(entry.Length, 1, 65_536);
+                Assert.InRange(entry.CompressedLength, 1, 65_536);
+                Assert.True(entry.Length > entry.CompressedLength * 100);
+                break;
+        }
+    }
+
+    private sealed record Fixture(
+        UpdateFlow Flow,
+        FakeDownloader Downloader,
+        TestVelopackLocator Locator);
+
+    private readonly record struct ZipEntrySpec(
+        string Name,
+        byte[] Content,
+        CompressionLevel Compression);
+
+    private sealed record Request(
+        string Url,
+        IReadOnlyDictionary<string, string> Headers);
+
+    private sealed class FakeDownloader(
+        string channel,
+        VelopackAsset target,
+        byte[] packageBytes) : IFileDownloader
+    {
+        private const string FeedUrl = "https://downloads.invalid/stable-feed";
+        private const string PrereleaseFeedUrl = "https://downloads.invalid/prerelease-feed";
+        private const string PackageUrl = "https://downloads.invalid/package";
+
+        internal List<Request> Requests { get; } = [];
+        internal int DownloadStringCalls { get; private set; }
+        internal int DownloadBytesCalls { get; private set; }
+        internal int DownloadFileCalls { get; private set; }
+        internal Exception? ApiException { get; set; }
+        internal Exception? DownloadException { get; set; }
+        internal string? ApiTextOverride { get; set; }
+        internal byte[]? FeedBytesOverride { get; set; }
+        internal bool BlockDownload { get; set; }
+        internal TaskCompletionSource DownloadStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource ReleaseDownload { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<string> DownloadString(
+            string url,
+            IDictionary<string, string>? headers = null,
+            double timeout = 30)
+        {
+            DownloadStringCalls++;
+            Capture(url, headers);
+            if (ApiException is not null)
+            {
+                return Task.FromException<string>(ApiException);
+            }
+
+            return Task.FromResult(ApiTextOverride ?? GithubReleasesJson());
+        }
+
+        public Task<byte[]> DownloadBytes(
+            string url,
+            IDictionary<string, string>? headers = null,
+            double timeout = 30)
+        {
+            DownloadBytesCalls++;
+            Capture(url, headers);
+            if (!string.Equals(url, FeedUrl, StringComparison.Ordinal))
+            {
+                return Task.FromException<byte[]>(
+                    new InvalidOperationException("Unexpected feed URL."));
+            }
+
+            return Task.FromResult(FeedBytesOverride ?? Encoding.UTF8.GetBytes(FeedJson()));
+        }
+
+        public async Task DownloadFile(
+            string url,
+            string targetFile,
+            Action<int> progress,
+            IDictionary<string, string>? headers = null,
+            double timeout = 30,
+            CancellationToken cancelToken = default)
+        {
+            DownloadFileCalls++;
+            Capture(url, headers);
+            DownloadStarted.TrySetResult();
+            if (DownloadException is not null)
+            {
+                throw DownloadException;
+            }
+
+            if (!string.Equals(url, PackageUrl, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Unexpected package URL.");
+            }
+
+            if (BlockDownload)
+            {
+                await ReleaseDownload.Task.WaitAsync(cancelToken);
+            }
+
+            await File.WriteAllBytesAsync(targetFile, packageBytes, cancelToken);
+            progress(100);
+        }
+
+        private void Capture(string url, IDictionary<string, string>? headers)
+        {
+            Requests.Add(new Request(
+                url,
+                headers is null
+                    ? new Dictionary<string, string>()
+                    : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase)));
+        }
+
+        private string GithubReleasesJson()
+        {
+            var index = $"releases.{channel}.json";
+            return JsonSerializer.Serialize(new object[]
+            {
+                new
+                {
+                    name = "prerelease",
+                    prerelease = true,
+                    published_at = "2026-07-31T02:00:00Z",
+                    assets = new[]
+                    {
+                        new
+                        {
+                            name = index,
+                            url = PrereleaseFeedUrl,
+                            browser_download_url = PrereleaseFeedUrl,
+                            content_type = "application/json",
+                        },
+                    },
+                },
+                new
+                {
+                    name = "stable",
+                    prerelease = false,
+                    published_at = "2026-07-31T01:00:00Z",
+                    assets = new[]
+                    {
+                        new
+                        {
+                            name = index,
+                            url = FeedUrl,
+                            browser_download_url = FeedUrl,
+                            content_type = "application/json",
+                        },
+                        new
+                        {
+                            name = target.FileName,
+                            url = PackageUrl,
+                            browser_download_url = PackageUrl,
+                            content_type = "application/octet-stream",
+                        },
+                    },
+                },
+            });
+        }
+
+        private string FeedJson() => JsonSerializer.Serialize(new
+        {
+            Assets = new[]
+            {
+                new
+                {
+                    target.PackageId,
+                    Version = target.Version.ToNormalizedString(),
+                    Type = target.Type.ToString(),
+                    target.FileName,
+                    target.SHA1,
+                    target.SHA256,
+                    target.Size,
+                },
+            },
+        });
+    }
+
+    private sealed class RecordingUpdateFlow(
+        IFileDownloader downloader,
+        IVelopackLocator locator) : UpdateFlow(downloader, locator)
+    {
+        internal int HandoffCalls { get; private set; }
+        internal VelopackAsset? HandoffTarget { get; private set; }
+        internal bool? Silent { get; private set; }
+        internal bool? Restart { get; private set; }
+        internal string[]? RestartArgs { get; private set; }
+        internal Exception? HandoffException { get; set; }
+        internal List<string>? Events { get; set; }
+
+        protected override void WaitExitThenApplyUpdates(
+            VelopackAsset target,
+            bool silent,
+            bool restart,
+            string[] restartArgs)
+        {
+            HandoffCalls++;
+            HandoffTarget = target;
+            Silent = silent;
+            Restart = restart;
+            RestartArgs = restartArgs;
+            Events?.Add("handoff");
+            if (HandoffException is not null)
+            {
+                throw HandoffException;
+            }
+        }
+    }
+
+    private sealed class NotInstalledLocator(string packagesDirectory)
+        : TestVelopackLocator(
+            UpdateFlow.PackageId,
+            "0.2.0",
+            packagesDirectory,
+            appDir: null,
+            rootDir: null,
+            updateExe: null,
+            channel: "win-x64")
+    {
+        public override SemanticVersion? CurrentlyInstalledVersion => null;
+    }
+}

--- a/src/TokenBar.Core.Tests/packages.lock.json
+++ b/src/TokenBar.Core.Tests/packages.lock.json
@@ -18,6 +18,12 @@
           "Microsoft.TestPlatform.TestHost": "17.14.1"
         }
       },
+      "Velopack": {
+        "type": "Direct",
+        "requested": "[1.2.0, )",
+        "resolved": "1.2.0",
+        "contentHash": "Rz67gJL619fSBS6omaSINUxyDuwhIxkm5mmubf7uLd5Qgi6LLKaKCha+QFP6n+Bw/UjA0vutnH4JQfYzn6ANtw=="
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -102,7 +108,7 @@
       "tokenbar.core": {
         "type": "Project",
         "dependencies": {
-          "TokenBar.Interop": "[0.1.0, )"
+          "TokenBar.Interop": "[0.2.0, )"
         }
       },
       "tokenbar.interop": {


### PR DESCRIPTION
## Outcome

Adds Phase 11 S3: a fail-soft, user-confirmed Velopack update flow. Syrtis checks once after the tray is ready, notifies when a validated stable release exists, and downloads only after the user clicks the balloon or native tray-menu action.

This PR does **not** publish a GitHub Release or assets, claim installed-directory ACL safety, or claim a real end-to-end update against a public target. Those remain gated behind the separate Phase 11 S4 sequence.

## Trust and data flow

- Production source is fixed to `https://github.com/Nanako0129/TokenBar-Windows`.
- `GithubSource` receives `accessToken: null` and `prerelease: false`.
- `UpdateOptions` keeps `ExplicitChannel = null` and rejects downgrades, so the installed Velopack locator remains the source of truth for AppId, version, channel, architecture, and package directory.
- A candidate must be a strictly newer, non-prerelease, Full `Nyanako.TokenBar` package with an exact `win-x64` or `win-arm64` filename, positive size, and 64-hex SHA-256 before download.
- After `DownloadUpdatesAsync` returns, checksum verification always runs, including Velopack 1.2.0's existing-final-package no-op path.
- The downloaded nupkg must contain exactly one nuspec. Compressed and uncompressed content are limited to 64 KiB, compression is limited to 100:1, DTD/entities are disabled, and `id`, `version`, `channel`, and `machineArchitecture` must match.
- Download, checksum, nuspec, or updater-launch failure remains fail-soft and does not quit the app.

## User interaction and shutdown

`PendingUpdateAction` is the shared in-process state for the H.NotifyIcon balloon and native menu. Publishing does not invoke the action; the first click takes it atomically, duplicate clicks are ignored, failures can restore it for a manual retry, and tray disposal invalidates it.

A validated package hands off with:

```csharp
WaitExitThenApplyUpdates(target, silent: false, restart: true, Array.Empty<string>())
```

Only a normal return from that call clears the action and invokes the existing `TrayService.QuitApp` cleanup path.

## Verification

- `UpdateFlowTests`: **50/50 passed** on macOS and Windows x64.
- Full managed regression: **338/338 passed** before the App-only DispatcherQueue compile correction; the correction is outside the source-linked test surface.
- Windows x64 Release artifact built successfully; `Syrtis.App.exe` and `tb_core_ffi.dll` verified as PE machine `0x8664`.
- Active Windows session startup smoke: exit `0`, sentinel `tray-ready`, architecture `X64`.
- Normal production-source launch reached `update-check: failed InvalidOperationException`, stayed alive, and emitted no `update-available`, `update-download`, or `update-handoff` marker.
- Fresh risk-triggered outcome verifier: **CONFIRMED**, with no claim-relevant P0–P2 findings.
- S2 exact-head packaging/feed preflight passed for `win-x64` and `win-arm64` without publishing.

The ARM64 host was offline; this PR's ARM64 coverage is the synthetic update path plus the S2 ARM64 packaging/feed preflight. Real installed update UX remains S4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
