### PR TITLE
feat(graph): expose local-first usage contract

### DIFF
--- a/crates/tb_core_ffi/src/lib.rs
+++ b/crates/tb_core_ffi/src/lib.rs
@@ -401,6 +401,24 @@ pub unsafe extern "C" fn tb_graph(year: *const c_char) -> *mut c_char {
     })
 }
 
+/// Contribution graph for `year` (NULL/empty = all time), computed from the
+/// local scan without reading or writing the authoritative `GRAPH_CACHE`.
+/// The engine's local-first entry also bypasses pricing resolution by
+/// construction; provider-reported message costs remain authoritative.
+///
+/// # Safety
+/// `year` must be NULL or a valid NUL-terminated string.
+#[no_mangle]
+pub unsafe extern "C" fn tb_graph_local_first(year: *const c_char) -> *mut c_char {
+    guarded("tb_graph_local_first", || {
+        let context = LocalSourceContext::current();
+        envelope(
+            unsafe { year_from(year) }
+                .and_then(|year| usage_graph::run_local_first(&context, &year)),
+        )
+    })
+}
+
 /// Force-recompute the contribution graph for `year`, bypassing the cache.
 ///
 /// # Safety
@@ -563,7 +581,41 @@ pub unsafe extern "C" fn tb_free(p: *mut c_char) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
     use usage_tail::UsageTailer;
