### PR TITLE
feat(usage): align daily activity and metric windows

### DIFF
--- a/src/TokenBar.App/DashboardView.xaml.cs
+++ b/src/TokenBar.App/DashboardView.xaml.cs
@@ -705,6 +705,7 @@ public sealed partial class DashboardView : UserControl
             snapshot.Graph,
             _selectedClients,
             _chartStackBy,
+            _chartMetric,
             colors,
             Format.TodayKey(),
             rangeEnd: stats.DateRange.End);
@@ -1195,25 +1196,7 @@ public sealed partial class DashboardView : UserControl
     {
         var panel = new StackPanel { Spacing = 6 };
         var colors = new ModelColorMap(snapshot.Models);
-        var days = snapshot.Graph.Contributions
-            .Select(day =>
-            {
-                var clients = day.Clients
-                    .Where(c => _selectedSet.Contains(ClientRegistry.CanonicalClient(c.Client)))
-                    .OrderByDescending(c => c.Cost)
-                    .ToList();
-                var tokens = clients.Aggregate(
-                    0L, (total, client) => total.SaturatingAdd(client.Tokens.Total));
-                return (
-                    Day: day,
-                    Clients: clients,
-                    Tokens: tokens,
-                    Cost: clients.Sum(c => c.Cost),
-                    Messages: clients.Sum(c => c.Messages));
-            })
-            .Where(day => day.Tokens > 0 || day.Cost > 0)
-            .Reverse()
-            .ToList();
+        var days = DailyRows.Build(snapshot.Graph, _selectedClients);
         if (days.Count == 0)
         {
             panel.Children.Add(Ui.Dim("No active days."));
@@ -1221,16 +1204,26 @@ public sealed partial class DashboardView : UserControl
 
         foreach (var selectedDay in days)
         {
-            var day = selectedDay.Day;
             var block = new StackPanel { Spacing = 4 };
+            var summary = $"{selectedDay.Messages} msgs";
+            if (selectedDay.Turns is { } turns)
+            {
+                var scope = selectedDay.TurnClients.Count switch
+                {
+                    1 => $"{ClientRegistry.ShortName(selectedDay.TurnClients[0])} only",
+                    > 1 => $"{string.Join(" + ", selectedDay.TurnClients.Select(ClientRegistry.ShortName))} only",
+                    _ => "selected clients",
+                };
+                summary += $" · {turns} turns · {scope}";
+            }
+
+            summary += $" · {Format.CompactTokens(selectedDay.Tokens)} · {Format.Usd(selectedDay.Cost)}";
             var head = Ui.Row(
-                Ui.Text(Format.MonthDay(day.Date), 12, bold: true),
-                Ui.Text(
-                    $"{selectedDay.Messages} msgs · {Format.CompactTokens(selectedDay.Tokens)} · {Format.Usd(selectedDay.Cost)}",
-                    11, 0.8));
+                Ui.Text(Format.MonthDay(selectedDay.Date), 12, bold: true),
+                Ui.Text(summary, 11, 0.8));
             block.Children.Add(head);
 
-            if (_expandedDay == day.Date)
+            if (_expandedDay == selectedDay.Date)
             {
                 foreach (var client in selectedDay.Clients)
                 {
@@ -1289,7 +1282,7 @@ public sealed partial class DashboardView : UserControl
                 Padding = new Thickness(10, 8, 10, 8),
                 Child = block,
             };
-            var date = day.Date;
+            var date = selectedDay.Date;
             card.Tapped += (_, _) =>
             {
                 _expandedDay = _expandedDay == date ? null : date;

--- a/src/TokenBar.Core.Tests/DailyRowsTests.cs
+++ b/src/TokenBar.Core.Tests/DailyRowsTests.cs
@@ -1,0 +1,170 @@
+using TokenBar.Interop;
+using Xunit;
+
+namespace TokenBar.Core.Tests;
+
+public class DailyRowsTests
+{
+    private static ContributionClient Client(
+        string id, long tokens = 0, double cost = 0, int messages = 0) =>
+        new(id, "m", "anthropic", new TokenBreakdown(tokens, 0, 0, 0, 0), cost, messages);
+
+    private static Contribution Day(
+        string date,
+        IReadOnlyList<ContributionClient> clients,
+        IReadOnlyDictionary<string, long>? turns = null) =>
+        new(date, new ContributionTotals(0, 0, 0), 0,
+            new TokenBreakdown(0, 0, 0, 0, 0), clients, turns);
+
+    private static UsagePayload Payload(params Contribution[] days) =>
+        new(
+            new UsageMeta("g", "v", new DateRange("2026-06-01", "2026-06-30")),
+            new UsageSummary(0, 0, 0, 0, 0, 0, [], []), [], days);
+
+    [Fact]
+    public void MessageAndCostOnlyRowsAreActiveAndOrdinalDescending()
+    {
+        var rows = DailyRows.Build(
+            Payload(
+                Day("2026-06-01", [Client("claude", messages: 2)]),
+                Day("2026-06-03", [Client("claude", cost: 1)]),
+                Day("2026-06-02", [Client("claude")])),
+            ["claude"]);
+
+        Assert.Equal(["2026-06-03", "2026-06-01"], rows.Select(row => row.Date));
+        Assert.Equal(1.0, rows[0].Cost);
+        Assert.Equal(2L, rows[1].Messages);
+        Assert.All(rows, row => Assert.NotEmpty(row.Clients));
+    }
+
+    [Fact]
+    public void CanonicalMembershipExcludesUnselectedAndKeepsRawDrilldown()
+    {
+        var rows = DailyRows.Build(
+            Payload(Day(
+                "2026-06-04",
+                [Client("claude-code", tokens: 10), Client("gemini", tokens: 90)])),
+            ["claude"]);
+
+        var row = Assert.Single(rows);
+        var client = Assert.Single(row.Clients);
+        Assert.Equal("claude-code", client.Client);
+        Assert.Equal(10L, row.Tokens);
+        Assert.Equal(["claude-code"], row.Clients.Select(c => c.Client));
+    }
+
+    [Fact]
+    public void SingleSupportedTurnScopeQueriesExactRawKey()
+    {
+        var rows = DailyRows.Build(
+            Payload(Day(
+                "2026-06-05",
+                [Client("claude-code", messages: 1)],
+                new Dictionary<string, long>
+                {
+                    ["claude-code"] = 5,
+                    ["claude"] = 99,
+                    ["map-only"] = 100,
+                })),
+            ["claude"]);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(["claude"], row.TurnClients);
+        Assert.Equal(5L, row.Turns!.Value);
+    }
+
+    [Fact]
+    public void DualSupportedScopeOrdersCanonicalClientsAndDedupesRawKeys()
+    {
+        var rows = DailyRows.Build(
+            Payload(Day(
+                "2026-06-06",
+                [
+                    Client("claude-code", messages: 1),
+                    Client("claude-code", messages: 1),
+                    Client("claude", messages: 1),
+                    Client("codex-cli", messages: 1),
+                    Client("gemini", messages: 1),
+                ],
+                new Dictionary<string, long>
+                {
+                    ["claude-code"] = 2,
+                    ["claude"] = 3,
+                    ["codex-cli"] = 4,
+                    ["codex"] = 100,
+                    ["gemini"] = 200,
+                })),
+            ["codex", "claude", "gemini"]);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(["codex", "claude"], row.TurnClients);
+        Assert.Equal(9L, row.Turns!.Value);
+    }
+
+    [Fact]
+    public void UnsupportedOnlyScopeIsNullAndMixedScopeIgnoresUnsupportedMapKeys()
+    {
+        var rows = DailyRows.Build(
+            Payload(
+                Day(
+                    "2026-06-07",
+                    [Client("gemini", messages: 1)],
+                    new Dictionary<string, long> { ["gemini"] = 100 }),
+                Day(
+                    "2026-06-08",
+                    [Client("claude", messages: 1), Client("gemini", messages: 1)],
+                    new Dictionary<string, long> { ["gemini"] = 100 })),
+            ["gemini", "claude"]);
+
+        var mixed = Assert.Single(rows.Where(row => row.Date == "2026-06-08"));
+        Assert.Equal(["claude"], mixed.TurnClients);
+        Assert.Equal(0L, mixed.Turns!.Value);
+        var unsupported = Assert.Single(rows.Where(row => row.Date == "2026-06-07"));
+        Assert.Null(unsupported.Turns);
+        Assert.Empty(unsupported.TurnClients);
+    }
+
+    [Fact]
+    public void NullAndEmptyMapsProduceZeroWhenSupportedScopeExists()
+    {
+        var rows = DailyRows.Build(
+            Payload(
+                Day("2026-06-09", [Client("codex", messages: 1)]),
+                Day("2026-06-10", [Client("claude", messages: 1)], new Dictionary<string, long>())),
+            ["codex", "claude"]);
+
+        Assert.All(rows, row => Assert.Equal(0L, row.Turns!.Value));
+        Assert.Equal(["claude"], rows.Single(row => row.Date == "2026-06-10").TurnClients);
+        Assert.Equal(["codex"], rows.Single(row => row.Date == "2026-06-09").TurnClients);
+    }
+
+    [Fact]
+    public void TurnsDoNotMakeAnInactiveDay()
+    {
+        var rows = DailyRows.Build(
+            Payload(Day(
+                "2026-06-11",
+                [Client("codex")],
+                new Dictionary<string, long> { ["codex"] = 5 })),
+            ["codex"]);
+
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public void TurnTotalsSaturateIntegerOverflow()
+    {
+        var rows = DailyRows.Build(
+            Payload(Day(
+                "2026-06-12",
+                [Client("claude", messages: 1), Client("claude-code", messages: 1)],
+                new Dictionary<string, long>
+                {
+                    ["claude"] = long.MaxValue,
+                    ["claude-code"] = long.MaxValue,
+                })),
+            ["claude"]);
+
+        Assert.Equal(long.MaxValue, Assert.Single(rows).Turns!.Value);
+    }
+}

--- a/src/TokenBar.Core.Tests/DayBarsTests.cs
+++ b/src/TokenBar.Core.Tests/DayBarsTests.cs
@@ -10,8 +10,9 @@ public class DayBarsTests
     private static Contribution Day(string date, params ContributionClient[] clients) =>
         new(date, new ContributionTotals(0, 0, 0), 1, new TokenBreakdown(0, 0, 0, 0, 0), clients);
 
-    private static ContributionClient Client(string id, long tokens, double cost = 1) =>
-        new(id, "m", "anthropic", new TokenBreakdown(tokens, 0, 0, 0, 0), cost, Messages: 1);
+    private static ContributionClient Client(
+        string id, long tokens, double cost = 1, int messages = 1) =>
+        new(id, "m", "anthropic", new TokenBreakdown(tokens, 0, 0, 0, 0), cost, messages);
 
     private static UsagePayload Payload(string metaEnd, params Contribution[] days) =>
         new(
@@ -31,23 +32,24 @@ public class DayBarsTests
             Day("2026-06-10", Client("claude", 100)));
 
         var bars = DayBars.Build(
-            payload, ["claude"], StackBy.Agent, new ModelColorMap([]),
-            endFallback: "2026-07-15", rangeEnd: "2026-06-10");
+            payload, ["claude"], StackBy.Agent, ChartMetric.Tokens,
+            new ModelColorMap([]), endFallback: "2026-07-15",
+            rangeEnd: "2026-06-10");
 
         Assert.Equal("2026-06-10", bars[^1].Date);
         Assert.Equal(100, bars[^1].TotalTokens);
     }
 
     [Fact]
-    public void NullRangeEndFallsBackToMetaRange()
+    public void MetricWithoutDataFallsBackToMetaRange()
     {
         var payload = Payload(
             "2026-06-20",
-            Day("2026-06-10", Client("claude", 100)));
+            Day("2026-06-10", Client("claude", 0, 0, 1)));
 
         var bars = DayBars.Build(
-            payload, ["claude"], StackBy.Agent, new ModelColorMap([]),
-            endFallback: "2026-07-15");
+            payload, ["claude"], StackBy.Agent, ChartMetric.Tokens,
+            new ModelColorMap([]), endFallback: "2026-07-15");
 
         Assert.Equal("2026-06-20", bars[^1].Date);
     }
@@ -62,9 +64,109 @@ public class DayBarsTests
                 Client("claude", long.MaxValue), Client("codex", long.MaxValue)));
 
         var bars = DayBars.Build(
-            payload, ["claude", "codex"], StackBy.Agent, new ModelColorMap([]),
-            endFallback: "2026-07-15", rangeEnd: "2026-06-10");
+            payload, ["claude", "codex"], StackBy.Agent, ChartMetric.Tokens,
+            new ModelColorMap([]), endFallback: "2026-07-15",
+            rangeEnd: "2026-06-10");
 
         Assert.Equal(long.MaxValue, bars[^1].TotalTokens);
