### PR TITLE
docs: add taskbar widget proposal and pin postmortem

### DIFF
--- a/docs/postmortem-engine-pin-stall.md
+++ b/docs/postmortem-engine-pin-stall.md
@@ -1,0 +1,108 @@
+# 復盤：一個 pin bump 為什麼卡了那麼久
+
+## TL;DR
+
+那個 session 要做的事，是把 `vendor/tokscale-core` 的 gitlink 從 `b31e394` 推到 `84e0d66`，順便更新 `vendor/ENGINE.md` 的兩行。實際變更是兩個檔案。
+
+它卡住的地方，是它自己蓋出來的驗證系統。
+
+| | 實際需要 | 那個 session 蓋的 |
+|---|---|---|
+| 變更 | 2 個檔案 | 同左 |
+| 驗證 | CI 既有的 x64、ARM64、packaged-FFI、cross-check 四道 job | 自建 evidence 系統、receipt codec、privacy canary、Phase-A、fingerprint-matched verifier worktree、雙 SID 的 ACL gate |
+| 語意檢查 | 一次舊新 pin 對同份資料的 token 守恆比對 | 尚未執行 |
+| 卡住的原因 | 無 | 自建鷹架的兩個 bug |
+
+`SelfTest.cs`、`Evidence.cs`、`ReceiptCodec`、`privacy-canaries.json`，這四個檔案我在 repo 全樹搜過，一個都不存在。它們是 repo 外的自建產物。
+
+---
+
+## 先講它做對的事
+
+復盤不是批鬥，它交付了實際成果。
+
+Phase 11 的 S2 與 S3 都完成並 merge 了。PR #18 的 Velopack 打包命令、PR #19 的使用者確認式更新流程，都通過 CI 與 codex 審查進了 `main`。現在 `origin/main` 停在 `de16e59`，那是它推上去的。
+
+它對自己 blocker 的根因分析也很準確。它指出 `SelfTest.cs:204` 把 `"sequence":1` 竄改成 `"sequence":01`，指出 `Evidence.cs:579` 的 `ReceiptCodec.DecodeStrict` 讓 `JsonReaderException` 原樣逸出，還附上 `privacy-canaries.json` 的 SHA-256 證明那個檔案本身是好的。它清理了現場，回報 process、firewall rule、recovery task、private root、safe root 全部歸零。它在沒有授權時停下來，沒有偷跑。
+
+這份精確正是可惜的地方。嚴謹被用在錯誤的對象上。
+
+---
+
+## 兩個 blocker 的實際內容
+
+**第一個：`WindowsPrincipal.IsInRole` 的 token 存取。**
+
+它要做「安裝後的 ACL gate」，查目前身分是否屬於某個群組時撞上權杖存取問題。這一輪用掉了你額外給的授權。source fix 套用、build 通過、runtime 安裝通過。
+
+**第二個：`JsonReaderException`。**
+
+修完上面那個之後，installed self-test 冒出新的例外。根因是它自己寫的負面測試：故意把 `"sequence":1` 改成 `"sequence":01`（前導零在 JSON 規格裡非法），用來確認解碼器會拒絕。解碼器確實拒絕了，但丟出的是底層 JSON 函式庫的 `JsonReaderException`，而測試斷言的是它自己定義的 `CanonicalEncodingException`。
+
+於是它要跟你要授權，去修「自己寫的測試對自己造的假資料丟錯例外型別」。
+
+兩個 blocker 都在自建鷹架裡。兩個都不影響任何會交付給使用者的程式碼。
+
+---
+
+## 根因
+
+### 一、驗證規模沒有跟變更的風險綁定
+
+這批引擎變更的實際風險面很窄。四個 commit 全是 Grok 歸因修正，只動四個引擎檔案，`Cargo.toml` 與 `Cargo.lock` byte-identical，沒有任何 C ABI 或 public API 變更，C# 側不需要 port。
+
+在這種形狀下，真正該問的問題只有一個：新的 parser 讀同一份資料，token 總量還守恆嗎。歸因修正應該只搬動模型分佈，總量必須完全相同。
+
+那是一次比對。它蓋的那套東西，規模上比較適合用來簽章發佈或處理憑證。
+
+### 二、它自建證據系統，而沒有用既有的
+
+這個 repo 已經有跑了幾十次的 gate。CI 上有 x64 build、arm64-cross、packaged-FFI、Swift/C# cross-check。`build-app-artifact.ps1` 裡有 clean-checkout 守門與 `evidence.json`，那道守門前幾天還擋過我一次，擋得對。
+
+既有 gate 的價值在於它們被跑過很多次，該爆的 bug 早就爆完了。自建鷹架沒有這段歷史，所以每一個 bug 都是第一次遇到，每一個都要現場除錯。
+
+### 三、自己給自己的工作沒有終止條件
+
+這是最關鍵的一點。
+
+驗證鷹架需要自己的驗證。privacy canary 檢查需要 canary 檔案。receipt codec 需要嚴格解碼器。嚴格解碼器需要負面測試。負面測試需要非法輸入。非法輸入丟出的例外型別對不上。
+
+每一層在局部看都合理，整個堆疊卻沒有停止條件。差別在於，產品需求會結束，自己造的需求不會。
+
+### 四、授權門被指向了錯誤的對象
+
+你的決策是稀缺資源。那些授權輪次被花在「我可以修我的測試輔助程式嗎」，而沒有花在「這個變更可以推上去嗎」。
+
+一個健康的授權門應該擋在有外部後果的動作前面：push、merge、release、動 registry、碰真實資料。擋在「修自己的鷹架」前面的門，消耗你的注意力卻不保護任何東西。
+
+---
+
+## 對照：同一件事的另一種做法
+
+我接手後做的事，供對照。
+
+變更兩個檔案：gitlink 推到 `84e0d66`，`ENGINE.md` 的 reviewed pin 與 UPSTREAM.md URL 各改一處，全樹零殘留舊 pin。
+
+驗證用既有的。`cargo build --release --locked` 通過，且 `Cargo.lock` 不在 modified 清單裡。這一條同時實證了「consumer root lock 應維持不變」那個預測。`--locked` 在 lock 需要重生成時會直接失敗，所以它通過就是證據，不必額外宣稱。剩下四道 gate 交給 CI。
+
+守恆比對的資料來源查清楚了，結論跟原本的假設不同。Windows 那台 `~/.grok/logs/unified.jsonl` 只有 37 行純診斷日誌，含 usage 的列數是零，Grok CLI 裝好之後沒被真的用過。這台 Mac 則有 15160 行，其中 1142 列 `shell.turn.inference_done` 帶 `prompt_tokens` 與 `cached_prompt_tokens`。所以守恆比對要在 Mac 上做。引擎是跨平台 Rust，用同一份快照跑舊新 pin 比對總量，證據力一樣成立。
+
+---
+
+## 誠實的邊界
+
+這份復盤有幾個地方我沒有把握，先講清楚。
+
+**pin 這件事我還沒做完。** 本地測試還在跑，PR 沒開，守恆比對沒執行，Native 那五處文件也沒改。上面寫的只是進度。
+
+**我是透過 bounded reader 讀那個 session 的。** reader 回報了 `W_TRUNCATED` 與 `W_METADATA_REDACTED`。我看到的是它的續接摘要與最後幾輪，沒有看到每一個 turn。它為什麼在每一個路口選了那條路，是我從它寫下的東西推斷的，它本人沒有這樣說過。
+
+**我沒有審它的鷹架程式碼。** 我只確認了那些檔案不在 repo 裡。那套 evidence 系統設計得好不好，我沒有評估，也不打算評估，因為那個問題已經不重要了。
+
+**它面對的限制可能比我多。** 它的 session 有明確的「no commit、no push、no PR、no merge」約束，而我接手時你給的自由度不同。在完全不能推任何東西的狀態下，把力氣放在「先把證據做完整」是有邏輯的。只是證據的規模仍然應該跟變更的風險綁定。
+
+---
+
+## 一句話
+
+驗證的規模要跟變更的風險綁定，不要跟流程的儀式感綁定。一個 gitlink bump 值得一次守恆比對加四道既有 CI gate，不值得一套需要自己除錯的證據系統。

