### PR TITLE
fix(release): align the Velopack pack id with the Syrtis product name

### DIFF
--- a/scripts/package-velopack.ps1
+++ b/scripts/package-velopack.ps1
@@ -192,9 +192,16 @@ $propsPath = Join-Path $repoRoot "Directory.Build.props"
 $buildScript = Join-Path $repoRoot "scripts\build-app-artifact.ps1"
 $outputRootResolved = Assert-NewOutputRoot -Path $OutputRoot
 $packProperties = Read-PackProperties -Path $propsPath
-# Keep the update identity stable across product renames so installed clients
-# continue to find the same release lineage.
-$packId = "Nyanako.TokenBar"
+# Velopack's durable install identity: it names the install directory, the
+# artifact filenames, and the package an installed client will accept. Changing
+# it orphans every existing install. It was held at the pre-rename value to keep
+# that lineage stable, but the value is a stale product name that surfaces in
+# %LocalAppData%\<packId> and in the Setup/nupkg filenames, so it was aligned to
+# Syrtis while the installed base was two machines. That window is closed: treat
+# this as frozen. Deliberately a literal here and in UpdateFlow.cs rather than
+# derived from $(TbProductName), so a future product rename cannot move it by
+# accident; UpdateFlowTests.PackageIdMatchesPackagingScript pins the two.
+$packId = "Nyanako.Syrtis"
 $appExecutableName = "{0}.App.exe" -f $packProperties.ProductName
 $machineArchitecture = if ($Rid -eq "win-x64") { "x64" } else { "arm64" }
 

--- a/src/TokenBar.App/UpdateFlow.cs
+++ b/src/TokenBar.App/UpdateFlow.cs
@@ -11,7 +11,17 @@ internal class UpdateFlow
 {
     internal const string RepositoryUrl =
         "https://github.com/Nanako0129/TokenBar-Windows";
-    internal const string PackageId = "Nyanako.TokenBar";
+    /// <summary>Velopack's durable install identity: it names the install
+    /// directory, the artifact filenames, and the package this client will
+    /// accept. Changing it orphans every existing install — that client keeps
+    /// comparing against the old value and silently refuses the renamed
+    /// package. Aligned to the Syrtis product name while the installed base
+    /// was two machines; that window is closed, so treat this as frozen.
+    /// It is deliberately a literal in both this file and
+    /// scripts/package-velopack.ps1 rather than derived from
+    /// $(TbProductName): a future product rename must not move it by
+    /// accident. PackageIdMatchesPackagingScript pins the two together.</summary>
+    internal const string PackageId = "Nyanako.Syrtis";
     private const int MaxNuspecBytes = 65_536;
     private const long MaxCompressionRatio = 100;
 

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -35,6 +35,13 @@
     <None Include="..\..\crosscheck\fixtures\provider-quota-pace-v3.json"
           Link="Fixtures\provider-quota-pace-v3.json"
           CopyToOutputDirectory="PreserveNewest" />
+    <!-- Read by UpdateFlowTests.PackageIdMatchesPackagingScript: the Velopack
+         pack id is an independent literal in the packaging script and in
+         UpdateFlow, and a silent divergence would ship packages no installed
+         client accepts. -->
+    <None Include="..\..\scripts\package-velopack.ps1"
+          Link="Fixtures\package-velopack.ps1"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/TokenBar.Core.Tests/UpdateFlowTests.cs
+++ b/src/TokenBar.Core.Tests/UpdateFlowTests.cs
@@ -27,6 +27,25 @@ public class UpdateFlowTests : IDisposable
         }
     }
 
