### PR TITLE
ci(release): build and attach release assets from a tag

### DIFF
--- a/.github/release-notes/v0.2.2.md
+++ b/.github/release-notes/v0.2.2.md
@@ -1,0 +1,65 @@
+# Syrtis v0.2.2
+
+**If you are on 0.2.0 or 0.2.1, you must uninstall and reinstall.** Automatic update will not reach you, and it will not tell you that — it reports *no update available*. See "Updating from an earlier version" below.
+
+## The reason this release exists
+
+**v0.2.1 does not work on a machine that has never had the Visual C++ Redistributable installed.** It installs, it opens, and then it never shows any data. The dashboard spins indefinitely, the tray falls back to a static icon, and nothing anywhere in the interface says why.
+
+The native library that reads your usage data was linked against `vcruntime140.dll`, which ships with the Visual C++ Redistributable rather than with Windows. Machines that have ever installed a game, a developer tool, or a great deal of ordinary desktop software already have it, which is why this went unnoticed. A freshly installed Windows does not.
+
+The library now links the C runtime statically and has no such dependency. Verified by installing on a clean Windows 11 with no redistributable present, on both x64 and ARM64.
+
+## Also fixed
+
+**The app would not open at all when built from recent source.** A payload-trimming change removed `WinUIEdit.dll`, which the XAML runtime loads while constructing the window. This never reached a published release, but it is fixed here.
+
+**Tray startup no longer gives up after half a second.** At logon the notification area can take several seconds to accept an icon. The retry budget is now a ten-second monotonic deadline rather than five quick attempts, and exhaustion exits visibly rather than leaving an invisible process.
+
+**Hover feedback on the dashboard** highlights the element a card describes — the bar, the model row, or the per-model row inside an expanded day — instead of leaving you to guess.
+
+## New: Lite installers
+
+Alongside the standard installer there are now `-lite` builds. They omit the bundled .NET runtime and fetch it during installation instead.
+
+| | Standard | Lite |
+|---|---|---|
+| Download | 79 MB (x64) / 76 MB (ARM64) | 47 MB (x64) / 45 MB (ARM64) |
+| .NET runtime | included | installed on first install |
+| Network needed to install | no | yes, if .NET 10 is absent |
+
+On a machine that does not already have .NET 10, Lite's smaller download plus the runtime it fetches comes to roughly what the standard installer costs, so **Lite is not a saving for most people** — it is worthwhile if you already have .NET 10 or expect to install other .NET applications.
+
+**Use the standard installer unless you have a specific reason not to.** Standard and Lite cannot update to one another; switching means uninstalling and reinstalling.
+
+## Updating from an earlier version
+
+The package identity changed in this release so that installed files and folders carry the product name. An unfortunate consequence is that **0.2.0 and 0.2.1 cannot update to 0.2.2.** They will check for updates, find nothing they consider valid, and report that you are up to date.
+
+To move to 0.2.2:
+
+1. Uninstall Syrtis from Settings → Apps
+2. Delete `%LocalAppData%\Nyanako.TokenBar` if it remains
+3. Install 0.2.2 from below
+
+Your settings live in `%AppData%\TokenBar\settings.json` and are not touched by this.
+
+Updates from 0.2.2 onward work normally.
+
+## Known issues
+
+**Slow first launch on some networks.** The first data refresh waits on a network connection that has no timeout of our own. If your network resolves IPv6 addresses but cannot route them — common on hotel and cafe WiFi, some home routers, and some VPNs — the dashboard can spin for 20 to 30 seconds before showing anything. It does eventually work. This is not new in 0.2.2; it is tracked in #39.
+
+**Unsigned.** Windows SmartScreen will warn on first run. Choose *More info* → *Run anyway*. Code signing is planned but not in this release.
+
+**ARM64 is less exercised than x64.** The ARM64 build has been installed and verified on a clean ARM64 Windows 11, but it has far less real-world use behind it.
+
+## Which file do I want
+
+| Machine | File |
+|---|---|
+| Intel or AMD, standard | `Nyanako.Syrtis-win-x64-Setup.exe` |
+| Snapdragon or other ARM, standard | `Nyanako.Syrtis-win-arm64-Setup.exe` |
+| Same, but you already have .NET 10 | the matching `-lite-Setup.exe` |
+
+If unsure, take the x64 standard installer.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,12 +141,20 @@ jobs:
       # download, so a corrupted upload fails closed on the client. This file
       # is for a human checking a Setup.exe before running it, which the feed
       # does not cover.