--- a/docs/proposals/taskbar-widget.md
+++ b/docs/proposals/taskbar-widget.md
@@ -91,36 +91,44 @@ of the tray, sharing its `TrayFeed` and lifetime).
 - Content: the selected `TrayMode`'s full `Title()` string (the icon truncates
   via `IconTitle`; the widget doesn't need to), quota gauge color accent when
   in `QuotaLeft` mode. One `TextBlock` + optional colored dot — no lens
-  content on the taskbar. When the mode is `TrayMode.Hidden` / “Icon only”,
-  the widget is not created or remains hidden; it never shows a blank pill.
-  The existing toggle remains available, and switching back to a displayable
-  mode restores the widget.
+  content on the taskbar. When `TrayMode.Title()` is temporarily empty,
+  including before the first async refresh, the widget remains hidden; it never
+  shows a loading placeholder or blank pill. The first non-empty title shows it,
+  and a later empty title hides it again. `TrayMode.Hidden` / “Icon only” follows
+  the same rule. The existing toggle remains available, and switching back to a
+  displayable mode restores the widget.
 - Input: left-click → `FlyoutWindow.ToggleFlyout()` (pointer events arrive
   without activation). Hover tooltip (`HoverTip` reuse) and right-click menu
   are Phase 2.
 
 ### Placement
 