+    }
+
+    [Fact]
+    public void CanonicalMembershipKeepsRawAgentSegmentIdentity()
+    {
+        var payload = Payload(
+            "2026-06-10",
+            Day("2026-06-10",
+                Client("claude-code", 100, 0),
+                Client("codex-cli", 50, 0)));
+
+        var bars = DayBars.Build(
+            payload, ["claude", "codex"], StackBy.Agent, ChartMetric.Tokens,
+            new ModelColorMap([]), endFallback: "2026-07-15",
+            rangeEnd: "2026-06-10");
+        var segments = bars[^1].Segments;
+
+        Assert.Equal(["claude-code", "codex-cli"], segments.Select(s => s.Key));
+        Assert.Equal(
+            [ClientRegistry.ShortName("claude-code"), ClientRegistry.ShortName("codex-cli")],
+            segments.Select(s => s.Label));
+    }
+
+    [Fact]
+    public void MetricAnchorFollowsOnlyTheActiveMetric()
+    {
+        var payload = Payload(
+            "2026-06-30",
+            Day("2026-06-01", Client("claude", 10, 0, 0)),
+            Day("2026-06-02", Client("claude", 0, 2, 0)),
+            Day("2026-06-03", Client("claude", 0, 0, 5)));
+
+        var tokenBars = DayBars.Build(
+            payload, ["claude"], StackBy.Agent, ChartMetric.Tokens,
+            new ModelColorMap([]), endFallback: "2026-07-15");
+        var costBars = DayBars.Build(
+            payload, ["claude"], StackBy.Agent, ChartMetric.Cost,
+            new ModelColorMap([]), endFallback: "2026-07-15");
+
+        Assert.Equal("2026-06-01", tokenBars[^1].Date);
+        Assert.Equal(10L, tokenBars[^1].TotalTokens);
+        Assert.Equal("2026-06-02", costBars[^1].Date);
+        Assert.Equal(2.0, costBars[^1].TotalCost);
+        Assert.Empty(costBars[^1].Segments.Where(s => s.Tokens == 0 && s.Cost == 0));
+    }
+
+    [Fact]
+    public void MessageOnlyStripeNeverCreatesSegment()
+    {
+        var payload = Payload(
+            "2026-06-03",
+            Day("2026-06-03", Client("claude", 0, 0, 4)));
+
+        var bars = DayBars.Build(
+            payload, ["claude"], StackBy.Agent, ChartMetric.Tokens,
+            new ModelColorMap([]), endFallback: "2026-07-15",
+            rangeEnd: "2026-06-03");
+
+        Assert.Empty(bars[^1].Segments);
+    }
+
+    [Fact]
+    public void MetricWithoutPositiveDatumFallsBackToRangeThenMetaThenFallback()
+    {
+        var payload = Payload(
+            "2026-06-20",
+            Day("2026-06-01", Client("claude", 10, 0, 0)));
+
+        var rangeBars = DayBars.Build(
+            payload, ["claude"], StackBy.Agent, ChartMetric.Cost,
+            new ModelColorMap([]), endFallback: "2026-07-15",
+            rangeEnd: "2026-06-10");
+        var metaBars = DayBars.Build(
+            payload, ["claude"], StackBy.Agent, ChartMetric.Cost,
+            new ModelColorMap([]), endFallback: "2026-07-15");
+        var fallbackBars = DayBars.Build(
+            Payload("", Day("2026-06-01", Client("claude", 10, 0, 0))),
+            ["claude"], StackBy.Agent, ChartMetric.Cost,
+            new ModelColorMap([]), endFallback: "2026-07-15");
+
+        Assert.Equal("2026-06-10", rangeBars[^1].Date);
+        Assert.Equal("2026-06-20", metaBars[^1].Date);
+        Assert.Equal("2026-07-15", fallbackBars[^1].Date);
+    }
+
+    [Fact]
+    public void HiddenAndUnselectedMetricTailsDoNotMoveAnchor()
+    {
+        var payload = Payload(
+            "2026-06-30",
+            Day("2026-06-02", Client("claude", 0, 2, 0)),
+            Day("2026-06-29", Client("gemini", 0, 9, 0)),
+            Day("2026-06-30", Client("claude", 0, 0, 4)));
+
+        var bars = DayBars.Build(
+            payload, ["claude"], StackBy.Agent, ChartMetric.Cost,
+            new ModelColorMap([]), endFallback: "2026-07-15");
+
+        Assert.Equal("2026-06-02", bars[^1].Date);
     }
 }

