### PR TITLE
chore(vendor): advance the reviewed engine pin to 84e0d66

### DIFF
--- a/vendor/ENGINE.md
+++ b/vendor/ENGINE.md
@@ -10,10 +10,10 @@ app consumer advances its reviewed pin.
 |---|---|
 | Path | `vendor/tokscale-core` |
 | Repository | `https://github.com/Nanako0129/tokscale-core.git` |
-| Reviewed pin | `b31e39425859393504a2d56cb5af7c93e6461c7d` |
+| Reviewed pin | `84e0d66413d4e0d87b734f66f7a848b3bc323258` |
 | Native consumer baseline | `704426e8df9acfb8e82fe4bf3b7ed3e5adbc2fea` |
 | Windows pre-migration baseline | `68e2541c5e9adb14a47433f8b25e26b0be84d1fc` |
-| Upstream and local-patch ledger | Immutable [`UPSTREAM.md`](https://github.com/Nanako0129/tokscale-core/blob/b31e39425859393504a2d56cb5af7c93e6461c7d/UPSTREAM.md) |
+| Upstream and local-patch ledger | Immutable [`UPSTREAM.md`](https://github.com/Nanako0129/tokscale-core/blob/84e0d66413d4e0d87b734f66f7a848b3bc323258/UPSTREAM.md) |
 
 > **Warning:** Do not edit shared source on a consumer branch. Engine changes
 > must pass review in `tokscale-core`; this repository then advances only the


### PR DESCRIPTION
Advances the shared-engine gitlink to the reviewed commit already adopted by Native (TokenBar PR #123, merge `2814a1d7`). Two files change.

| | before | after |
|---|---|---|
| `vendor/tokscale-core` gitlink | `b31e394…` | `84e0d66…` |
| `vendor/ENGINE.md` reviewed pin | `b31e394…` | `84e0d66…` |
| `vendor/ENGINE.md` UPSTREAM.md link | `…/blob/b31e394…/UPSTREAM.md` | `…/blob/84e0d66…/UPSTREAM.md` |

No other occurrence of the old SHA remains in the repository.

## What the range contains

`b31e394..84e0d66` is four engine commits touching four engine files: `UPSTREAM.md`, `src/lib.rs`, `src/message_cache.rs`, `src/sessions/grok.rs`. All four fix model attribution in the Grok Build unified log: parent authority isolated per PID generation, exact child authority isolated per subagent session, a prepass collecting generation-scoped parent evidence for retro-attribution, and fail-closed to `grok-unknown` on conflict or across `AuthManager::new`.

## Why nothing else moves

- Engine `Cargo.toml` / `Cargo.lock` are byte-identical across the range, so the consumer root `Cargo.lock` is untouched. `cargo build --release --locked` succeeds and leaves the lock unmodified — `--locked` fails outright if the lock would need regenerating, so this is a check rather than an assertion.
- No C ABI, DTO, or public API change, so `TokenBar.Core` and the C# bridge need no port.

## Expected runtime consequence

Grok parser identity moves 1 → 3 while `CACHE_FORMAT_VERSION` stays 2, so existing parser-v1/v2 shards at the same fingerprint are judged stale and cold-rebuild on first read. Other client identities are unchanged. This is intended.

## Verification

| Gate | Where | Status |
|---|---|---|
| `cargo build --release --locked`, root lock unmodified | macOS, local | passed |
| `cargo test --locked --release` | macOS, local | passed |
| Managed suite | CI | this host runs SDK 10.0.302 while `global.json` pins 10.0.301, so it was not run locally |
| Windows x64 build, packaged-FFI | CI | this PR |
| ARM64 cross-build/package | CI | this PR |
| 119-case Swift/C# cross-check | CI | this PR, expecting zero material difference |
| Same-snapshot token conservation, old pin vs new pin | tracked separately | not claimed by this PR |

On the conservation check: the Windows x64 host has no usable input. Its `~/.grok/logs/unified.jsonl` holds 37 lines of CLI diagnostic logging with zero usage rows, so the CLI was installed and never actually used there. A host with real data is being used instead, and the result will be reported before integration rather than folded into this PR.

## Claim limitation

目前沒有任何 cross-port parity 主張；same-pin 只證明 shared source 相同，不取代 cross-check 這道跨語言 gate。

## Follow-up, not in this PR

After this merges, the Native repo needs its "temporarily diverged" wording returned to same-pin at `docs/knowledge/architecture.md:67`, `verification.md:193`, `vendor-tokscale.md` (Native temporary pin paragraph plus the consumer adoption row), and `current-state.md:39` and `:67`. The dated PR #114 / Windows PR #12 checkpoint at `verification.md:209` is historical evidence and stays as it is.