-Right-anchored next to the system tray — on Win11 centered *and* left-aligned
-layouts the region just left of `TrayNotifyWnd` is the only spot that app
-icons never grow into.
+Placement is supported only for a horizontal primary taskbar. Read the
+`Shell_TrayWnd` rect orientation first; on Windows 10, a left or right vertical
+taskbar hides the widget rather than applying the horizontal formula.
+
+For a horizontal taskbar, first compute a candidate rect next to the system
+tray, then obtain a verifiable task-list/overflow available boundary. If the
+candidate intersects the task-list host or its controls, hide the widget;
+show it again when space returns. If Gate 0 cannot reliably resolve that
+boundary on a Windows build, fail closed and hide the widget; that is a No-Go,
+not permission to cover clickable icons.
 
 ```
-widget.right  = TrayNotifyWnd.rect.left − gap      (physical px)
-widget.centerY = Shell_TrayWnd.rect.centerY
-widget.height ≈ taskbar height − 2·margin; width fits the text
+candidate.right  = TrayNotifyWnd.rect.left − gap   (physical px)
+candidate.centerY = Shell_TrayWnd.rect.centerY
+candidate.height ≈ taskbar height − 2·margin; width fits the text
 ```
 
 All inputs are physical-pixel rects from `GetWindowRect`, so placement needs
 no DIP conversion; text scale comes from `GetDpiForWindow` as usual
-(PerMonitorV2 manifest already in place). Primary taskbar only in v1
-(`Shell_SecondaryTrayWnd` is Phase 2).
+(PerMonitorV2 manifest already in place). `Shell_SecondaryTrayWnd` is Phase 2.
 
 ### Tracking & resilience
 
 | Event | Mechanism | Response |
 |---|---|---|
-| Taskbar/tray rect moves (resolution, DPI, auto-hide slide, tray icons added) | `SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE)` filtered to the two HWNDs | reposition |
+| Taskbar/tray/task-list rect moves (resolution, DPI, auto-hide slide, tray icons, overflow/task-list controls) | `SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE)` filtered to the taskbar, tray, task-list host, and overflow-relevant HWNDs | re-evaluate orientation, candidate rect, and available boundary; reposition or hide |
 | Explorer restart | `RegisterWindowMessage("TaskbarCreated")` broadcast, received by subclassing the widget HWND (`SetWindowSubclass`) | re-resolve HWNDs, reposition, re-assert topmost |
 | Fullscreen app on the same monitor | `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` switches the current foreground HWND; `SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE)` re-evaluates the taskbar, tray, and current foreground HWND rects | hide/show immediately when the same HWND enters or leaves browser/video fullscreen |
 | Auto-hide taskbar | falls out of the LocationChange handling: taskbar rect mostly off-screen → hide widget | follow taskbar visibility |
