### PR TITLE
feat(usage): align v1.13.1 engine contracts

### DIFF
--- a/crates/tb_core_ffi/src/model_report.rs
+++ b/crates/tb_core_ffi/src/model_report.rs
@@ -1,8 +1,8 @@
 //! Per-model usage breakdown for the popover, backed by tokscale-core's
 //! `get_model_report`. Mirrors the design of tokscale's TUI "Models" view
-//! (`crates/tokscale-cli/src/tui/ui/models.rs`): one row per model with the
-//! token breakdown, message count, cost, and throughput (ms/1K), sorted by
-//! cost on the frontend.
+//! (`crates/tokscale-cli/src/tui/ui/models.rs`): one row per exact
+//! `(client, provider, model)` with the token breakdown, message count, cost,
+//! and throughput (ms/1K), sorted by cost on the frontend.
 //!
 //! Like `usage_graph`, this drives the async core on a short-lived
 //! current-thread runtime (callers run it inside `spawn_blocking`) and maps the
@@ -49,16 +49,29 @@ struct ModelReportData {
 /// Build the per-model report for `year` (empty string = all time).
 pub(crate) fn run(context: &crate::LocalSourceContext, year: &str) -> Result<Value, String> {
     let year = normalize_year(year)?;
-    let options = context.report_options(year, None);
+    let data = load_report(report_options(context, year))?;
+    serde_json::to_value(data).map_err(|e| format!("serialize model report: {}", e))
+}
 
+fn report_options(
+    context: &crate::LocalSourceContext,
+    year: Option<String>,
+) -> tokscale_core::ReportOptions {
+    let mut options = context.report_options(year, None);
+    // Group before the FFI boundary: ClientModel would comma-join providers and
+    // C# cannot recover the original rows from that pre-aggregated value.
+    options.group_by = tokscale_core::GroupBy::ClientProviderModel;
+    options
+}
+
+fn load_report(options: tokscale_core::ReportOptions) -> Result<ModelReportData, String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|e| format!("build runtime: {}", e))?;
-    let report = runtime.block_on(tokscale_core::get_model_report(options))?;
-
-    let data = map_report(report);
-    serde_json::to_value(data).map_err(|e| format!("serialize model report: {}", e))
+    runtime
+        .block_on(tokscale_core::get_model_report(options))
+        .map(map_report)
 }
 
 fn normalize_year(year: &str) -> Result<Option<String>, String> {
@@ -122,7 +135,13 @@ mod tests {
     /// #766 clamps corrupt Antigravity varints to `i64::MAX` per bucket. Two
     /// such buckets in one model entry must saturate the mapped `total`, not
     /// overflow it (a plain `+` panics in debug / wraps in release).
-    fn entry(input: i64, output: i64, cache_read: i64, cache_write: i64, reasoning: i64) -> tokscale_core::ModelUsage {
+    fn entry(
+        input: i64,
+        output: i64,
+        cache_read: i64,
+        cache_write: i64,
+        reasoning: i64,
+    ) -> tokscale_core::ModelUsage {
         tokscale_core::ModelUsage {
             client: "antigravity_cli".to_string(),
             merged_clients: None,
@@ -181,5 +200,122 @@ mod tests {
         let report = wrap(vec![entry(1, 2, 4, 8, 16)]);
         let mapped = map_report(report);
         assert_eq!(mapped.entries[0].total, 31);
+    }
+
+    #[test]
+    fn producer_groups_same_client_model_by_exact_provider() {
+        const CHILD_HOME: &str = "TB_MODEL_REPORT_PROVIDER_FIXTURE_HOME";
+        if let Some(home) = std::env::var_os(CHILD_HOME) {
+            run_provider_fixture(std::path::Path::new(&home));
+            return;
+        }
+
+        let root = std::env::temp_dir().join(format!(
+            "tb-core-ffi-model-provider-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let fixture_dir = root.join(".mux/sessions/provider-fixture");
+        std::fs::create_dir_all(&fixture_dir).unwrap();
+        std::fs::write(
+            fixture_dir.join("session-usage.json"),
+            r#"{
+                "version": 1,
+                "byModel": {
+                    "openai:same-model": {
+                        "input": { "tokens": 1, "cost_usd": 0.1 },
+                        "output": { "tokens": 2 }
+                    },
+                    "nvidia:same-model": {
+                        "input": { "tokens": 3, "cost_usd": 0.2 },
+                        "output": { "tokens": 4 }
+                    },
+                    "same-model": {
+                        "input": { "tokens": 5, "cost_usd": 0.3 },
+                        "output": { "tokens": 6 }
+                    }
+                },
+                "lastRequest": { "timestamp": 1700000000000 }
+            }"#,
+        )
+        .unwrap();
+
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("model_report::tests::producer_groups_same_client_model_by_exact_provider")
+            .arg("--exact")
+            .env(CHILD_HOME, &root)
+            .env("HOME", &root)
+            .env("TOKSCALE_CONFIG_DIR", root.join("tokscale-config"))
+            .env("TOKSCALE_PRICING_CACHE_ONLY", "1")
+            .status()
+            .unwrap();
+        std::fs::remove_dir_all(&root).unwrap();
+        assert!(status.success(), "isolated provider fixture failed");
+    }
+
+    fn run_provider_fixture(home: &std::path::Path) {
+        let context = crate::LocalSourceContext {
+            home_dir: Some(home.to_path_buf()),
+        };
+        let mut options = report_options(&context, None);
+        options.use_env_roots = false;
+        options.clients = Some(vec!["mux".to_string()]);
+        assert_eq!(
+            options.group_by,
+            tokscale_core::GroupBy::ClientProviderModel
+        );
+
+        let report = load_report(options).unwrap();
+        assert_eq!(report.entries.len(), 3);
+        assert!(report.entries.iter().all(|entry| entry.client == "mux"
+            && entry.model == "same-model"
+            && !entry.provider.contains(',')));
+
+        let by_provider: std::collections::HashMap<_, _> = report
+            .entries
+            .iter()
+            .map(|entry| (entry.provider.as_str(), entry))
+            .collect();
+        assert_eq!(
+            (
+                by_provider["openai"].input,
+                by_provider["openai"].output,
+                by_provider["openai"].total,
+                by_provider["openai"].message_count,
+            ),
+            (1, 2, 3, 1)
+        );
+        assert_eq!(
+            (
+                by_provider["nvidia"].input,
+                by_provider["nvidia"].output,
+                by_provider["nvidia"].total,
+                by_provider["nvidia"].message_count,
+            ),
+            (3, 4, 7, 1)
+        );
+        assert_eq!(
+            (
+                by_provider[""].input,
+                by_provider[""].output,
+                by_provider[""].total,
+                by_provider[""].message_count,
+            ),
+            (5, 6, 11, 1)
+        );
+        assert!((by_provider["openai"].cost - 0.1).abs() < f64::EPSILON);
+        assert!((by_provider["nvidia"].cost - 0.2).abs() < f64::EPSILON);
+        assert!((by_provider[""].cost - 0.3).abs() < f64::EPSILON);
+        assert_eq!(
+            report.entries.iter().map(|entry| entry.total).sum::<i64>(),
+            21
+        );
+        assert_eq!(report.total_input, 9);
+        assert_eq!(report.total_output, 12);
+        assert_eq!(report.total_messages, 3);
+        assert!((report.total_cost - 0.6).abs() < f64::EPSILON);
     }
 }

--- a/crates/tb_core_ffi/src/usage_graph.rs
+++ b/crates/tb_core_ffi/src/usage_graph.rs
@@ -7,6 +7,8 @@
 //! maps the resulting `GraphResult` back onto the camelCase JSON shape the
 //! frontend already consumes (`src/lib/types.ts` `UsagePayload`).
 
+use std::collections::BTreeMap;
+
 use serde::Serialize;
 use serde_json::Value;
 
@@ -49,6 +51,7 @@ struct DailyContribution {
     intensity: u8,
     token_breakdown: TokenBreakdown,
     clients: Vec<ClientContribution>,
+    turns_by_client: BTreeMap<String, i64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -197,6 +200,7 @@ fn map_contribution(day: tokscale_core::DailyContribution) -> DailyContribution 
                 messages: c.messages,
             })
             .collect(),
+        turns_by_client: day.turns_by_client,
     }
 }
 
@@ -207,5 +211,53 @@ fn map_breakdown(breakdown: &tokscale_core::TokenBreakdown) -> TokenBreakdown {
         cache_read: breakdown.cache_read,
         cache_write: breakdown.cache_write,
         reasoning: breakdown.reasoning,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn engine_day(
+        date: &str,
+        messages: i32,
+        turns_by_client: BTreeMap<String, i64>,
+    ) -> tokscale_core::DailyContribution {
+        tokscale_core::DailyContribution {
+            date: date.to_string(),
+            totals: tokscale_core::DailyTotals {
+                messages,
+                ..Default::default()
+            },
+            intensity: 0,
+            token_breakdown: tokscale_core::TokenBreakdown::default(),
+            clients: Vec::new(),
+            active_time_ms: None,
+            turns_by_client,
+        }
+    }
+
+    #[test]
+    fn maps_daily_turns_by_exact_client_and_keeps_message_only_days_empty() {
+        let mapped = map_contribution(engine_day(
+            "2026-08-08",
+            4,
+            BTreeMap::from([("cc-mirror/foo".to_string(), 1), ("claude".to_string(), 2)]),
+        ));
+
+        assert_eq!(mapped.turns_by_client.get("cc-mirror/foo"), Some(&1));
+        assert_eq!(mapped.turns_by_client.get("claude"), Some(&2));
+        assert_eq!(mapped.turns_by_client.values().sum::<i64>(), 3);
+        let wire = serde_json::to_value(&mapped).unwrap();
+        assert_eq!(wire["turnsByClient"]["cc-mirror/foo"], 1);
+        assert!(wire.get("turns_by_client").is_none());
+
+        let message_only = map_contribution(engine_day("2026-08-09", 5, BTreeMap::new()));
+        assert_eq!(message_only.totals.messages, 5);
+        assert!(message_only.turns_by_client.is_empty());
+        assert_eq!(
+            serde_json::to_value(message_only).unwrap()["turnsByClient"],
+            serde_json::json!({})
+        );
     }
 }

--- a/src/TokenBar.Core.Tests/DtoDecodeTests.cs
+++ b/src/TokenBar.Core.Tests/DtoDecodeTests.cs
@@ -369,6 +369,7 @@ public class DtoDecodeTests
                "range":{"start":"2026-01-01","end":"2026-07-02"}}],
              "contributions":[{"date":"2026-07-01","totals":{"tokens":50,"cost":0.7,"messages":3},
                "intensity":2,"tokenBreakdown":{"input":10,"output":20,"cacheRead":15,"cacheWrite":5,"reasoning":0},
+               "turnsByClient":{"cc-mirror/foo":2},
                "clients":[{"client":"claude","modelId":"m","providerId":"anthropic",
                  "tokens":{"input":10,"output":20,"cacheRead":15,"cacheWrite":5,"reasoning":0},
                  "cost":0.7,"messages":3}]}]}}