+    /// <summary>The Velopack pack id is a literal in two places by design, so a
+    /// product rename cannot move it by accident. That only holds if the two
+    /// cannot drift: a packaging script emitting one id while the installed
+    /// client demands another produces releases that every client silently
+    /// refuses, and the failure appears as "no update available" rather than an
+    /// error.</summary>
+    [Fact]
+    public void PackageIdMatchesPackagingScript()
+    {
+        var script = File.ReadAllText(
+            Path.Combine(AppContext.BaseDirectory, "Fixtures", "package-velopack.ps1"));
+        var match = System.Text.RegularExpressions.Regex.Match(
+            script, @"^\$packId\s*=\s*""(?<id>[^""]+)""\s*$",
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+
+        Assert.True(match.Success, "package-velopack.ps1 has no $packId assignment.");
+        Assert.Equal(UpdateFlow.PackageId, match.Groups["id"].Value);
+    }
+
     [Theory]
     [InlineData("win-x64", "x64")]
     [InlineData("win-arm64", "arm64")]
@@ -90,15 +109,15 @@ public class UpdateFlowTests : IDisposable
                     break;
                 case "same-version":
                     target.Version = SemanticVersion.Parse("0.2.0");
-                    target.FileName = "Nyanako.TokenBar-0.2.0-win-x64-full.nupkg";
+                    target.FileName = "Nyanako.Syrtis-0.2.0-win-x64-full.nupkg";
                     break;
                 case "lower-version":
                     target.Version = SemanticVersion.Parse("0.1.0");
-                    target.FileName = "Nyanako.TokenBar-0.1.0-win-x64-full.nupkg";
+                    target.FileName = "Nyanako.Syrtis-0.1.0-win-x64-full.nupkg";
                     break;
                 case "prerelease-version":
                     target.Version = SemanticVersion.Parse("0.3.0-beta.1");
-                    target.FileName = "Nyanako.TokenBar-0.3.0-beta.1-win-x64-full.nupkg";
+                    target.FileName = "Nyanako.Syrtis-0.3.0-beta.1-win-x64-full.nupkg";
                     break;
                 case "missing-sha256":
                     target.SHA256 = "";
@@ -122,8 +141,8 @@ public class UpdateFlowTests : IDisposable
 
     [Theory]
     [InlineData("Other.Package", "win-x64")]
-    [InlineData("Nyanako.TokenBar", "win")]
-    [InlineData("Nyanako.TokenBar", "linux-x64")]
+    [InlineData("Nyanako.Syrtis", "win")]
+    [InlineData("Nyanako.Syrtis", "linux-x64")]
     public async Task RejectsInvalidInstalledIdentityOrChannelBeforeNetwork(
         string appId,
         string channel)


### PR DESCRIPTION
Aligns the Velopack pack id with the product name the user actually sees.

## The gap

`39a2c99` renamed the product to Syrtis. The packaging script kept the pack id at the pre-rename value on purpose:

```powershell
# Keep the update identity stable across product renames so installed clients
# continue to find the same release lineage.
$packId = "Nyanako.TokenBar"
```

That reasoning is right for an *opaque* identifier. This value is not opaque — it is the previous product name, and Velopack puts it in three places a user sees:

| Surface | Today |
|---|---|
| Install directory | `%LocalAppData%\Nyanako.TokenBar` (confirmed on the x64 host) |
| Setup filename | `Nyanako.TokenBar-win-x64-Setup.exe` |
| nupkg filename | `Nyanako.TokenBar-0.2.1-win-x64-full.nupkg` |

So a release page titled **Syrtis v0.2.1** hands the user `Nyanako.TokenBar-win-x64-Setup.exe`. Holding the stale name bought lineage stability and paid for it with a permanently wrong user-visible identity.

## Why now

The cost of this change is a function of installed base, and the installed base is **two machines**, three days after 0.2.1 shipped. Every week that passes makes it more expensive; there is no later point at which it gets cheaper.

## Breaking change: existing installs must be reinstalled

An installed client compares the id with `StringComparison.Ordinal` in four places — `UpdateFlow.cs` lines 137, 148, 166 and 253. Those clients have the **old** constant compiled in, so after this ships they will fetch the feed, see `Nyanako.Syrtis-…`, and reject it.

The failure mode is silent: **"no update available", not an error.** The two existing installs must uninstall and reinstall once.

Renaming only the published Setup asset was considered and rejected — it leaves the install directory wrong forever, and the directory is the one of the three surfaces that persists on disk.

## Why the value stays duplicated

The id remains an independent literal in `UpdateFlow.cs` and in `package-velopack.ps1` rather than deriving from `$(TbProductName)`.

Deriving it would make exactly the accident this PR repairs cheap to repeat: a future product rename would move the update identity silently and orphan every user at that point. The value should be *hard* to change. Both comments now say it is frozen and why.

## The guard

Two independent literals that must agree, whose divergence fails silently, need a test. `UpdateFlowTests.PackageIdMatchesPackagingScript` reads the packaging script — copied to the test output through the same convention the `provider-quota-pace-v3` fixture already uses — extracts the `$packId` assignment and asserts equality with `UpdateFlow.PackageId`.

Verified in both directions on the x64 host:

```
--- guard runs? ---
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1

--- negative: script id changed to Nyanako.Drifted ---
   Assert.Equal() Failure: Strings differ
Failed!  - Failed: 1, Passed: 0, Skipped: 0, Total: 1

--- restored: 0 changed lines ---
```

A guard that cannot fail is not a guard, so the negative case is the one that matters.

## Verification

`dotnet test -c Release -p:Platform=x64` on the physical x64 Windows host: **339 passed, 0 failed**.

The existing `UpdateFlowTests` literals for the same-version, lower-version, prerelease-version and invalid-identity cases move to the new id so they keep exercising the accept/reject boundary instead of passing for the wrong reason.

## Note for #23

This touches `package-velopack.ps1` at the hunk `#23` extends (`@@ -197`), so that branch will need a rebase. Its filename assertions are suffix-based and should survive unchanged.