--- a/src/TokenBar.Core.Tests/UsageStatsTests.cs
+++ b/src/TokenBar.Core.Tests/UsageStatsTests.cs
@@ -8,10 +8,11 @@ namespace TokenBar.Core.Tests;
 public class UsageStatsTests
 {
     private static Dictionary<string, PerDay> PerDayOf(params string[] dates) =>
-        dates.ToDictionary(d => d, d => new PerDay(d, Tokens: 10, Cost: 1, Intensity: 1));
+        dates.ToDictionary(d => d, d => new PerDay(d, Tokens: 10, Cost: 1, Messages: 0, Intensity: 1));
 
-    private static ContributionClient Client(string id, long tokens, double cost = 1) =>
-        new(id, "m", "anthropic", new TokenBreakdown(tokens, 0, 0, 0, 0), cost, Messages: 1);
+    private static ContributionClient Client(
+        string id, long tokens, double cost = 1, int messages = 1) =>
+        new(id, "m", "anthropic", new TokenBreakdown(tokens, 0, 0, 0, 0), cost, messages);
 
     private static Contribution Day(string date, params ContributionClient[] clients) =>
         new(date, new ContributionTotals(0, 0, 0), 1, new TokenBreakdown(0, 0, 0, 0, 0), clients);
@@ -70,8 +71,8 @@ public class UsageStatsTests
     {
         var grid = Grid.Build("2026", new Dictionary<string, PerDay>
         {
-            ["2026-01-01"] = new("2026-01-01", 500, 1, 1),
-            ["2025-12-29"] = new("2025-12-29", 900, 1, 1),
+            ["2026-01-01"] = new("2026-01-01", 500, 1, 0, 1),
+            ["2025-12-29"] = new("2025-12-29", 900, 1, 0, 1),
         });
 
         Assert.Equal(7, grid.Rows);
@@ -84,7 +85,7 @@ public class UsageStatsTests
         var jan1 = grid.Cells.First(c => c.Date == "2026-01-01");
         Assert.Equal((0, 4, true), (jan1.Col, jan1.Row, jan1.Active));
         // Out-of-year tokens don't drive max and out-of-year cells are inactive.
-        Assert.Equal(500, grid.MaxTokens);
+        Assert.Equal(500L, grid.MaxTokens);
         Assert.False(grid.Cells.First(c => c.Date == "2025-12-29").Active);
     }
 
@@ -173,5 +174,74 @@ public class UsageStatsTests
             onlyHidden, new HashSet<string> { "gemini" }));
         Assert.True(UsageStatsVisibility.HasVisibleActivity(
             onlyHidden, new HashSet<string>()));