@@ -377,6 +378,19 @@ public class DtoDecodeTests
         Assert.Equal(8, p.Summary.ActiveDays);
         Assert.Equal("anthropic", p.Contributions[0].Clients[0].ProviderId);
         Assert.Equal(15, p.Contributions[0].TokenBreakdown.CacheRead);
+        Assert.Equal(2, p.Contributions[0].TurnsByClient!["cc-mirror/foo"]);
+    }
+
+    [Fact]
+    public void ContributionTurnsByClientAllowsAbsentOrEmptyMaps()
+    {
+        Contribution DecodeContribution(string suffix) =>
+            JsonSerializer.Deserialize<Contribution>(
+                $$"""{"date":"2026-08-09","totals":{"tokens":0,"cost":0,"messages":1},"intensity":0,"tokenBreakdown":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"reasoning":0},"clients":[]{{suffix}}}""",
+                Web) ?? throw new InvalidOperationException("contribution decoded to null");
+
+        Assert.Null(DecodeContribution("").TurnsByClient);
+        Assert.Empty(DecodeContribution(",\"turnsByClient\":{}").TurnsByClient!);
     }
 
     [Fact]

--- a/src/TokenBar.Interop/Graph.cs
+++ b/src/TokenBar.Interop/Graph.cs
@@ -68,7 +68,8 @@ public sealed record Contribution(
     ContributionTotals Totals,
     int Intensity,
     TokenBreakdown TokenBreakdown,
-    IReadOnlyList<ContributionClient> Clients);
+    IReadOnlyList<ContributionClient> Clients,
+    IReadOnlyDictionary<string, long>? TurnsByClient = null);
 
 public sealed record DateRange(
     string Start,

--- a/vendor/ENGINE.md
+++ b/vendor/ENGINE.md
@@ -10,14 +10,25 @@ app consumer advances its reviewed pin.
 |---|---|
 | Path | `vendor/tokscale-core` |
 | Repository | `https://github.com/Nanako0129/tokscale-core.git` |
-| Reviewed pin | `84e0d66413d4e0d87b734f66f7a848b3bc323258` |
+| Reviewed pin | `5b5f500d3a8abe66ab5fa44b18f4fc1aaee53947` |
+| TokenBar alignment | `v1.12.0` → `v1.13.1` |
+| Engine alignment | `84e0d66413d4e0d87b734f66f7a848b3bc323258` → `5b5f500d3a8abe66ab5fa44b18f4fc1aaee53947` |
 | Native consumer baseline | `704426e8df9acfb8e82fe4bf3b7ed3e5adbc2fea` |
 | Windows pre-migration baseline | `68e2541c5e9adb14a47433f8b25e26b0be84d1fc` |
-| Upstream and local-patch ledger | Immutable [`UPSTREAM.md`](https://github.com/Nanako0129/tokscale-core/blob/84e0d66413d4e0d87b734f66f7a848b3bc323258/UPSTREAM.md) |
+| Upstream and local-patch ledger | Immutable [`UPSTREAM.md`](https://github.com/Nanako0129/tokscale-core/blob/5b5f500d3a8abe66ab5fa44b18f4fc1aaee53947/UPSTREAM.md) |
 
 > **Warning:** Do not edit shared source on a consumer branch. Engine changes
 > must pass review in `tokscale-core`; this repository then advances only the
 > reviewed gitlink and runs the Windows consumer gates.
+
+## v1.13.1 consumer alignment
+
+This slice advances only the shared engine pin and the Windows-owned consumer
+contracts: exact-client daily turns and per-`(client, provider, model)` model
+rows. Cache format 3, Claude rewrite retention, missing-source pruning, and the
+batched parser remain engine-owned and are accepted through the pinned engine's
+behavioral regressions. This slice does not include UI, downstream attribution,
+or performance claims.
 
 ## Ownership
 


### PR DESCRIPTION
## Summary

- advance `vendor/tokscale-core` to the reviewed TokenBar `v1.13.1`-aligned pin `5b5f500d3a8abe66ab5fa44b18f4fc1aaee53947`
- carry exact-client daily turns through the Rust FFI as camelCase `turnsByClient`, with backward-compatible C# decoding for absent, empty, and populated maps
- group model-report rows by `ClientProviderModel` before engine aggregation so `(client, provider, model)` identity is preserved at the Rust source of truth
- document the engine-owned cache/parser contracts and add production-path Rust and C# regression coverage

## Data contract

```text
vendor/tokscale-core
  → crates/tb_core_ffi
  → camelCase JSON
  → TokenBar.Interop DTOs
```

Exact client IDs such as `cc-mirror/foo` are not canonicalized. Provider identity is established before the FFI boundary; the C# consumer does not attempt to reconstruct providers after pre-aggregation.

## Verification

| Gate | Result |
|---|---|
| Candidate patch SHA-256 | `c1164f804fb47b252f37e4ad4a13a3cfe329e443684a058e56b103f280208e60` |
| Rust Debug / Release tests | Passed |
| C# Debug / Release and DTO tests | Passed |
| Cache format v3 → v2 reverse rollback | Passed; rollback output matched the clean v2 cold baseline |
| Windows x64 | Passed with Rust `1.96.1` and .NET SDK `10.0.301` |
| ARM64 cross-build / App artifact / Velopack package | Passed |
| Native ARM64 self-contained runtime smoke | Passed on ARM64 Windows; ZIP SHA-256 `3b7f1c1a4b3495bbc76eb8d2f1b559d5cf37b0a5ce831a00c3409cde909df6b5` |
| Fresh verifier | `CONFIRMED`, no P0–P4 findings |

## Non-goals

This slice does not add UI, Daily turns presentation, Dashboard loading or snapshots, attribution, Discord behavior, or other A2 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