+
+    static GRAPH_CACHE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+    impl EnvGuard {
+        fn set(vars: &[(&'static str, &std::ffi::OsStr)]) -> Self {
+            let guard = Self(
+                vars.iter()
+                    .map(|(key, _)| (*key, std::env::var_os(key)))
+                    .collect(),
+            );
+            unsafe {
+                for (key, value) in vars {
+                    std::env::set_var(key, value);
+                }
+            }
+            guard
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                for (key, previous) in self.0.drain(..) {
+                    match previous {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn select_user_home_prefers_non_empty_home() {
@@ -855,6 +907,89 @@ mod tests {
         let st = lock_tick();
         assert!(!st.in_flight);
         assert!(st.last.is_none()); // unstamped → next poll re-ticks
+    }
+
+    #[test]
+    #[allow(clippy::undocumented_unsafe_blocks)]
+    fn local_first_is_cache_isolated_in_both_call_orders_and_validates_abi_year() {
+        let _lock = GRAPH_CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let root = std::env::temp_dir().join(format!(
+            "tokenbar-ffi-local-first-{}-{}",
+            std::process::id(),
+            Instant::now().elapsed().as_nanos()
+        ));
+        let data_root = root.join("data");
+        std::fs::create_dir_all(&data_root).unwrap();
+        let _env = EnvGuard::set(&[
+            ("HOME", root.as_os_str()),
+            ("TOKSCALE_CONFIG_DIR", root.as_os_str()),
+            ("XDG_DATA_HOME", data_root.as_os_str()),
+            ("TOKSCALE_PRICING_CACHE_ONLY", std::ffi::OsStr::new("1")),
+        ]);
+        GRAPH_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+
+        // Best-effort first populates the authoritative cache; local-first must
+        // neither hit it nor change its payload.
+        let best_effort = unsafe { take(tb_graph(std::ptr::null())) };
+        assert!(best_effort.contains(r#""ok":true"#), "{best_effort}");
+        let cached_after_best_effort = GRAPH_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get("")
+            .cloned()
+            .expect("best-effort graph should populate its cache");
+        let local_first = unsafe { take(tb_graph_local_first(std::ptr::null())) };
+        assert!(local_first.contains(r#""ok":true"#), "{local_first}");
+        assert!(
+            local_first.contains(r#""pricingMode":"localOnly""#),
+            "{local_first}"
+        );
+        assert_eq!(
+            GRAPH_CACHE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .get("")
+                .cloned(),
+            Some(cached_after_best_effort)
+        );
+
+        // Reverse order: local-first computes an empty fixture without creating
+        // an authoritative cache entry, then the legacy path still can create it.
+        GRAPH_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+        let local_first_first = unsafe { take(tb_graph_local_first(std::ptr::null())) };
+        assert!(
+            local_first_first.contains(r#""ok":true"#),
+            "{local_first_first}"
+        );
+        assert!(GRAPH_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty());
+        let _best_effort_after = unsafe { take(tb_graph(std::ptr::null())) };
+        assert!(GRAPH_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains_key(""));
+
+        let invalid_year = std::ffi::CString::new("26").unwrap();
+        let invalid = unsafe { take(tb_graph_local_first(invalid_year.as_ptr())) };
+        assert!(invalid.contains(r#""ok":false"#), "{invalid}");
+        assert!(invalid.contains("invalid year filter"), "{invalid}");
+
+        GRAPH_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+        drop(_env);
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/crates/tb_core_ffi/src/usage_graph.rs
+++ b/crates/tb_core_ffi/src/usage_graph.rs
@@ -88,6 +88,8 @@ struct ExportMeta {
     generated_at: String,
     version: String,
     date_range: DateRange,
+    pricing_mode: String,
+    cost_coverage: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -101,12 +103,25 @@ struct TokenContributionData {
 
 /// Build the contribution-graph payload for `year` (empty string = all time).
 ///
-/// Invoked from `lib.rs` inside `spawn_blocking`, so the calling thread has no
-/// Tokio reactor — we spin up a short-lived current-thread runtime to drive
-/// the async `generate_local_graph_report`. That entry point uses cached
-/// pricing with a graceful offline fallback, and `PricingService` is a process
-/// -wide `OnceCell`, so the network fetch happens at most once per launch.
+/// The existing path remains best-effort and retains its pricing fallback.
 pub(crate) fn run(context: &crate::LocalSourceContext, year: &str) -> Result<Value, String> {
+    run_mode(context, year, false)
+}
+
+/// Build a per-call local-first graph. The engine entry structurally bypasses
+/// pricing resolution and therefore cannot invoke an outbound pricing loader.
+pub(crate) fn run_local_first(
+    context: &crate::LocalSourceContext,
+    year: &str,
+) -> Result<Value, String> {
+    run_mode(context, year, true)
+}
+
+fn run_mode(
+    context: &crate::LocalSourceContext,
+    year: &str,
+    local_only: bool,
+) -> Result<Value, String> {
     let year = normalize_year(year)?;
     let options = context.report_options(year, None);
 
@@ -114,9 +129,17 @@ pub(crate) fn run(context: &crate::LocalSourceContext, year: &str) -> Result<Val
         .enable_all()
         .build()
         .map_err(|e| format!("build runtime: {}", e))?;
-    let graph = runtime.block_on(tokscale_core::generate_local_graph_report(options))?;
+    let report = if local_only {
+        runtime.block_on(tokscale_core::generate_local_graph_report_local_only(
+            options,
+        ))?
+    } else {
+        runtime.block_on(tokscale_core::generate_local_graph_report_with_contract(
+            options,
+        ))?
+    };
 
-    let payload = map_graph(graph);
+    let payload = map_graph(report);
     serde_json::to_value(payload).map_err(|e| format!("serialize usage graph: {}", e))
 }
 
@@ -137,7 +160,15 @@ fn normalize_year(year: &str) -> Result<Option<String>, String> {
 /// `range_start/end`, the frontend expects nested `{ start, end }`. Extra
 /// tokscale fields (`active_time_ms`, `time_metrics`, `processing_time_ms`)
 /// are intentionally dropped. The reported `version` is branded as tokenbar.
-fn map_graph(graph: tokscale_core::GraphResult) -> TokenContributionData {
+fn map_graph(report: tokscale_core::GraphResultWithContract) -> TokenContributionData {
+    let (graph, contract) = report.into_parts();
+    map_graph_with_contract(graph, contract)
+}
+
+fn map_graph_with_contract(
+    graph: tokscale_core::GraphResult,
+    contract: tokscale_core::GraphMetaContract,
+) -> TokenContributionData {
     TokenContributionData {
         meta: ExportMeta {
             generated_at: graph.meta.generated_at,
@@ -146,6 +177,8 @@ fn map_graph(graph: tokscale_core::GraphResult) -> TokenContributionData {
                 start: graph.meta.date_range_start,
                 end: graph.meta.date_range_end,
             },
+            pricing_mode: contract.pricing_mode.as_wire().to_string(),
+            cost_coverage: contract.cost_coverage.as_wire().to_string(),
         },
         summary: DataSummary {
             total_tokens: graph.summary.total_tokens,
@@ -235,6 +268,30 @@ mod tests {
             active_time_ms: None,
             turns_by_client,
         }
+    }
+
+    #[test]
+    fn maps_graph_meta_to_exact_camel_case_mode_and_coverage() {
+        let graph = tokscale_core::build_graph_result_from_messages(&[], None);
+        let payload = map_graph_with_contract(
+            graph,
+            tokscale_core::GraphMetaContract {
+                pricing_mode: tokscale_core::GraphPricingMode::LocalOnly,
+                cost_coverage: tokscale_core::CostCoverage::Partial,
+            },
+        );
+        let wire = serde_json::to_value(payload).unwrap();
+        assert_eq!(wire["meta"]["pricingMode"], "localOnly");
+        assert_eq!(wire["meta"]["costCoverage"], "partial");
+        assert!(wire["meta"].get("pricing_mode").is_none());
+        assert!(wire["meta"].get("cost_coverage").is_none());
+    }
+
+    #[test]
+    fn invalid_year_is_rejected_before_engine_scan() {
+        let context = crate::LocalSourceContext { home_dir: None };
+        let error = run_local_first(&context, "26").unwrap_err();
+        assert!(error.contains("invalid year filter"));
     }
 
     #[test]

--- a/crosscheck/README.md
+++ b/crosscheck/README.md
@@ -25,7 +25,7 @@ Canonical fixture fingerprints:
 |---|---:|---|
 | `fixtures/provider-quota-pace-v3.json` | 7,625 | `412f6ffd05f23f00266820c243376f265d29024d9e419217e55f8e1559b36c50` |
 | `fixtures/usage-pace.json` | 13,532 | `9a83616ea5053b2073dcfbcfb975c923d8597c0c41ddd5877ac0ddd8a9b7806c` |
-| `fixtures/format.json` | 7,504 | `408ac7604e1661b2732c05c8e113d62b6d365cd8ea02004933f681cf99ad0913` |
+| `fixtures/format.json` | 7,573 | `eff7638ba5c1826ae2dff3a24055f907d718b15eba801db30b3066db1efb9d6d` |
 
 Observed provider-v3 output fingerprints at the reconciliation gate:
 

--- a/crosscheck/fixtures/format.json
+++ b/crosscheck/fixtures/format.json
@@ -3,7 +3,9 @@
     "meta": {
       "generatedAt": "2026-07-10T10:30:00Z",
       "version": "crosscheck",
-      "dateRange": { "start": "2026-07-08", "end": "2026-07-10" }
+      "dateRange": { "start": "2026-07-08", "end": "2026-07-10" },
+      "pricingMode": "bestEffort",
+      "costCoverage": "complete"
     },
     "summary": {
       "totalTokens": 5100, "totalCost": 2.13, "totalDays": 2, "activeDays": 2,

--- a/include/ctb.h
+++ b/include/ctb.h
@@ -57,6 +57,9 @@ char *tb_probe(void);
 
 // Contribution graph (UsagePayload). Serves a <=30s-old cached payload.
 char *tb_graph(const char *year);
+// Contribution graph, local-first per call: bypasses pricing resolution and the
+// authoritative year-only graph cache. Provider-reported costs remain intact.
+char *tb_graph_local_first(const char *year);
 // Contribution graph, always recomputed (cache refreshed as a side effect).
 char *tb_refresh_graph(const char *year);
 

--- a/src/TokenBar.Core.Tests/DailyRowsTests.cs
+++ b/src/TokenBar.Core.Tests/DailyRowsTests.cs
@@ -18,7 +18,7 @@ public class DailyRowsTests
 
     private static UsagePayload Payload(params Contribution[] days) =>
         new(
-            new UsageMeta("g", "v", new DateRange("2026-06-01", "2026-06-30")),
+            new UsageMeta("g", "v", new DateRange("2026-06-01", "2026-06-30"), PricingMode.BestEffort, CostCoverage.Complete),
             new UsageSummary(0, 0, 0, 0, 0, 0, [], []), [], days);
 
     [Fact]

--- a/src/TokenBar.Core.Tests/DayBarsTests.cs
+++ b/src/TokenBar.Core.Tests/DayBarsTests.cs
@@ -16,7 +16,7 @@ public class DayBarsTests
 
     private static UsagePayload Payload(string metaEnd, params Contribution[] days) =>
         new(
-            new UsageMeta("g", "v", new DateRange("2026-06-01", metaEnd)),
+            new UsageMeta("g", "v", new DateRange("2026-06-01", metaEnd), PricingMode.BestEffort, CostCoverage.Complete),
             new UsageSummary(0, 0, 0, 0, 0, 0, [], []),
             [],
             days);

--- a/src/TokenBar.Core.Tests/DtoDecodeTests.cs
+++ b/src/TokenBar.Core.Tests/DtoDecodeTests.cs
@@ -362,7 +362,8 @@ public class DtoDecodeTests
     {
         var json = """
             {"ok":true,"data":{
-             "meta":{"generatedAt":"g","version":"v","dateRange":{"start":"2026-01-01","end":"2026-07-02"}},
+             "meta":{"generatedAt":"g","version":"v","dateRange":{"start":"2026-01-01","end":"2026-07-02"},
+               "pricingMode":"localOnly","costCoverage":"partial"},
              "summary":{"totalTokens":100,"totalCost":1.5,"totalDays":10,"activeDays":8,
                "averagePerDay":10.0,"maxCostInSingleDay":0.9,"clients":["claude"],"models":["m"]},
              "years":[{"year":"2026","totalTokens":100,"totalCost":1.5,
@@ -376,9 +377,63 @@ public class DtoDecodeTests
             """;
         var p = TbCore.DecodeEnvelope<UsagePayload>(json);
         Assert.Equal(8, p.Summary.ActiveDays);
+        Assert.Equal(PricingMode.LocalOnly, p.Meta.PricingMode);
+        Assert.Equal(CostCoverage.Partial, p.Meta.CostCoverage);
         Assert.Equal("anthropic", p.Contributions[0].Clients[0].ProviderId);
         Assert.Equal(15, p.Contributions[0].TokenBreakdown.CacheRead);
         Assert.Equal(2, p.Contributions[0].TurnsByClient!["cc-mirror/foo"]);
+    }
+
+    private static string GraphEnvelope(string metadata) =>
+        $$"""
+        {
+          "ok":true,
+          "data":{
+            "meta":{
+              "generatedAt":"g",
+              "version":"v",
+              "dateRange":{"start":"2026-01-01","end":"2026-07-02"}{{metadata}}
+            },
+            "summary":{
+              "totalTokens":0,
+              "totalCost":0,
+              "totalDays":0,
+              "activeDays":0,
+              "averagePerDay":0,
+              "maxCostInSingleDay":0,
+              "clients":[],
+              "models":[]
+            },
+            "years":[],
+            "contributions":[]
+          }
+        }
+        """;
+
+    [Fact]
+    public void UsageMetaRequiresKnownStringModeAndCoverage()
+    {
+        var payload = TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"pricingMode\":\"localOnly\",\"costCoverage\":\"complete\""));
+        Assert.Equal(PricingMode.LocalOnly, payload.Meta.PricingMode);
+        Assert.Equal(CostCoverage.Complete, payload.Meta.CostCoverage);
+
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"costCoverage\":\"complete\"")));
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"pricingMode\":\"localOnly\"")));
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"pricingMode\":null,\"costCoverage\":\"complete\"")));
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"pricingMode\":\"future\",\"costCoverage\":\"complete\"")));
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"pricingMode\":0,\"costCoverage\":\"complete\"")));
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"pricingMode\":\"localOnly\",\"costCoverage\":null")));
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"pricingMode\":\"localOnly\",\"costCoverage\":\"future\"")));
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<UsagePayload>(
+            GraphEnvelope(",\"pricingMode\":\"localOnly\",\"costCoverage\":0")));
     }
 
     [Fact]

