### PR TITLE
fix(app): stop stripping WinUIEdit.dll from the publish payload

### DIFF
--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -353,6 +353,11 @@ Assert-RequiredDesktopMuiLocales `
     -MuiFiles $muiFiles
 
 # Forbidden payload / diagnostics / unused SDK binaries (must be absent from installer payload).
+# This list mirrors the removals in TokenBar.App.csproj and must stay in step
+# with them: an entry here without the matching strip fails the build on a
+# correct payload, and a strip without an entry here goes unguarded.
+# WinUIEdit.dll was in both and is now in neither - the XAML runtime loads it
+# while building the visual tree, so removing it stopped the app from opening.
 $forbiddenExact = @(
     "onnxruntime.dll",
     "onnxruntime_providers_shared.dll",
@@ -360,7 +365,6 @@ $forbiddenExact = @(
     "Microsoft.Windows.Widgets.dll",
     "Microsoft.Windows.Widgets.Projection.dll",
     "Microsoft.Windows.Widgets.winmd",
-    "WinUIEdit.dll",
     "mscordaccore.dll",
     "mscordbi.dll"
 )

--- a/src/TokenBar.App/TokenBar.App.csproj
+++ b/src/TokenBar.App/TokenBar.App.csproj
@@ -79,16 +79,34 @@
        not help because the binaries arrive through the self-contained payload.
        The SDK adds the payload as None items, so drop them by name after it does.
 
-       Stripped binaries and justification (confirmed by repository-wide search):
+       Stripped binaries and justification:
          onnxruntime.dll + DirectML.dll      (38.5 MB) — no AI/ONNX/WinML usage
          onnxruntime_providers_shared.dll     (0.05 MB) — companion of onnxruntime
          Microsoft.Windows.Widgets.*         ( 2.5 MB) — no Widget API usage
-         WinUIEdit.dll                       ( 3.3 MB) — no TextBox/RichEditBox
          Microsoft.DiaSymReader.Native.*.dll ( 2.1 MB) — debug symbol reader only
 
-       NOTE: .mui locale files and SatelliteResourceLanguages are intentionally
-       NOT stripped — doing so breaks XAML resource resolution on non-English
-       Windows systems (zh-TW, ja-JP, etc.) with XamlParseException. -->
+       NOT stripped, and each entry here is a scar:
+
+       WinUIEdit.dll (3.3 MB) was stripped on the grounds that a repository-wide
+       search found no TextBox, RichEditBox, AutoSuggestBox, PasswordBox or
+       NumberBox. That search answered the wrong question. WinUI loads this
+       binary while building the visual tree regardless of which controls the
+       source names, so the app died at startup with
+       XamlParseException: Cannot create instance of type 'DashboardView',
+       from FlyoutWindow.InitializeComponent. Restoring this one file, with
+       every other removal left in place, is the difference between an app that
+       will not open at all and one that starts normally. Do not strip it again
+       on the strength of a source-text search; the only evidence that settles
+       a payload removal is launching the built app.
+
+       .mui locale files and SatelliteResourceLanguages are likewise NOT
+       stripped — that breaks XAML resource resolution on non-English Windows
+       (zh-TW, ja-JP) with the same exception class.
+
+       The general rule both scars point at: these binaries are loaded by the
+       XAML runtime, not called from our code, so "we never reference it" is not
+       evidence that it is unused. -->
+
   <Target Name="TbTrimUnusedWindowsAppSdkPayload"
           AfterTargets="AddMicrosoftWindowsAppSDKPayloadFilesFromMsix;AddMicrosoftWindowsAppSDKPayloadFilesFromComponents">
     <ItemGroup>
@@ -99,7 +117,6 @@
                        '%(Filename)%(Extension)' == 'Microsoft.Windows.Widgets.dll' or
                        '%(Filename)%(Extension)' == 'Microsoft.Windows.Widgets.Projection.dll' or
                        '%(Filename)%(Extension)' == 'Microsoft.Windows.Widgets.winmd' or
-                       '%(Filename)%(Extension)' == 'WinUIEdit.dll' or
                        $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.DiaSymReader.Native'))" />
     </ItemGroup>
   </Target>
@@ -154,8 +171,7 @@
                                         '%(Filename)%(Extension)' == 'Microsoft.Windows.Widgets.dll' or
                                         '%(Filename)%(Extension)' == 'Microsoft.Windows.Widgets.Projection.dll' or
                                         '%(Filename)%(Extension)' == 'Microsoft.Windows.Widgets.winmd' or
-                                        '%(Filename)%(Extension)' == 'WinUIEdit.dll' or
-                                        $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.DiaSymReader.Native'))" />
+                                                         $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.DiaSymReader.Native'))" />
 
       <!-- .NET diagnostics DLLs (crash-dump analysis tools, not needed at runtime;
            clrjit is required and is NOT stripped) -->


### PR DESCRIPTION
**`main` does not start.** Built from `21937e9` and launched on a clean Windows 11 desktop, the app dies before showing anything:

```
launch FAILED: Microsoft.UI.Xaml.Markup.XamlParseException:
Cannot create instance of type 'TokenBar.App.DashboardView'
   at TokenBar.App.FlyoutWindow.InitializeComponent()
   at TokenBar.App.App.OnLaunched(LaunchActivatedEventArgs args)
```

The published v0.2.1 opens on the same machine. The only relevant difference is the payload strip from #29, which removed `WinUIEdit.dll`.

## Controlled test

Same machine, same build, one file restored, everything else from #29 left stripped:

| `WinUIEdit.dll` | Result |
|---|---|
| stripped | `XamlParseException`, app never opens |
| restored | starts normally, tray up, `first snapshot ready` |

## Why the original justification did not hold

The removal was justified by a repository-wide search finding no `TextBox`, `RichEditBox`, `AutoSuggestBox`, `PasswordBox` or `NumberBox`. That search answered a different question than the one that mattered: WinUIEdit is loaded by the XAML runtime while building the visual tree, and whether our source names an editing control does not determine whether the binary is needed.

It is the same mistake as the `.mui` removal recorded in the comment directly above it, which also failed with `XamlParseException`. The comment now presents both as scars rather than as a list of successful removals, and states the rule they share — these binaries are loaded by the XAML runtime rather than called from our code, so "we never reference it" is not evidence that it is unused.

## How this got through

I approved #29 across three rounds against seven green CI jobs. Every one of those checks inspected the shape of the produced files; none of them started the application. Between #29 merging and this test, no build from `main` had been launched anywhere.

## Cost

3.3 MB recovered, against roughly 41 MB the remaining strips still remove.

## Verification

Clean Windows 11 VM, no .NET and no VC++ redistributable, launched from the desktop. Devlog after restoring the file:

```
launch: creating tray
launch: tray up
slow lane: graph+models=19540ms year=all
first snapshot ready
```

cc @ImL1s — not a criticism of the PR; the review that let it through was mine.