+      #
+      # The commit recorded here is the checked-out HEAD, not github.sha. Under
+      # workflow_dispatch, github.sha is the ref the run was dispatched from —
+      # usually the default branch — while both jobs check out inputs.tag. The
+      # header would then name a commit the assets were not built from, in the
+      # one file whose only purpose is provenance.
       - name: Generate SHA256SUMS.txt
         run: |
+          built_sha="$(git rev-parse HEAD)"
+          echo "built from: $built_sha"
           cd staging
           {
             echo "# Syrtis ${{ inputs.tag || github.ref_name }}"
-            echo "# built from ${{ github.sha }} by ${{ github.workflow }} run ${{ github.run_id }}"
+            echo "# built from ${built_sha} by ${{ github.workflow }} run ${{ github.run_id }}"
             echo
             sha256sum * | sort -k2
           } > ../SHA256SUMS.txt
@@ -154,6 +162,13 @@ jobs:
 
       # Draft, always. The tag authorises building the assets; a person still
       # decides whether they reach anyone.
+      #
+      # --verify-tag because gh creates a missing tag from the default branch
+      # rather than failing. A workflow_dispatch input naming something that is
+      # not a tag — a same-named branch, a typo — checks out fine and can pass
+      # the version guard, and gh would then mint a tag at the default branch
+      # head while the attached binaries came from somewhere else. This
+      # workflow only ever builds tags that already exist.
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -167,6 +182,7 @@ jobs:
           fi
           gh release create "$TAG" \
             --draft \