--- a/src/TokenBar.Core.Tests/GraphTests.cs
+++ b/src/TokenBar.Core.Tests/GraphTests.cs
@@ -41,7 +41,7 @@ public class GraphTests
 
     private static UsagePayload PayloadWith(params Contribution[] contributions) =>
         new(
-            new UsageMeta("g", "v", new DateRange("2026-07-01", "2026-07-02")),
+            new UsageMeta("g", "v", new DateRange("2026-07-01", "2026-07-02"), PricingMode.BestEffort, CostCoverage.Complete),
             new UsageSummary(999, 9.9, 2, 2, 5, 5, ["claude", "codex"], ["m"]),
             [],
             contributions);

--- a/src/TokenBar.Core.Tests/UsageStatsTests.cs
+++ b/src/TokenBar.Core.Tests/UsageStatsTests.cs
@@ -19,7 +19,7 @@ public class UsageStatsTests
 
     private static UsagePayload Payload(string metaStart, string metaEnd, params Contribution[] days) =>
         new(
-            new UsageMeta("g", "v", new DateRange(metaStart, metaEnd)),
+            new UsageMeta("g", "v", new DateRange(metaStart, metaEnd), PricingMode.BestEffort, CostCoverage.Complete),
             new UsageSummary(0, 0, 0, 0, 0, 0, [], []),
             [],
             days);

