### PR TITLE
feat(app): drop the unused Windows AI payload and prepare 0.2.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
   <PropertyGroup>
     <TbProductName>Syrtis</TbProductName>
     <Product>$(TbProductName)</Product>
-    <TbSemanticVersion>0.2.0</TbSemanticVersion>
-    <TbAssemblyVersion>0.2.0.0</TbAssemblyVersion>
+    <TbSemanticVersion>0.2.1</TbSemanticVersion>
+    <TbAssemblyVersion>0.2.1.0</TbAssemblyVersion>
     <Version>$(TbSemanticVersion)</Version>
     <PackageVersion>$(TbSemanticVersion)</PackageVersion>
     <InformationalVersion>$(TbSemanticVersion)</InformationalVersion>

--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -25,8 +25,8 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$ExpectedSemanticVersion = "0.2.0"
-$ExpectedAssemblyVersion = "0.2.0.0"
+$ExpectedSemanticVersion = "0.2.1"
+$ExpectedAssemblyVersion = "0.2.1.0"
 $ExpectedDotnetVersion = "10.0.301"
 $ExpectedRustVersion = "1.96.1"
 

--- a/src/TokenBar.App/TokenBar.App.csproj
+++ b/src/TokenBar.App/TokenBar.App.csproj
@@ -73,4 +73,21 @@
           OverwriteReadOnlyFiles="true" />
   </Target>
 
+  <!-- Phase 11 S5: WindowsAppSDK 1.8's self-contained payload carries the
+       Windows AI runtime. onnxruntime.dll and DirectML.dll are 38.5 MB
+       uncompressed between them and this app has no call site for either; a
+       repository-wide search for AI, ONNX, DirectML, WinML or Phi Silica finds
+       nothing. The umbrella package cannot be dropped, because
+       H.NotifyIcon.WinUI depends on it, and ExcludeAssets on the .AI and .ML
+       sub-packages does not help, because the binaries arrive through the
+       self-contained payload rather than those packages' own assets. The SDK
+       adds the payload as None items, so drop the two by name after it does. -->
+  <Target Name="TbTrimUnusedWindowsAppSdkPayload"
+          AfterTargets="AddMicrosoftWindowsAppSDKPayloadFilesFromMsix;AddMicrosoftWindowsAppSDKPayloadFilesFromComponents">
+    <ItemGroup>
+      <None Remove="@(None)"
+            Condition="'%(Filename)%(Extension)' == 'onnxruntime.dll' or '%(Filename)%(Extension)' == 'DirectML.dll'" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/TokenBar.App/app.manifest
+++ b/src/TokenBar.App/app.manifest
@@ -2,7 +2,7 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <!-- Keep this checked template literal aligned with Directory.Build.props;
        the Phase 10 artifact verifier rejects drift. -->
-  <assemblyIdentity version="0.2.0.0" name="TokenBar.App" />
+  <assemblyIdentity version="0.2.1.0" name="TokenBar.App" />
 
   <!-- Without this the process runs DPI-virtualized: AppWindow coordinates
        live in a scaled-down space while the screen (and the low-level mouse


### PR DESCRIPTION
Removes `onnxruntime.dll` and `DirectML.dll` from the self-contained WindowsAppSDK payload, and advances the version contract to `0.2.1`.

## Why they are there and why they can go

38.5 MB uncompressed between them, for Windows AI APIs this app never calls. A repository-wide search for AI, ONNX, DirectML, WinML or Phi Silica returns nothing. They arrive because WindowsAppSDK 1.8s umbrella package depends on `.AI` and `.ML`, whose content is part of the self-contained runtime payload.

## Two cleaner approaches were tried first and failed

| Approach | Result |
|---|---|
| Reference only the sub-packages actually used | **Does not build.** `H.NotifyIcon.WinUI` depends on the umbrella, so dropping our explicit reference resolves `Microsoft.WindowsAppSDK` **1.6.250108002** alongside the 1.8 sub-packages. WinUI props/targets import twice: five MSB4011 warnings, then a hard MSIX build-tools failure about `CustomBeforeMicrosoftCommonTargets` reassignment. |
| `ExcludeAssets="all"` on `.AI` / `.ML` / `.Widgets` | **Builds, barely helps.** 562 files / 230.0 MB → 553 files / 229.4 MB, both large binaries still present. `ExcludeAssets` suppresses assets *from those packages*; these files come through the self-contained payload carried by `Microsoft.WindowsAppSDK.Runtime`. |

The csproj comment records both, so a later reader does not "tidy" this back into one of them.

## What works

`AddMicrosoftWindowsAppSDKPayloadFilesFromMsix` and its `FromComponents` sibling collect the payload into `MicrosoftWindowsAppSDKFiles` and hand it to `CreateItem`, which emits `None` items with `CopyToOutputDirectory=PreserveNewest`. A target running `AfterTargets` on both removes the two by filename.

The SDK does expose `MicrosoftWindowsAppSDKFilesExcluded` for this, but populating it correctly depends on SDK-internal path properties being set at the right moment, which is more fragile across SDK versions than matching filenames. Either way this stays in the project next to the dependency graph rather than deleting files from a finished package, so the cost is visible where someone would look for it.

## Measured

| | before | after |
|---|---|---|
| publish output | 562 files, 230.0 MB | 560 files, 191.6 MB |
| `Setup.exe` | 103,545,300 B | **86,694,896 B** |
| `full.nupkg` | 99,083,732 B | 82,233,328 B |

Compressed saving 16.9 MB, 16.3 percent. `onnxruntime.dll` and `DirectML.dll` absent; `Syrtis.App.exe` and `tb_core_ffi.dll` present, native DLL still verifying at PE machine `0x8664`.

## Not claimed here

**That the app still starts with those binaries absent.** Removing files from a self-contained runtime can only be proven safe by running it, which needs an interactive desktop session. The interactive launch and the `0.2.0` → `0.2.1` update are the next gate.

## Further slimming, deliberately not attempted

What remains is 69.0 MB of .NET runtime and 79.4 MB of WindowsAppSDK. Both shrink only by moving to framework-dependent deployment, which changes what the installer must do on a machine lacking those runtimes. Changing the deployment model before the update mechanism has ever run end to end would mean debugging two unknowns at once.