### PR TITLE
chore(version): move the version contract to 0.2.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
   <PropertyGroup>
     <TbProductName>Syrtis</TbProductName>
     <Product>$(TbProductName)</Product>
-    <TbSemanticVersion>0.2.1</TbSemanticVersion>
-    <TbAssemblyVersion>0.2.1.0</TbAssemblyVersion>
+    <TbSemanticVersion>0.2.2</TbSemanticVersion>
+    <TbAssemblyVersion>0.2.2.0</TbAssemblyVersion>
     <Version>$(TbSemanticVersion)</Version>
     <PackageVersion>$(TbSemanticVersion)</PackageVersion>
     <InformationalVersion>$(TbSemanticVersion)</InformationalVersion>

--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -32,8 +32,8 @@ Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot "lib\MuiGuard.ps1")
 . (Join-Path $PSScriptRoot "lib\RuntimeConfig.ps1")
 
-$ExpectedSemanticVersion = "0.2.1"
-$ExpectedAssemblyVersion = "0.2.1.0"
+$ExpectedSemanticVersion = "0.2.2"
+$ExpectedAssemblyVersion = "0.2.2.0"
 $ExpectedDotnetVersion = "10.0.301"
 $ExpectedRustVersion = "1.96.1"
 

--- a/src/TokenBar.App/app.manifest
+++ b/src/TokenBar.App/app.manifest
@@ -2,7 +2,7 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <!-- Keep this checked template literal aligned with Directory.Build.props;
        the Phase 10 artifact verifier rejects drift. -->
-  <assemblyIdentity version="0.2.1.0" name="TokenBar.App" />
+  <assemblyIdentity version="0.2.2.0" name="TokenBar.App" />
 
   <!-- Without this the process runs DPI-virtualized: AppWindow coordinates
        live in a scaled-down space while the screen (and the low-level mouse


### PR DESCRIPTION
Prepares the release that delivers #36 to users.

`main` is fixed; **v0.2.1 on Latest is not**. Anyone downloading it today gets an app that installs, opens, and never shows data, with no error anywhere in the UI. Closing #36 repaired what we build, not what people already have.

## Version contract

Three sites, moved together — `build-app-artifact.ps1:86` asserts the props file matches its constants, so a partial bump fails the build rather than shipping a mismatch:

| File | 0.2.1 | 0.2.2 |
|---|---|---|
| `Directory.Build.props` | `TbSemanticVersion`, `TbAssemblyVersion` | ✓ |
| `src/TokenBar.App/app.manifest` | `assemblyIdentity version` | ✓ |
| `scripts/build-app-artifact.ps1` | `$ExpectedSemanticVersion`, `$ExpectedAssemblyVersion` | ✓ |

## What 0.2.2 carries

Everything below was observed working on clean VMs — no .NET, no VC++ redistributable, checkpointed:

- **#36** — static CRT linking; `tb_core_ffi.dll` loads on a clean **x64** and a clean **ARM64** host with no redistributable present
- **#37** — `WinUIEdit.dll` no longer stripped; without it the app did not open at all
- **#30** — Lite channel, with its runtime bootstrap observed installing .NET 10.0.10 on a machine with no .NET
- **#27** — pack id matches the product name; artifacts and the install directory now read `Nyanako.Syrtis`
- **#28** — unpackaged tray startup bounded by a monotonic 10 s deadline
- **#22** — dashboard hover feedback

## Breaking for existing installs

0.2.0 and 0.2.1 **cannot update to this.** The pack id changed in `864aa03`, and an installed client compares it with `StringComparison.Ordinal`, so it reports *no update available* rather than failing. Those installs need one manual uninstall and reinstall, and the release notes have to say so plainly — the failure is silent.

## Known and not fixed in this release

**#39** — the first snapshot blocks on a network connect with no timeout. On a network where IPv6 resolves but does not route, that is 20–30 s of unexplained spinning. Not a regression; present in 0.2.1 too.