--- a/src/TokenBar.CrossCheck/Program.cs
+++ b/src/TokenBar.CrossCheck/Program.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using TokenBar.Core;
 using TokenBar.Interop;
@@ -32,6 +33,11 @@ var wire = new JsonSerializerOptions(JsonSerializerDefaults.Web)
 {
     RespectRequiredConstructorParameters = true,
     RespectNullableAnnotations = true,
+    Converters =
+    {
+        new JsonStringEnumConverter<PricingMode>(allowIntegerValues: false),
+        new JsonStringEnumConverter<CostCoverage>(allowIntegerValues: false),
+    },
 };
 var outOpts = new JsonSerializerOptions { WriteIndented = true };
 

--- a/src/TokenBar.Interop/Graph.cs
+++ b/src/TokenBar.Interop/Graph.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace TokenBar.Interop;
 
 // Contribution-graph payload (`UsagePayload` in the Tauri frontend's
@@ -81,10 +83,35 @@ public sealed record YearMeta(
     double TotalCost,
     DateRange Range);
 
+public enum PricingMode
+{
+    [JsonStringEnumMemberName("localOnly")]
+    LocalOnly,
+
+    [JsonStringEnumMemberName("bestEffort")]
+    BestEffort,
+}
+
+public enum CostCoverage
+{
+    [JsonStringEnumMemberName("complete")]
+    Complete,
+
+    [JsonStringEnumMemberName("partial")]
+    Partial,
+
+    [JsonStringEnumMemberName("none")]
+    None,
+}
+
 public sealed record UsageMeta(
     string GeneratedAt,
     string Version,
-    DateRange DateRange);
+    DateRange DateRange,
+    [property: JsonRequired]
+    [property: JsonPropertyName("pricingMode")] PricingMode PricingMode,
+    [property: JsonRequired]
+    [property: JsonPropertyName("costCoverage")] CostCoverage CostCoverage);
 
 public sealed record UsageSummary(
     long TotalTokens,

--- a/src/TokenBar.Interop/NativeMethods.cs
+++ b/src/TokenBar.Interop/NativeMethods.cs
@@ -22,6 +22,9 @@ internal static partial class NativeMethods
     internal static partial nint tb_graph(string? year);
 
     [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial nint tb_graph_local_first(string? year);
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
     internal static partial nint tb_refresh_graph(string? year);
 
     [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]

--- a/src/TokenBar.Interop/TbCore.cs
+++ b/src/TokenBar.Interop/TbCore.cs
@@ -27,6 +27,8 @@ public static class TbCore
         Converters =
         {
             new JsonStringEnumConverter<FilterParityStatus>(allowIntegerValues: false),
+            new JsonStringEnumConverter<PricingMode>(allowIntegerValues: false),
+            new JsonStringEnumConverter<CostCoverage>(allowIntegerValues: false),
         },
     };
 
@@ -47,6 +49,14 @@ public static class TbCore
     /// time). Served from a &lt;=30s cache inside the cdylib when warm.</summary>
     public static UsagePayload Graph(string? year = null) =>
         Unwrap<UsagePayload>(NativeMethods.tb_graph(year));
+
+    /// <summary>
+    /// Contribution graph from the local scan for this call only. This is a
+    /// blocking off-UI-thread operation; it bypasses outbound pricing
+    /// resolution and the authoritative year-only graph cache.
+    /// </summary>
+    public static UsagePayload GraphLocalFirst(string? year = null) =>
+        Unwrap<UsagePayload>(NativeMethods.tb_graph_local_first(year));
 
     /// <summary>Contribution graph, always recomputed.</summary>
     public static UsagePayload RefreshGraph(string? year = null) =>

--- a/src/TokenBar.Smoke/Program.cs
+++ b/src/TokenBar.Smoke/Program.cs
@@ -60,6 +60,16 @@ Step("tb_graph", () =>
            $"totalTokens={g.Summary.TotalTokens} totalCost={g.Summary.TotalCost:F2}";
 });
 
