### PR TITLE
fix(native): statically link the MSVC CRT into tb_core_ffi

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,27 @@
+# Statically link the MSVC C runtime into the native library.
+#
+# Rust's *-pc-windows-msvc targets link vcruntime140.dll dynamically by default.
+# That DLL ships with the Visual C++ Redistributable, which a fresh Windows 11
+# does not have — Windows provides ucrtbase.dll (satisfying api-ms-win-crt-*)
+# but not vcruntime140.dll. We neither bundled nor declared it, so on a clean
+# machine every P/Invoke into tb_core_ffi failed with 0x8007007E
+# (ERROR_MOD_NOT_FOUND) and the app opened to a dashboard that spun forever
+# with no error shown. See issue #36.
+#
+# Static linking is safe here specifically because no CRT resource crosses the
+# FFI boundary. The contract is stated in src/TokenBar.Interop/NativeMethods.cs:
+# every returned pointer is "released with tb_free exactly once", and
+# TbCore.TakeString is the single legal path. Rust allocates, Rust frees; the
+# managed side never calls a CRT free on Rust memory. If that contract is ever
+# relaxed — if C# starts freeing Rust allocations directly, or a FILE* or errno
+# is shared — this setting must be revisited before that change lands.
+#
+# Chosen over shipping vcruntime140.dll app-locally (which would make us
+# responsible for its security updates) and over declaring a vcredist
+# prerequisite (which adds an install-time download and a failure point).
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -429,6 +429,35 @@ if ($nativeHash -ne $nativeSourceHash) {
     throw "Published native DLL does not match the BuildTbNative source bytes."
 }
 
+# The native DLL must not depend on the Visual C++ Redistributable. A fresh
+# Windows 11 ships ucrtbase.dll (satisfying api-ms-win-crt-*) but not
+# vcruntime140.dll, so an import of it made every P/Invoke fail with
+# 0x8007007E on a clean machine while the app opened normally and spun
+# forever with no error surfaced (issue #36). .cargo/config.toml links the
+# CRT statically to prevent that; this asserts the result rather than trusting
+# the setting, because RUSTFLAGS in the environment silently overrides the
+# config file and nothing else here would notice.
+#
+# This scans the file's bytes for the import name rather than walking the PE
+# import directory. An imported DLL's name is stored as a plain ASCII string
+# there, so the scan cannot miss a real import; it could in principle fire on
+# the name appearing as unrelated data, which for this library it does not.
+# CI runners and dev boxes all carry the redistributable, so this is the only
+# thing standing between a reintroduced dependency and a user seeing it.
+$nativeBytes = [System.IO.File]::ReadAllBytes($nativeSourcePath)
+$nativeAscii = [System.Text.Encoding]::ASCII.GetString($nativeBytes)
+$forbiddenCrtImports = @('vcruntime140.dll', 'vcruntime140_1.dll', 'msvcp140.dll')
+$foundCrtImports = @($forbiddenCrtImports | Where-Object {
+    $nativeAscii.IndexOf($_, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+})
+if ($foundCrtImports.Count -gt 0) {
+    throw ("tb_core_ffi.dll depends on the Visual C++ Redistributable ({0}), " +
+        "which a clean Windows install does not have. Expected a statically " +
+        "linked CRT — check that .cargo/config.toml applies and that RUSTFLAGS " +
+        "is not overriding it." -f ($foundCrtImports -join ', '))
+}
+Write-Output "Native CRT: statically linked (no VC++ redistributable imports)"
+
 $fileVersionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($exePath)
 if ($fileVersionInfo.FileVersion -ne $ExpectedAssemblyVersion) {
     throw "Published App FileVersion '$($fileVersionInfo.FileVersion)' does not match $ExpectedAssemblyVersion."


### PR DESCRIPTION
Closes #36.

On a fresh Windows 11 the published app installs, opens, and never shows any data. The dashboard spins indefinitely, the tray falls back to a static icon, and **no error is surfaced anywhere in the UI**. Devlog from a clean VM running the published v0.2.1 installer:

```
tray graph failed: Unable to load DLL 'tb_core_ffi' or one of its dependencies:
The specified module could not be found. (0x8007007E)
```

repeated on every refresh cycle for every data path, forever. `tb_core_ffi.dll` itself is present in the install — the failure is the second half of that message.

## Root cause

Rust's `*-pc-windows-msvc` targets link the Visual C++ runtime dynamically, so `tb_core_ffi.dll` imports `vcruntime140.dll`. Windows ships `ucrtbase.dll`, which satisfies the `api-ms-win-crt-*` API sets every other shipped binary uses, but `vcruntime140.dll` arrives only with the Visual C++ Redistributable. We neither bundled it nor declared it.

Proven on one machine, one variable:

| `vcruntime140.dll` | `LoadLibraryEx("tb_core_ffi.dll")` |
|---|---|
| absent | **fails**, win32 `126` — the code behind `0x8007007E` |
| present | **loads** |

Not introduced by any contributor PR: v0.2.1 shipped 2026-08-02, the first outside PR arrived on the 4th.

## Why nine green jobs missed it

Every machine that has ever run this app carries the redistributable — the x64 test box has the Visual Studio toolchain, GitHub's `windows-latest` runners ship it. The defect is structurally invisible without a genuinely clean host, and one only existed as of this week.

## Why static linking is safe here

The usual hazard is allocating on one CRT heap and freeing on another. This FFI forbids that by contract: `NativeMethods.cs:12` states every returned pointer is "released with `tb_free` exactly once", `TbCore.TakeString` is the single legal path, and the managed side never calls a CRT free on Rust memory. The config comment records that constraint so a future change to the ownership rules is forced to revisit this setting.

Shipping `vcruntime140.dll` app-locally would make us responsible for its security updates; declaring a vcredist prerequisite adds an install-time download and a failure point to a deployment whose selling point is having none. Static linking removes the dependency instead of managing it.

## Guard

`build-app-artifact.ps1` asserts the outcome rather than the setting — `RUSTFLAGS` in the environment silently overrides `.cargo/config.toml` and nothing else would notice. The comment states plainly that it is a name scan rather than a walk of the PE import directory, and why that suffices. The same detection fires on the pre-fix DLL, so it distinguishes.

## Verification on the clean VM

```
vcruntime140 in System32 : ABSENT
vcruntime140.dll         : not imported
RESULT : LOADED (handle 0x7FFBA3060000)
```

and, launched from the desktop, no `0x8007007E` in the devlog at all — `tray up`, then `first snapshot ready`. Cold start on a machine with no cache took 19.5 s, against 325 ms warm on the physical host.

**Requires #37.** That run needed `WinUIEdit.dll` restored; without it `main` does not open at all, for unrelated reasons.

## Not verified

The full Velopack installer path with this change — the acceptance above extracted the app artifact zip rather than running `Setup.exe`, because the installer is not the variable under test. That path should be exercised before a release is cut. ARM64 has no clean host yet.