+    }
+
+    [Fact]
+    public void ActivityRequiresTokensCostOrMessages()
+    {
+        Assert.False(UsageActivity.IsActive(0, 0, 0));
+        Assert.True(UsageActivity.IsActive(1, 0, 0));
+        Assert.True(UsageActivity.IsActive(0, 0.01, 0));
+        Assert.True(UsageActivity.IsActive(0, 0, 1));
+    }
+
+    [Fact]
+    public void StatsCanonicalizeSelectionButKeepRawPresence()
+    {
+        var payload = Payload(
+            "2026-06-01", "2026-06-02",
+            Day("2026-06-01",
+                Client("claude-code", 10, 1, 2),
+                Client("claude", 20, 2, 3),
+                Client("codex-cli", 5, 0.5, 1),
+                Client("gemini", 100, 9, 7)));
+
+        var stats = new UsageStats(payload, new HashSet<string> { "claude", "codex" });
+        Assert.Equal(35L, stats.TotalTokens);
+        Assert.Equal(3.5, stats.TotalCost);
+        Assert.Equal(6L, Assert.Single(stats.PerDay).Messages);
+        Assert.Equal(35L, stats.MaxTokens);
+        Assert.Equal(["claude", "claude-code", "codex-cli", "gemini"], stats.PresentClients);
+    }
+
+    [Fact]
+    public void MessageOnlyAndCostOnlyDaysAreActiveEverywhere()
+    {
+        var payload = Payload(
+            "2026-06-01", "2026-06-03",
+            Day("2026-06-01", Client("claude", 0, 0, 2)),
+            Day("2026-06-02", Client("claude", 0, 1, 0)),
+            Day("2026-06-03", Client("claude", 0, 0, 0)));
+
+        var stats = new UsageStats(payload, new HashSet<string> { "claude" });
+        Assert.Equal(2, stats.ActiveDays);
+        Assert.Equal(2L, stats.PerDay.Sum(day => day.Messages));
+        Assert.Equal(1, stats.TotalCost);
+        Assert.All(stats.PerDay, day => Assert.True(day.IsActive));
+        Assert.Equal(2, stats.Streaks.Longest);
+        Assert.Equal(0, stats.Streaks.Current);
+    }
+
+    [Fact]
+    public void GridUsesSharedActivityWithoutChangingTokenScale()
+    {
+        var grid = Grid.Build("2026", new Dictionary<string, PerDay>
+        {
+            ["2026-01-01"] = new("2026-01-01", 0, 0, 2, 1),
+            ["2026-01-02"] = new("2026-01-02", 500, 0, 0, 1),
+        });
+
+        Assert.True(grid.Cells.First(c => c.Date == "2026-01-01").Active);
+        Assert.Equal(500L, grid.MaxTokens);
+    }
+
+    [Fact]
+    public void VisibilityCanonicalizesAliasesAndDoesNotTakeSelection()
+    {
+        var aliasOnly = new[] { Day("2026-05-01", Client("claude-code", 0, 0, 1)) };
+        Assert.False(UsageStatsVisibility.HasVisibleActivity(
+            aliasOnly, new HashSet<string> { "claude" }));
+        Assert.Contains("2026", UsageStatsVisibility.YearsWithVisibleActivity(
+            aliasOnly, new HashSet<string>()));
     }
 }