+            --verify-tag \
             --title "Syrtis ${TAG#v}" \
             "${NOTES_ARG[@]}" \
             staging/* SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,14 @@ jobs:
       tag: ${{ steps.pin.outputs.tag }}
       sha: ${{ steps.pin.outputs.sha }}
     steps:
+      # refs/tags/ explicitly. actions/checkout resolves a bare name as a
+      # branch first, so a dispatch input naming something that exists as both
+      # would build the branch commit while --verify-tag passed on the
+      # same-named tag, and the release would point somewhere the binaries
+      # never came from. The push trigger already supplies a full ref.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
       - id: pin
         run: |
           tag="${{ inputs.tag || github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,173 @@
+name: Release
+
+# The release-authority contract that CI deliberately does not carry. ci.yml
+# builds these same packages on every push and uploads sanitized evidence only,
+# never Setup.exe or nupkg, so release binaries have until now existed only on
+# whichever machine a human built them on. That made every release depend on
+# moving ~480 MB off a laptop, and gave users a binary whose provenance was
+# "someone says their checkout was clean".
+#
+# Pushing a v* tag is the authority signal. The result is a DRAFT release: the
+# assets are built and attached, and a human still decides whether it goes out.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build (e.g. v0.2.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x64
+            mode: Full
+            rust_target: x86_64-pc-windows-msvc
+          - rid: win-x64
+            mode: Lite
+            rust_target: x86_64-pc-windows-msvc
+          - rid: win-arm64
+            mode: Full
+            rust_target: aarch64-pc-windows-msvc
+          - rid: win-arm64
+            mode: Lite
+            rust_target: aarch64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.96.1
+          targets: ${{ matrix.rust_target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.rid }}-${{ matrix.mode }}
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.301
+
+      # A tag can be pushed at any commit. Without this, tagging v0.3.0 on a
+      # tree that still says 0.2.2 would publish 0.2.2 assets under a 0.3.0
+      # release and the mismatch would only surface when an installed client
+      # refused the update.
+      - name: Tag must match the version contract
+        shell: pwsh
+        run: |
+          $tag = "${{ inputs.tag || github.ref_name }}"
+          $expected = $tag -replace '^v', ''
+          [xml]$props = Get-Content -LiteralPath ./Directory.Build.props
+          $semantic = ($props.Project.PropertyGroup.TbSemanticVersion | Where-Object { $_ }) -join ''
+          "tag=$tag  contract=$semantic"
+          if ($semantic -cne $expected) {
+            throw "Tag $tag does not match TbSemanticVersion $semantic. Bump the version contract, or tag the commit that carries it."
+          }
+
+      - name: Package ${{ matrix.mode }} / ${{ matrix.rid }}
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP "rel-${{ matrix.mode }}-${{ matrix.rid }}"
+          ./scripts/package-velopack.ps1 -Rid ${{ matrix.rid }} -OutputRoot $root -DeploymentMode ${{ matrix.mode }}
+          "RELEASE_DIR=$root/releases" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      # package-velopack already asserts pack id, version, mainExe, machine
+      # architecture and channel. This only checks the set of files is the
+      # shape the publish job expects, so a missing feed is caught here rather
+      # than as a release with an asset silently absent.
+      - name: Release directory must hold exactly one channel's four files
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -LiteralPath $env:RELEASE_DIR -File | Sort-Object Name)
+          $files | ForEach-Object { "  {0}  {1:N0} bytes" -f $_.Name, $_.Length }
+          $nupkg  = @($files | Where-Object { $_.Extension -eq '.nupkg' }).Count
+          $setup  = @($files | Where-Object { $_.Name -like '*Setup.exe' }).Count
+          $feed   = @($files | Where-Object { $_.Name -like 'releases.*.json' }).Count
+          $legacy = @($files | Where-Object { $_.Name -like 'RELEASES-*' }).Count
+          if ($nupkg -ne 1 -or $setup -ne 1 -or $feed -ne 1 -or $legacy -ne 1) {
+            throw "Unexpected release set: nupkg=$nupkg setup=$setup feed=$feed legacy=$legacy"
+          }
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.rid }}-${{ matrix.mode }}
+          path: ${{ env.RELEASE_DIR }}
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: staging
+          merge-multiple: true
+
+      # Four channels, four files each. Anything else means a matrix leg was
+      # skipped or two legs collided on a filename, and publishing a partial
+      # set is worse than failing: the feed for a missing channel would 404 for
+      # every client already on it.
+      - name: Exactly sixteen assets, one set per channel
+        run: |
+          cd staging
+          ls -l
+          count=$(ls -1 | wc -l)
+          if [ "$count" -ne 16 ]; then
+            echo "expected 16 assets, found $count" >&2
+            exit 1
+          fi
+          for ch in win-x64 win-x64-lite win-arm64 win-arm64-lite; do
+            test -f "releases.$ch.json" || { echo "missing feed for $ch" >&2; exit 1; }
+            test -f "RELEASES-$ch"      || { echo "missing RELEASES for $ch" >&2; exit 1; }
+          done
+
+      # The feed a client reads carries the SHA256 of the package it will
+      # download, so a corrupted upload fails closed on the client. This file
+      # is for a human checking a Setup.exe before running it, which the feed
+      # does not cover.
+      - name: Generate SHA256SUMS.txt
+        run: |
+          cd staging
+          {
+            echo "# Syrtis ${{ inputs.tag || github.ref_name }}"
+            echo "# built from ${{ github.sha }} by ${{ github.workflow }} run ${{ github.run_id }}"
+            echo
+            sha256sum * | sort -k2
+          } > ../SHA256SUMS.txt
+          cat ../SHA256SUMS.txt
+
+      # Draft, always. The tag authorises building the assets; a person still
+      # decides whether they reach anyone.
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          NOTES=".github/release-notes/${TAG}.md"
+          if [ -f "$NOTES" ]; then
+            NOTES_ARG=(--notes-file "$NOTES")
+          else
+            NOTES_ARG=(--notes "Draft. Release notes were not committed at .github/release-notes/${TAG}.md; fill these in before publishing.")
+          fi
+          gh release create "$TAG" \
+            --draft \
+            --title "Syrtis ${TAG#v}" \
+            "${NOTES_ARG[@]}" \
+            staging/* SHA256SUMS.txt
+          gh release view "$TAG" --json isDraft,assets --jq '{draft:.isDraft, assets:[.assets[].name]}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,17 @@ jobs:
       # the version guard, and gh would then mint a tag at the default branch
       # head while the attached binaries came from somewhere else. This
       # workflow only ever builds tags that already exist.
-      - name: Create draft release
+      # Creating the release and uploading its assets are separate API calls,
+      # so ~480 MB of uploads can fail partway and leave a draft holding some
+      # of them. A rerun would then hit "release already exists" and the only
+      # recovery would be deleting the draft by hand. Transient upload failure
+      # is ordinary, not adversarial, so the rerun path is the one that has to
+      # work: an existing draft is topped up with --clobber instead.
+      #
+      # A published release is never touched. Retry is meaningful for a draft
+      # nobody has seen; replacing assets under something already distributed
+      # is a different act and this workflow does not get to perform it.
+      - name: Create or update draft release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -236,10 +246,28 @@ jobs:
           else
             NOTES_ARG=(--notes "Draft. Release notes were not committed at .github/release-notes/${TAG}.md; fill these in before publishing.")
           fi
-          gh release create "$TAG" \
-            --draft \
-            --verify-tag \
-            --title "Syrtis ${TAG#v}" \
-            "${NOTES_ARG[@]}" \
-            staging/* SHA256SUMS.txt
-          gh release view "$TAG" --json isDraft,assets --jq '{draft:.isDraft, assets:[.assets[].name]}'
+
+          if existing_draft="$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null)"; then
+            if [ "$existing_draft" != "true" ]; then
+              echo "release $TAG already exists and is published; refusing to modify it" >&2
+              exit 1
+            fi
+            echo "draft $TAG exists — replacing its assets"
+            gh release upload "$TAG" staging/* SHA256SUMS.txt --clobber
+            gh release edit "$TAG" --draft --title "Syrtis ${TAG#v}" "${NOTES_ARG[@]}"
+          else
+            # --verify-tag: gh otherwise creates a missing tag from the default
+            # branch. A dispatch input naming something that is not a tag — a
+            # same-named branch, a typo — checks out fine and can pass the
+            # version guard, and gh would then mint a tag at the default branch
+            # head while the binaries came from elsewhere.
+            gh release create "$TAG" \
+              --draft \
+              --verify-tag \
+              --title "Syrtis ${TAG#v}" \
+              "${NOTES_ARG[@]}" \
+              staging/* SHA256SUMS.txt
+          fi
+
+          gh release view "$TAG" --json isDraft,assets \
+            --jq '{draft:.isDraft, assetCount:(.assets|length), assets:[.assets[].name]}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,25 @@ on:
         required: true
         type: string
 
+# Two runs for the same tag would both reach the --clobber retry path and
+# overwrite each other's assets one file at a time. Two packaging executions do
+# not produce identical bytes, so the release could end up holding one run's
+# SHA256SUMS.txt against another run's binaries — checksum verification and
+# Velopack updates would then both fail on something already published.
+#
+# Not cancel-in-progress: interrupting a run midway through uploading ~480 MB
+# leaves exactly the partial draft this serialisation exists to avoid. Queue
+# instead.
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+# Read by default. Only publish creates a release, and the package jobs run
+# third-party actions behind mutable refs — dtolnay/rust-toolchain@stable,
+# Swatinem/rust-cache@v2 — with whatever token the job carries. A tag takeover
+# on either would otherwise hold repository write for the length of a build.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Resolve the tag to a commit exactly once. Every later checkout takes that
@@ -159,6 +176,11 @@ jobs:
   publish:
     needs: [resolve, package]
     runs-on: ubuntu-latest
+    # The only job that writes anything. Scoped here rather than at workflow
+    # level so the four package jobs, which run third-party actions, never hold
+    # a write token.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,30 @@ permissions:
   contents: write
 
 jobs:
+  # Resolve the tag to a commit exactly once. Every later checkout takes that
+  # SHA rather than the tag name, so the four package legs and the publish job
+  # cannot disagree about what they built: a tag force-moved mid-run would
+  # otherwise be resolved independently by each leg, and the release would
+  # combine artifacts from different commits with nothing to reveal it.
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.pin.outputs.tag }}
+      sha: ${{ steps.pin.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - id: pin
+        run: |
+          tag="${{ inputs.tag || github.ref_name }}"
+          sha="$(git rev-parse HEAD)"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "pinned $tag -> $sha"
+
   package:
+    needs: resolve
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -45,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ needs.resolve.outputs.sha }}
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -65,7 +88,7 @@ jobs:
       - name: Tag must match the version contract
         shell: pwsh
         run: |
-          $tag = "${{ inputs.tag || github.ref_name }}"
+          $tag = "${{ needs.resolve.outputs.tag }}"
           $expected = $tag -replace '^v', ''
           [xml]$props = Get-Content -LiteralPath ./Directory.Build.props
           $semantic = ($props.Project.PropertyGroup.TbSemanticVersion | Where-Object { $_ }) -join ''
@@ -105,13 +128,41 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      # package-velopack produces a version- and RID-bound symbols archive next
+      # to the app artifact, deliberately kept out of Setup.exe and the nupkg.
+      # It is the only way to symbolicate a crash dump from a shipped build, so
+      # letting it die with the runner would make that whole mechanism do
+      # nothing for exactly the binaries it exists for.
+      #
+      # A workflow artifact rather than a release asset: it carries PDBs, which
+      # belong with whoever is diagnosing a crash, not on a public download
+      # page. Retention outlives the release-set artifacts above because those
+      # are consumed minutes later by publish, while these are wanted the first
+      # time someone reports a crash.
+      - name: Locate symbols archive
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP "rel-${{ matrix.mode }}-${{ matrix.rid }}"
+          $zip = Get-ChildItem -LiteralPath (Join-Path $root 'app-artifact') -Recurse -Filter 'Syrtis-Symbols-*.zip' -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if ($null -eq $zip) { throw "symbols archive missing under $root/app-artifact" }
+          "  {0}  {1:N0} bytes" -f $zip.Name, $zip.Length
+          "SYMBOLS_ZIP=$($zip.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: symbols-${{ matrix.rid }}-${{ matrix.mode }}
+          path: ${{ env.SYMBOLS_ZIP }}
+          if-no-files-found: error
+          retention-days: 90
+
   publish:
-    needs: package
+    needs: [resolve, package]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ needs.resolve.outputs.sha }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -150,10 +201,15 @@ jobs:
       - name: Generate SHA256SUMS.txt
         run: |
           built_sha="$(git rev-parse HEAD)"
+          pinned="${{ needs.resolve.outputs.sha }}"
+          if [ "$built_sha" != "$pinned" ]; then
+            echo "checkout HEAD $built_sha does not match pinned $pinned" >&2
+            exit 1
+          fi
           echo "built from: $built_sha"
           cd staging
           {
-            echo "# Syrtis ${{ inputs.tag || github.ref_name }}"
+            echo "# Syrtis ${{ needs.resolve.outputs.tag }}"
             echo "# built from ${built_sha} by ${{ github.workflow }} run ${{ github.run_id }}"
             echo
             sha256sum * | sort -k2
@@ -173,7 +229,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG="${{ needs.resolve.outputs.tag }}"
           NOTES=".github/release-notes/${TAG}.md"
           if [ -f "$NOTES" ]; then
             NOTES_ARG=(--notes-file "$NOTES")


### PR DESCRIPTION
Releases have had no automation. `ci.yml` builds these same four packages on every push but uploads **sanitized evidence only** — both upload steps carry the comment *"never Setup.exe / nupkg / symbols ZIP binaries"* — so release binaries have only ever existed on whichever machine a human built them on.

Cutting v0.2.2 by hand meant moving ~480 MB off a laptop over a tunnel, and it gives users a binary whose provenance is an assertion that someone's checkout was clean.

## What this adds

Pushing a `v*` tag builds all four channels on hosted runners and attaches 16 assets plus `SHA256SUMS.txt` to a **draft** release.

The tag is authority to *build*. A person still decides whether it goes out — which keeps the boundary #23 and #30 drew, while removing the laptop from the path.

The package job reuses `deployment-matrix`'s steps verbatim: same Rust 1.96.1 and .NET 10.0.301 pins, recursive submodules, same `package-velopack.ps1` entry point. A release is built the way CI already verifies, not by a second recipe that can drift.

## Guards

Each exists for a failure that would otherwise surface only after publishing.

| Guard | Failure it prevents |
|---|---|
| Tag must match `TbSemanticVersion` | Tagging `v0.3.0` on a tree that says 0.2.2 publishes 0.2.2 assets under a 0.3.0 release; first symptom is an installed client refusing the update |
| Each leg asserts 1 nupkg + 1 Setup + 1 feed + 1 RELEASES | A missing feed fails in the leg that produced it, not as a release with an asset silently absent |
| Publish requires exactly 16 assets, all four channels | A partial set is worse than a failed release — the feed for a missing channel 404s for every client already on it |

`SHA256SUMS.txt` covers what the feed does not: clients already verify downloads against the SHA256 in `releases.<channel>.json`, so the checksum file is for a person deciding whether to run a `Setup.exe`.

## Release notes in the repo

`.github/release-notes/<tag>.md`, applied automatically when present. Notes get reviewed in a PR instead of pasted into the GitHub UI at publish time.

v0.2.2's notes are included in this PR. They lead with the uninstall-and-reinstall requirement, because the pack id changed in `864aa03` and an installed 0.2.0 or 0.2.1 reports *no update available* rather than failing — the failure is silent, so the notes are the only place a user can learn it.

## Not verified

**This has never run.** The first tag push is its first execution. It produces a draft, so a failure there costs a re-run rather than a published mistake — but I am not claiming it works.