+Step("tb_graph_local_first", () =>
+{
+    var g = TbCore.GraphLocalFirst();
+    if (expectedClient is not null && !g.Summary.Clients.Contains(expectedClient))
+        throw new InvalidOperationException(
+            $"tb_graph_local_first expected client '{expectedClient}' in Summary.Clients");
+    return $"ok days={g.Contributions.Count} totalTokens={g.Summary.TotalTokens} " +
+           $"mode={g.Meta.PricingMode} coverage={g.Meta.CostCoverage}";
+});
+
 Step("tb_refresh_graph", () =>
 {
     var g = TbCore.RefreshGraph();


### PR DESCRIPTION
## Summary

- pin `vendor/tokscale-core` to merged engine revision `731a2dcc2589cbeaf82150933331b5b2b6b590ff` from engine PR #8
- add `tb_graph_local_first` across the Rust C ABI, `ctb.h`, C# P/Invoke, and `TbCore.GraphLocalFirst`
- map instance-bound `pricingMode` and `costCoverage` metadata into the graph payload and enforce strict known-string DTO decoding
- verify local-first is isolated from the existing authoritative graph cache in both call orders
- exercise the new entry point in the native Rust↔C# smoke

## Runtime contract

`tb_graph_local_first` performs a per-call local scan through the engine's `GraphPricingMode::LocalOnly`. It structurally bypasses pricing resolution and does not read or write the existing `GRAPH_CACHE`. Provider-reported costs remain intact.

The existing `tb_graph` remains best-effort and cache-backed. `tb_refresh_graph` retains its existing forced-refresh behavior.

The C# `UsageMeta` contract requires:

- `pricingMode`: `localOnly` or `bestEffort`
- `costCoverage`: `complete`, `partial`, or `none`

Missing, null, unknown, and numeric enum values fail decoding rather than silently defaulting.

## Scope

This is `ALIGN-V13-B1-E1` only. It establishes the engine/FFI/DTO foundation. It does **not** wire Dashboard startup to local-first, change Dashboard/TrayFeed authority, add graph snapshots, or implement restored/checking/fresh/stale UI; those remain later B2–B4 slices.

## Verification

- `cargo build --workspace --release --locked`
- `cargo test --workspace --release --locked`
  - `tb_core_ffi`: 324 passed
  - `tokscale-core`: 1368 passed, 1 ignored
  - integrations: 10 + 1 + 3 + 1 passed
- offline cached NuGet restore with package sources cleared
- `TokenBar.Core.Tests`: 392 passed
- isolated native Rust↔C# smoke: all exercised local entry points passed; `tb_graph_local_first` decoded as `LocalOnly` / `Complete`; network-bound agent usage skipped
- `git diff --check`
- fresh cross-language verifier: `CONFIRMED`

Engine dependency: https://github.com/Nanako0129/tokscale-core/pull/8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