@@ -164,18 +172,18 @@ menu, secondary taskbars, gauge rendering, entrance animation.
 | Axis | Cases |
 |---|---|
 | DPI | 100% / 125% / 150%, live DPI change |
-| Taskbar | centered / left-aligned icons; auto-hide on/off; tray icon count change (rect shift) |
+| Taskbar | centered / left-aligned icons; auto-hide on/off; tray icon count change (rect shift); Windows 10 left/right vertical taskbar → hide and do not cover controls |
 | Resilience | `taskkill /f /im explorer.exe` + restart → widget re-appears correctly ≤ 2 s |
 | Fullscreen | video fullscreen + a game/borderless window → widget hides, returns on exit |
 | Theme | light / dark switch live |
-| Crowding | many open windows → no overlap with app icons (right-anchor holds) |
+| Crowding | many open windows and overflow pressure → hide before the candidate reaches task-list/overflow controls; show again when space returns |
 | Arch | x64 physical + ARM64 VM (RDP resolution changes included) |
 
 ## 6. Risks
 
 | Risk | Mitigation |
 |---|---|
-| Windows update changes taskbar internals | We depend only on two window-class *rects* — the most stable surface available (survived every Win11 build to date). Failure mode: widget hides/misplaces; tray icon unaffected. Default-off + toggle = instant user-side rollback. |
+| Windows update changes taskbar internals | We depend on verifiable taskbar, tray, and task-list/overflow *rects*; if the available boundary cannot be resolved, the widget fails closed and hides. Failure mode: widget unavailable; tray icon unaffected. Default-off + toggle = instant user-side rollback. |
 | Topmost z-order battles (shell re-asserts taskbar above us) | Re-assert `HWND_TOPMOST` on every hook event; verified in Gate 0. |
 | Widget floats over fullscreen video (classic overlay bug) | Foreground-fullscreen detection is a Gate 0 pass/fail criterion, not a nice-to-have. |
 | WinUI window per-monitor quirks when the taskbar is on a secondary display | v1 is primary-taskbar-only; explicit non-goal until Phase 2. |
@@ -187,5 +195,6 @@ menu, secondary taskbars, gauge rendering, entrance animation.
 - `SetParent` embedding / living inside explorer's window tree.
 - Faking the taskbar's Mica material.
 - Replacing the tray icon — the widget is additive and opt-in.
+- Vertical primary taskbars — v1 supports horizontal primary taskbars only.
 - Graphs/charts on the taskbar (taskbar-monitor's whole point, not ours —
   our rich surface is the flyout, one click away).

--- a/docs/proposals/taskbar-widget.md
+++ b/docs/proposals/taskbar-widget.md
@@ -147,8 +147,12 @@ The app already ships a WH_MOUSE_LL precedent.
   toggle available but shows a short helper that the widget stays hidden until
   a displayable mode is selected; no separate widget mode is introduced.
 - `TrayService` creates/destroys the window on the setting change, same
-  pattern as the animator. Tray icon behavior is completely unchanged — it
-  remains the fallback and the only surface when the widget is off or hidden.
+  pattern as the animator. Destruction is idempotent: it calls
+  `UnhookWinEvent` for both hooks before releasing their callback delegates or
+  widget state, then removes the subclass and destroys the HWND. Re-enabling
+  creates one fresh hook pair, so repeated toggles cannot accumulate
+  registrations. Tray icon behavior is completely unchanged — it remains the
+  fallback and the only surface when the widget is off or hidden.
 - This is a **Windows-only divergence from macOS parity** (macOS has a real
   text menu-bar item and needs none of this), same bucket as the parked
   global hotkey — hence opt-in, and quota/agent-limit content follows