--- a/src/TokenBar.Core/DailyRows.cs
+++ b/src/TokenBar.Core/DailyRows.cs
@@ -1,0 +1,111 @@
+using TokenBar.Interop;
+
+namespace TokenBar.Core;
+
+/// <summary>UI-free projection for one active contribution day. Clients retain
+/// the payload's raw stripe ids for drill-down; turn scope ids are canonical.</summary>
+public sealed record DailyRow(
+    string Date,
+    long Tokens,
+    double Cost,
+    long Messages,
+    long? Turns,
+    IReadOnlyList<string> TurnClients,
+    IReadOnlyList<ContributionClient> Clients);
+
+public static class DailyRows
+{
+    private static readonly HashSet<string> SupportedTurnClients =
+        ["codex", "claude"];
+
+    /// <summary>Project selected payload stripes into most-recent-first rows.
+    /// Selection is canonical, while raw client ids and turn-map keys are never
+    /// normalized or substituted.</summary>
+    public static IReadOnlyList<DailyRow> Build(
+        UsagePayload payload, IReadOnlyList<string> orderedSelectedClients)
+    {
+        var selected = orderedSelectedClients
+            .Select(ClientRegistry.CanonicalClient)
+            .ToHashSet(StringComparer.Ordinal);
+        var orderedTurnClients = orderedSelectedClients
+            .Select(ClientRegistry.CanonicalClient)
+            .Where(SupportedTurnClients.Contains)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var rows = new List<DailyRow>();
+
+        foreach (var contribution in payload.Contributions)
+        {
+            var clients = contribution.Clients
+                .Where(client => selected.Contains(
+                    ClientRegistry.CanonicalClient(client.Client)))
+                .OrderByDescending(client => client.Cost)
+                .ToList();
+            long tokens = 0;
+            long messages = 0;
+            var cost = 0.0;
+            foreach (var client in clients)
+            {
+                tokens = tokens.SaturatingAdd(client.Tokens.Total);
+                messages = messages.SaturatingAdd(client.Messages);
+                cost += client.Cost;
+            }
+
+            if (!UsageActivity.IsActive(tokens, cost, messages))
+            {
+                continue;
+            }
+
+            var turnClients = orderedTurnClients
+                .Where(canonical => clients.Any(client =>
+                    ClientRegistry.CanonicalClient(client.Client) == canonical))
+                .ToList();
+            long? turns = turnClients.Count == 0
+                ? null
+                : SumTurns(contribution.TurnsByClient, clients);
+            rows.Add(new DailyRow(
+                contribution.Date,
+                tokens,
+                cost,
+                messages,
+                turns,
+                turnClients,
+                clients));
+        }
+
+        return rows
+            .OrderByDescending(row => row.Date, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static long SumTurns(
+        IReadOnlyDictionary<string, long>? turnsByClient,
+        IReadOnlyList<ContributionClient> clients)
+    {
+        if (turnsByClient is null || turnsByClient.Count == 0)
+        {
+            return 0;
+        }
+
+        long total = 0;
+        var seenRawIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var client in clients)
+        {
+            if (!SupportedTurnClients.Contains(
+                    ClientRegistry.CanonicalClient(client.Client))
+                || !seenRawIds.Add(client.Client))
+            {
+                continue;
+            }
+
+            // Query only exact raw stripe ids. Map-only keys and aliases that did
+            // not appear as matching stripes must not contribute turns.
+            if (turnsByClient.TryGetValue(client.Client, out var count))
+            {
+                total = total.SaturatingAdd(count);
+            }
+        }
+
+        return total;
+    }
+}

--- a/src/TokenBar.Core/DayBars.cs
+++ b/src/TokenBar.Core/DayBars.cs
@@ -45,29 +45,29 @@ public static class DayBars
 {
     public const int Window = 30;
 
-    /// <summary>Build the trailing Window-day series ending at
-    /// <paramref name="rangeEnd"/> (today, via <paramref name="endFallback"/>,
-    /// when absent). Days outside the data render as empty bars.
+    /// <summary>Build the trailing Window-day series using the active metric's
+    /// last positive selected datum as the anchor. If that metric has no datum,
+    /// fall back to the selected range end, payload range end, then the caller's
+    /// fallback date. Days outside the data render as empty bars.
     ///
-    /// <paramref name="rangeEnd"/> must be the SELECTED clients' range end
+    /// <paramref name="rangeEnd"/> is the SELECTED clients' range end
     /// (UsageStats.DateRange.End, selection-derived), NOT the unfiltered
-    /// payload.Meta.DateRange.End: a hidden client whose activity extends past
-    /// the visible clients' last day would otherwise shift the trailing window
-    /// forward and push visible activity off the chart while the range-filtered
-    /// headline stats disagree. When nothing is hidden the two are equal, so the
-    /// window is unchanged. Passing null falls back to the unfiltered
-    /// payload range end (the pre-hide behavior for callers not yet plumbed for
-    /// selection-derived ranges).</summary>
+    /// payload.Meta.DateRange.End. Membership is canonical, but agent segment
+    /// keys and labels retain each stripe's raw id.</summary>
     public static IReadOnlyList<DayBar> Build(
         UsagePayload payload,
         IReadOnlyList<string> clientIds,
         StackBy stackBy,
+        ChartMetric metric,
         ModelColorMap colors,
         string endFallback,
         string? rangeEnd = null)
     {
-        var allowed = new HashSet<string>(clientIds);
+        var allowed = clientIds
+            .Select(ClientRegistry.CanonicalClient)
+            .ToHashSet(StringComparer.Ordinal);
         var byDate = new Dictionary<string, DayBar>();
+        string? metricEnd = null;
         foreach (var contribution in payload.Contributions)
         {
             var day = BuildDayBar(contribution, allowed, stackBy, colors);
@@ -75,13 +75,37 @@ public static class DayBars
             {
                 byDate[day.Date] = day;
             }
+
+            if (contribution.Clients.Any(client =>
+                allowed.Contains(ClientRegistry.CanonicalClient(client.Client))
+                && (metric == ChartMetric.Cost
+                    ? client.Cost > 0
+                    : client.Tokens.Total > 0))
+                && (metricEnd is null
+                    || string.CompareOrdinal(contribution.Date, metricEnd) > 0))
+            {
+                metricEnd = contribution.Date;
+            }
         }
 
-        var effectiveRangeEnd = rangeEnd ?? payload.Meta.DateRange.End;
-        var end = effectiveRangeEnd.Length == 0 ? endFallback : effectiveRangeEnd;
-        // A malformed (non-empty but unparseable) range end shouldn't blank the
-        // whole chart — fall back to today's key, which is always parseable.
-        var endDay = ISODay.Parse(end) ?? ISODay.Parse(endFallback);
+        // A metric-specific tail is authoritative: a message-only tail must not
+        // move the chart, and a cost chart must not follow token-only data.
+        ISODay? endDay = null;
+        foreach (var candidate in new[]
+        {
+            metricEnd,
+            rangeEnd,
+            payload.Meta.DateRange.End,
+            endFallback,
+        })
+        {
+            if (!string.IsNullOrEmpty(candidate) && ISODay.Parse(candidate) is { } parsed)
+            {
+                endDay = parsed;
+                break;
+            }
+        }
+
         if (endDay is null)
         {
             return [];
@@ -105,13 +129,13 @@ public static class DayBars
         var grouped = new Dictionary<string, DaySegment>();
         foreach (var client in contribution.Clients)
         {
-            if (!allowed.Contains(client.Client))
+            if (!allowed.Contains(ClientRegistry.CanonicalClient(client.Client)))
             {
                 continue;
             }
 
             var tokens = client.Tokens.Total;
-            if (tokens <= 0 && client.Cost <= 0)
+            if (!UsageActivity.IsActive(tokens, client.Cost, 0))
             {
                 continue;
             }

--- a/src/TokenBar.Core/Grid.cs
+++ b/src/TokenBar.Core/Grid.cs
@@ -49,7 +49,7 @@ public static class Grid
                 var inYear = date.StartsWith(yearPrefix, StringComparison.Ordinal);
                 perDayMap.TryGetValue(date, out var entry);
                 var tokens = entry?.Tokens ?? 0;
-                var active = inYear && tokens > 0;
+                var active = inYear && entry?.IsActive == true;
                 if (active)
                 {
                     maxTokens = Math.Max(maxTokens, tokens);

--- a/src/TokenBar.Core/UsageStats.cs
+++ b/src/TokenBar.Core/UsageStats.cs
@@ -59,13 +59,22 @@ public readonly record struct ISODay(int Number)
     public int Weekday => ((Number + 4) % 7 + 7) % 7;
 }
 
-public sealed record PerDay(string Date, long Tokens, double Cost, int Intensity);
+public static class UsageActivity
+{
+    public static bool IsActive(long tokens, double cost, long messages) =>
+        tokens > 0 || cost > 0 || messages > 0;
+}
+
+public sealed record PerDay(string Date, long Tokens, double Cost, long Messages, int Intensity)
+{
+    public bool IsActive => UsageActivity.IsActive(Tokens, Cost, Messages);
+}
 
 public sealed record Streaks(int Longest, int Current)
 {
     /// <summary>Port of computeStreaks: walk every calendar day in the range;
-    /// a day is active when it has tokens. Current counts back from the range
-    /// end.</summary>
+    /// a day is active when it has tokens, cost, or messages. Current counts
+    /// back from the range end.</summary>
     public static Streaks Compute(
         IReadOnlyDictionary<string, PerDay> perDayMap, string rangeStart, string rangeEnd)
     {
@@ -77,7 +86,7 @@ public sealed record Streaks(int Longest, int Current)
         }
 
         bool Active(int n) =>
-            perDayMap.TryGetValue(new ISODay(n).Iso, out var day) && day.Tokens > 0;
+            perDayMap.TryGetValue(new ISODay(n).Iso, out var day) && day.IsActive;
 
         var longest = 0;
         var run = 0;
@@ -115,17 +124,24 @@ public sealed class UsageStats
     public IReadOnlyList<PerDay> PerDay { get; }
     public IReadOnlyDictionary<string, PerDay> PerDayMap { get; }
     public Streaks Streaks { get; }
+    /// <summary>Raw ids observed in contribution stripes, kept for display and
+    /// diagnostics. Selection membership is canonicalized internally.</summary>
     public IReadOnlyList<string> PresentClients { get; }
     public long MaxTokens { get; }
 
     /// <summary>Port of computeStats: aggregate per-day totals over
     /// <paramref name="selectedClients"/> (empty set = nothing selected; pass
-    /// all present clients for the all-agent view).</summary>
+    /// all present clients for the all-agent view). Selection membership is
+    /// canonical, while the payload's raw ids remain untouched.</summary>
     public UsageStats(UsagePayload payload, IReadOnlySet<string> selectedClients)
     {
+        var selected = selectedClients
+            .Select(ClientRegistry.CanonicalClient)
+            .ToHashSet(StringComparer.Ordinal);
         var perDay = new List<PerDay>();
         var perDayMap = new Dictionary<string, PerDay>();
         var present = new SortedSet<string>(StringComparer.Ordinal);
+        var canonicalPresent = new HashSet<string>(StringComparer.Ordinal);
         long totalTokens = 0;
         var totalCost = 0.0;
         (string Date, double Cost)? bestDay = null;
@@ -134,11 +150,14 @@ public sealed class UsageStats
         foreach (var c in payload.Contributions)
         {
             long dayTokens = 0;
+            long dayMessages = 0;
             var dayCost = 0.0;
             foreach (var cc in c.Clients)
             {
                 present.Add(cc.Client);
-                if (!selectedClients.Contains(cc.Client))
+                var canonical = ClientRegistry.CanonicalClient(cc.Client);
+                canonicalPresent.Add(canonical);
+                if (!selected.Contains(canonical))
                 {
                     continue;
                 }
@@ -148,15 +167,16 @@ public sealed class UsageStats
                 // folds these here — a wrapping/throwing += would corrupt or
                 // crash the dashboard.
                 dayTokens = dayTokens.SaturatingAdd(cc.Tokens.Total);
+                dayMessages = dayMessages.SaturatingAdd(cc.Messages);
                 dayCost += cc.Cost;
             }
 
-            if (dayTokens == 0 && dayCost == 0)
+            if (!UsageActivity.IsActive(dayTokens, dayCost, dayMessages))
             {
                 continue;
             }
 
-            var entry = new PerDay(c.Date, dayTokens, dayCost, c.Intensity);
+            var entry = new PerDay(c.Date, dayTokens, dayCost, dayMessages, c.Intensity);
             perDay.Add(entry);
             perDayMap[c.Date] = entry;
             totalTokens = totalTokens.SaturatingAdd(dayTokens);
@@ -183,7 +203,7 @@ public sealed class UsageStats
         // that case, matching a payload in which the hidden clients never
         // existed. The all-present (nothing hidden) and empty (nothing active)
         // cases keep meta.DateRange — byte-identical to before.
-        var filtering = !present.IsSubsetOf(selectedClients);
+        var filtering = !canonicalPresent.IsSubsetOf(selected);
         var selectedDates = perDay.Select(p => p.Date).ToList();
         DateRange effectiveRange;
         if (filtering && selectedDates.Count > 0)
@@ -211,13 +231,14 @@ public sealed class UsageStats
 
 public static class UsageStatsVisibility
 {
-    /// <summary>A contribution stripe is "visible activity" when its client
-    /// isn't hidden and it carries tokens or cost.</summary>
+    /// <summary>A contribution stripe is "visible activity" when its raw client
+    /// canonicalizes to a non-hidden id and it carries tokens, cost, or messages.</summary>
     private static bool IsVisible(ContributionClient cc, IReadOnlySet<string> hidden) =>
-        !hidden.Contains(cc.Client) && (cc.Tokens.Total > 0 || cc.Cost > 0);
+        !hidden.Contains(ClientRegistry.CanonicalClient(cc.Client))
+        && UsageActivity.IsActive(cc.Tokens.Total, cc.Cost, cc.Messages);
 
     /// <summary>The set of YYYY years in which at least one NON-hidden client
-    /// had activity (tokens or cost), derived from a payload's contributions.
+    /// had activity (tokens, cost, or messages), derived from a payload's contributions.
     /// Used to drop from the year picker years that only hidden clients used.
     /// Only meaningful over an all-time payload (contributions spanning every
     /// year); callers fall back to the unfiltered known-year list when the


### PR DESCRIPTION
## Summary

- define `UsageActivity` as the shared `tokens > 0 || cost > 0 || messages > 0` contract for headline stats, streaks, year visibility, 3D grid cells, and Daily rows
- canonicalize selected/hidden membership while preserving raw contribution IDs for presence diagnostics, Daily drill-down, and agent chart segments
- add `DailyRows` so the Daily lens consumes exact-client `turnsByClient` values only for selected Codex and Claude stripes
- give Tokens and Price independent metric-specific 30-day anchors, preventing message-only, hidden, unselected, and other-metric tails from shifting the chart

## Data flow

`vendor/tokscale-core` and `tb_core_ffi` already expose optional camelCase `turnsByClient` maps through `TokenBar.Interop.Contribution`. `DailyRows` now projects selected contribution stripes into active day rows, retains each raw `ContributionClient`, and queries only exact matching raw turn-map keys after canonical membership has admitted the stripe.

Supported Codex and Claude scope reports zero when the map is null, empty, or missing the exact key. Unsupported-only days omit turns. Map-only aliases and unsupported keys do not contribute, duplicate raw stripe IDs are counted once, and totals use saturating addition.

`DashboardView` passes the active `ChartMetric` into `DayBars.Build`. The builder independently finds the last positive selected token or cost datum before constructing the 30-day series; its fallback remains the selected range end, payload range end, then today's key.

## Verification

- `git diff --check`
- Core.Tests Debug on Windows x64: 391 passed
- Core.Tests Release on Windows x64: 391 passed
- x64 App build on .NET SDK 10.0.301
- ARM64 App cross-build
- Rust 1.96.1 native mapping gates: PE machine `0x8664` for x64 and `0xAA64` for ARM64
- isolated x64 fixture observed in Daily, Stats, 3D, Tokens, Price, and year selection
- fresh integration-boundary verifier: `CONFIRMED`, no P0–P4 findings

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