--- a/docs/proposals/taskbar-widget.md
+++ b/docs/proposals/taskbar-widget.md
@@ -1,0 +1,185 @@
+# Proposal: Taskbar Widget (usage readout on the taskbar itself)
+
+**Status:** draft, awaiting Go/No-Go spike
+**Date:** 2026-07-17
+**Owner:** Nanako
+
+## 1. Problem
+
+The notification-area icon is the app's only always-visible surface, and it is
+16×16 (24×24 at 150%): even with the value drawn into the icon
+(`TrayIconRenderer`), a figure like `50M` is at the edge of legibility and
+anything richer (cost + tokens + rate) is impossible. macOS gets a real text
+menu-bar item for free; Windows does not — parity table #1 works around it
+with the tooltip and the always-on flyout header, but none of those are
+*glanceable*.
+
+Idea: render the readout directly on the taskbar's empty area, the way
+[taskbar-monitor](https://github.com/leandrosa81/taskbar-monitor),
+[TrafficMonitor](https://github.com/zhongyang219/TrafficMonitor) and
+[ElevenClock](https://github.com/marticliment/ElevenClock) do.
+
+## 2. Research: how existing tools do it
+
+Source read in full (cloned at `~/side-project/taskbar-monitor`; **GPL-3.0 —
+technique reference only, no code may be copied**).
+
+taskbar-monitor is really two implementations:
+
+| | Windows 10 (`TaskbarMonitor/`) | Windows 11 (`TaskbarMonitorWindows11/`) |
+|---|---|---|
+| Mechanism | COM **DeskBand** (CSDeskBand) | WinForms tray app; control **`SetParent`-ed into `Shell_TrayWnd`** (`TaskbarManager.cs:268`) |
+| Position | shell-managed | manual: right-aligned, offset by the `TrayNotifyWnd` rect (`TaskbarManager.cs:100-104`) |
+| Tracking | shell-managed | `SetWinEventHook` LocationChange + Destroy (re-embed on explorer restart, `TaskbarManager.cs:385-409`) **plus a 4 s polling timer as a belt** (`TaskbarManager.cs:32`) |
+| Win11 ≥ 22621 extras | n/a | `WS_EX_LAYERED \| WS_EX_TRANSPARENT` + color-key hack to stay visible (`TaskbarManager.cs:271-274`) — the control becomes click-through |
+
+Takeaways:
+
+- **DeskBand is dead.** It was the last supported taskbar-extension API and
+  Windows 11 removed it. Not an option.
+- **`SetParent` embedding works but is the fragile path.** Even its own author
+  doesn't trust the event hooks and re-asserts on a 4-second timer; each
+  Win11 feature update (the XAML taskbar rewrite, 22621's input changes)
+  broke it and required new ex-style hacks that cost interactivity. The
+  project's issue tracker (51 open) is dominated by "invisible after
+  update" reports.
+- **ElevenClock proves the third path**: an independent frameless topmost
+  window *positioned over* the taskbar, never re-parented. It shipped to a
+  large user base across many Win11 builds. Failure mode is graceful — worst
+  case the pill is misplaced, never swallowed by an explorer repaint.
+- `Shell_TrayWnd` / `TrayNotifyWnd` window classes still exist on Win11
+  (the Win11 fork queries them, `TaskbarManager.cs:157-163`) and have been
+  the stable anchor across every build so far; we need them only for
+  *rects*, not as a parent.
+
+## 3. Options
+
+**A. `SetParent` into `Shell_TrayWnd`** (taskbar-monitor / TrafficMonitor)
+Auto-follows the taskbar, shell clips and z-orders for us. But a WinUI 3
+window (bridge windows, InputSite) almost certainly cannot survive a
+cross-process re-parent into explorer, so this path forces a second
+rendering stack (raw HWND + GDI/D2D) that shares nothing with the app; and
+it inherits the click-through layered hack plus the break-on-every-update
+maintenance profile above.
+
+**B. Independent topmost overlay window** (ElevenClock)
+Frameless `WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE` topmost WinUI 3 window whose
+rect is computed from `Shell_TrayWnd`/`TrayNotifyWnd`. Reuses everything the
+flyout already proved out: popup chrome + DWM rounded corners
+(`FlyoutWindow.ApplyPopupChrome`), PerMonitorV2 DPI, focusless-window input
+lessons, `IsSystemDark()` theming, `TrayFeed` data. We own position tracking,
+explorer-restart recovery, and fullscreen avoidance.
+
+**Decision: B.** Same conclusion for both axes that matter: it reuses the
+existing WinUI stack instead of adding a GDI one, and its dependency on
+explorer internals is read-only (two window rects) rather than structural
+(living inside explorer's window tree).
+
+## 4. Design
+
+New `TaskbarWidgetWindow` owned by `TrayService` (the widget is a second face
+of the tray, sharing its `TrayFeed` and lifetime).
+
+### Window
+
+- WinUI 3 `Window`, borderless via the flyout's `ApplyPopupChrome` recipe
+  (extracted to a shared helper), plus `WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE`,
+  `IsShownInSwitchers = false`, `HWND_TOPMOST`.
+- Small "pill": DWM `DWMWCP_ROUNDSMALL` corners, opaque background from the
+  taskbar theme (`IsSystemDark()`), **no attempt to fake Mica** — a deliberate
+  pill reads intentional; a near-miss texture clone reads broken.
+- Content: the selected `TrayMode`'s full `Title()` string (the icon truncates
+  via `IconTitle`; the widget doesn't need to), quota gauge color accent when
+  in `QuotaLeft` mode. One `TextBlock` + optional colored dot — no lens
+  content on the taskbar.
+- Input: left-click → `FlyoutWindow.ToggleFlyout()` (pointer events arrive
+  without activation). Hover tooltip (`HoverTip` reuse) and right-click menu
+  are Phase 2.
+
+### Placement
+
+Right-anchored next to the system tray — on Win11 centered *and* left-aligned
+layouts the region just left of `TrayNotifyWnd` is the only spot that app
+icons never grow into.
+
+```
+widget.right  = TrayNotifyWnd.rect.left − gap      (physical px)
+widget.centerY = Shell_TrayWnd.rect.centerY
+widget.height ≈ taskbar height − 2·margin; width fits the text
+```
+
+All inputs are physical-pixel rects from `GetWindowRect`, so placement needs
+no DIP conversion; text scale comes from `GetDpiForWindow` as usual
+(PerMonitorV2 manifest already in place). Primary taskbar only in v1
+(`Shell_SecondaryTrayWnd` is Phase 2).
+
+### Tracking & resilience
+
+| Event | Mechanism | Response |
+|---|---|---|
+| Taskbar/tray rect moves (resolution, DPI, auto-hide slide, tray icons added) | `SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE)` filtered to the two HWNDs | reposition |
+| Explorer restart | `RegisterWindowMessage("TaskbarCreated")` broadcast, received by subclassing the widget HWND (`SetWindowSubclass`) | re-resolve HWNDs, reposition, re-assert topmost |
+| Fullscreen app on the same monitor | `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` + foreground-rect ≈ monitor-rect check (the ElevenClock rule) | hide; show again when foreground shrinks |
+| Auto-hide taskbar | falls out of the LocationChange handling: taskbar rect mostly off-screen → hide widget | follow taskbar visibility |
+| Anything the hooks miss | piggyback `TrayFeed`'s existing 30 s fast tick with a cheap rect re-check — **no new polling timer** | self-heal |
+
+No `SetParent`, no layered color-key, no injected hooks beyond the two
+out-of-context WinEvent hooks (same machinery taskbar-monitor uses, and the
+app already ships a WH_MOUSE_LL precedent).
+
+### Settings & lifecycle
+
+- `tokenbar.taskbar.widget` (bool, **default off**). One toggle in Settings;
+  the widget reuses the existing "Menu bar shows" mode selection rather than
+  growing its own.
+- `TrayService` creates/destroys the window on the setting change, same
+  pattern as the animator. Tray icon behavior is completely unchanged — it
+  remains the fallback and the only surface when the widget is off or hidden.
+- This is a **Windows-only divergence from macOS parity** (macOS has a real
+  text menu-bar item and needs none of this), same bucket as the parked
+  global hotkey — hence opt-in, and quota/agent-limit content follows
+  whatever the paused macOS contract lands on, not this proposal.
+
+## 5. Phasing
+
+**Gate 0 — spike (Go/No-Go, ~1 day).** Bare window, hardcoded text, full
+placement + tracking logic. Run the verification matrix below on the real
+x64 box and the ARM64 VM. This is where the approach earns the right to
+product code — mirrors the `spike/RESULTS.md` precedent from the 3D work.
+
+**Phase 1 — product widget.** Setting, `TrayFeed` wiring, mode-driven text,
+theme, click-to-flyout. Ships behind the default-off toggle.
+
+**Phase 2 — polish (optional, demand-driven).** Hover tooltip, right-click
+menu, secondary taskbars, gauge rendering, entrance animation.
+
+### Gate 0 verification matrix
+
+| Axis | Cases |
+|---|---|
+| DPI | 100% / 125% / 150%, live DPI change |
+| Taskbar | centered / left-aligned icons; auto-hide on/off; tray icon count change (rect shift) |
+| Resilience | `taskkill /f /im explorer.exe` + restart → widget re-appears correctly ≤ 2 s |
+| Fullscreen | video fullscreen + a game/borderless window → widget hides, returns on exit |
+| Theme | light / dark switch live |
+| Crowding | many open windows → no overlap with app icons (right-anchor holds) |
+| Arch | x64 physical + ARM64 VM (RDP resolution changes included) |
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Windows update changes taskbar internals | We depend only on two window-class *rects* — the most stable surface available (survived every Win11 build to date). Failure mode: widget hides/misplaces; tray icon unaffected. Default-off + toggle = instant user-side rollback. |
+| Topmost z-order battles (shell re-asserts taskbar above us) | Re-assert `HWND_TOPMOST` on every hook event; verified in Gate 0. |
+| Widget floats over fullscreen video (classic overlay bug) | Foreground-fullscreen detection is a Gate 0 pass/fail criterion, not a nice-to-have. |
+| WinUI window per-monitor quirks when the taskbar is on a secondary display | v1 is primary-taskbar-only; explicit non-goal until Phase 2. |
+| GPL contamination from the reference repo | No code copied — API technique only (window classes, WinEvent usage are public Win32 surface). |
+
+## 7. Non-goals
+
+- DeskBand (removed from Windows 11).
+- `SetParent` embedding / living inside explorer's window tree.
+- Faking the taskbar's Mica material.
+- Replacing the tray icon — the widget is additive and opt-in.
+- Graphs/charts on the taskbar (taskbar-monitor's whole point, not ours —
+  our rich surface is the flyout, one click away).

--- a/docs/proposals/taskbar-widget.md
+++ b/docs/proposals/taskbar-widget.md
@@ -91,7 +91,10 @@ of the tray, sharing its `TrayFeed` and lifetime).
 - Content: the selected `TrayMode`'s full `Title()` string (the icon truncates
   via `IconTitle`; the widget doesn't need to), quota gauge color accent when
   in `QuotaLeft` mode. One `TextBlock` + optional colored dot — no lens
-  content on the taskbar.
+  content on the taskbar. When the mode is `TrayMode.Hidden` / “Icon only”,
+  the widget is not created or remains hidden; it never shows a blank pill.
+  The existing toggle remains available, and switching back to a displayable
+  mode restores the widget.
 - Input: left-click → `FlyoutWindow.ToggleFlyout()` (pointer events arrive
   without activation). Hover tooltip (`HoverTip` reuse) and right-click menu
   are Phase 2.
@@ -119,19 +122,22 @@ no DIP conversion; text scale comes from `GetDpiForWindow` as usual
 |---|---|---|
 | Taskbar/tray rect moves (resolution, DPI, auto-hide slide, tray icons added) | `SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE)` filtered to the two HWNDs | reposition |
 | Explorer restart | `RegisterWindowMessage("TaskbarCreated")` broadcast, received by subclassing the widget HWND (`SetWindowSubclass`) | re-resolve HWNDs, reposition, re-assert topmost |
-| Fullscreen app on the same monitor | `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` + foreground-rect ≈ monitor-rect check (the ElevenClock rule) | hide; show again when foreground shrinks |
+| Fullscreen app on the same monitor | `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` switches the current foreground HWND; `SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE)` re-evaluates the taskbar, tray, and current foreground HWND rects | hide/show immediately when the same HWND enters or leaves browser/video fullscreen |
 | Auto-hide taskbar | falls out of the LocationChange handling: taskbar rect mostly off-screen → hide widget | follow taskbar visibility |
 | Anything the hooks miss | piggyback `TrayFeed`'s existing 30 s fast tick with a cheap rect re-check — **no new polling timer** | self-heal |
 
 No `SetParent`, no layered color-key, no injected hooks beyond the two
-out-of-context WinEvent hooks (same machinery taskbar-monitor uses, and the
-app already ships a WH_MOUSE_LL precedent).
+out-of-context WinEvent hooks: foreground changes select the current HWND,
+and location changes re-evaluate the taskbar, tray, and that foreground HWND.
+The app already ships a WH_MOUSE_LL precedent.
 
 ### Settings & lifecycle
 
 - `tokenbar.taskbar.widget` (bool, **default off**). One toggle in Settings;
   the widget reuses the existing "Menu bar shows" mode selection rather than
-  growing its own.
+  growing its own. In `TrayMode.Hidden` / “Icon only”, Settings keeps the
+  toggle available but shows a short helper that the widget stays hidden until
+  a displayable mode is selected; no separate widget mode is introduced.
 - `TrayService` creates/destroys the window on the setting change, same
   pattern as the animator. Tray icon behavior is completely unchanged — it
   remains the fallback and the only surface when the widget is off or hidden.

--- a/docs/proposals/taskbar-widget.md
+++ b/docs/proposals/taskbar-widget.md
@@ -131,6 +131,7 @@ no DIP conversion; text scale comes from `GetDpiForWindow` as usual
 | Taskbar/tray/task-list rect moves (resolution, DPI, auto-hide slide, tray icons, overflow/task-list controls) | `SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE)` filtered to the taskbar, tray, task-list host, and overflow-relevant HWNDs | re-evaluate orientation, candidate rect, and available boundary; reposition or hide |
 | Explorer restart | `RegisterWindowMessage("TaskbarCreated")` broadcast, received by subclassing the widget HWND (`SetWindowSubclass`) | re-resolve HWNDs, reposition, re-assert topmost |
 | Fullscreen app on the same monitor | `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` switches the current foreground HWND; `SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE)` re-evaluates the taskbar, tray, and current foreground HWND rects | hide/show immediately when the same HWND enters or leaves browser/video fullscreen |
+| Windows system theme setting changes | subscribe to the OS theme/settings notification that covers `SystemUsesLightTheme`, rather than relying only on WinUI app-theme notifications | re-read `IsSystemDark()` and rerender the pill colors even when the title is unchanged |
 | Auto-hide taskbar | falls out of the LocationChange handling: taskbar rect mostly off-screen → hide widget | follow taskbar visibility |
 | Anything the hooks miss | piggyback `TrayFeed`'s existing 30 s fast tick with a cheap rect re-check — **no new polling timer** | self-heal |
 


### PR DESCRIPTION
## Summary

Add the taskbar widget design proposal and the engine pin stall postmortem as historical and design records.

## Scope

| Path | Purpose |
|---|---|
| `docs/proposals/taskbar-widget.md` | Records the proposed independent topmost taskbar overlay and Gate 0 validation matrix. |
| `docs/postmortem-engine-pin-stall.md` | Records why a prior engine pin update stalled and the resulting verification lessons. |

Both files are byte-identical to the existing local drafts. This PR changes no code or runtime behavior.

## Verification

The branch contains one commit directly on the locked `main` base, and its diff contains only the two documentation paths above. Source, staged, and committed SHA-256 values match for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
