### PR TITLE
feat(graph): publish local usage before cost authority

### DIFF
--- a/src/TokenBar.App/App.xaml.cs
+++ b/src/TokenBar.App/App.xaml.cs
@@ -11,6 +11,7 @@ public partial class App : Application
 
     private TrayService? _tray;
     private FlyoutWindow? _flyout;
+    private GraphRequestCoordinator? _graphCoordinator;
     private bool _started;
     private bool _startupSmokeRequested;
     private string? _startupSmokePath;
@@ -54,10 +55,12 @@ public partial class App : Application
 
         try
         {
+            DevLog.Write("launch: creating graph coordinator");
+            _graphCoordinator = new GraphRequestCoordinator();
             DevLog.Write("launch: creating flyout");
-            _flyout = new FlyoutWindow();
+            _flyout = new FlyoutWindow(_graphCoordinator);
             DevLog.Write("launch: creating tray");
-            _tray = new TrayService(_flyout);
+            _tray = new TrayService(_flyout, _graphCoordinator);
             DevLog.Write("launch: tray up");
 
             if (Environment.GetCommandLineArgs().Contains("--dump-tray-icons"))

--- a/src/TokenBar.App/App.xaml.cs
+++ b/src/TokenBar.App/App.xaml.cs
@@ -56,7 +56,8 @@ public partial class App : Application
         try
         {
             DevLog.Write("launch: creating graph coordinator");
-            _graphCoordinator = new GraphRequestCoordinator();
+            _graphCoordinator = new GraphRequestCoordinator(
+                boost: ProcessPower.Boost);
             DevLog.Write("launch: creating flyout");
             _flyout = new FlyoutWindow(_graphCoordinator);
             DevLog.Write("launch: creating tray");

--- a/src/TokenBar.App/CostSurfaceProjection.cs
+++ b/src/TokenBar.App/CostSurfaceProjection.cs
@@ -1,0 +1,140 @@
+using TokenBar.Core;
+using TokenBar.Interop;
+
+namespace TokenBar.App;
+
+/// <summary>One authority-aware policy for every cost-bearing surface. The
+/// graph metadata, accepted by GraphConsumerState, is the only authority input;
+/// a numeric cost is never used to infer readiness.</summary>
+public static class CostSurfaceProjection
+{
+    public const string Checking = "Checking";
+    public const string ChartChecking = "Checking cost…";
+
+    public static bool CanUseCost(bool authoritative) => authoritative;
+
+    public static bool IsChartCostChecking(
+        bool authoritative, ChartMetric requested) =>
+        !authoritative && requested == ChartMetric.Cost;
+
+    public static bool IsAuthoritative(UsagePayload? graph) =>
+        graph?.Meta.PricingMode == PricingMode.BestEffort
+        && graph.Meta.CostCoverage == CostCoverage.Complete;
+
+    public static string CostText(double cost, bool authoritative) =>
+        authoritative ? Format.Usd(cost) : Checking;
+
+    public static string HeaderCostLine(
+        double todayCost, UsageStats stats, bool authoritative) =>
+        authoritative
+            ? $"{Format.Usd(todayCost)} today · "
+                + $"{Format.Usd(stats.TotalCost)} all time · {stats.ActiveDays} active days"
+            : $"{Checking} · {stats.ActiveDays} active days";
+
+    public static string HeaderCostLine(UsageStats stats, bool authoritative) =>
+        HeaderCostLine(
+            stats.PerDayMap.TryGetValue(Format.TodayKey(), out var today)
+                ? today.Cost
+                : 0,
+            stats,
+            authoritative);
+
+    public static string ModelsSubtitle(
+        IReadOnlyList<ModelReportEntry> entries, bool authoritative) =>
+        $"{entries.Count} models · "
+        + (authoritative ? Format.Usd(entries.Sum(e => e.Cost)) : Checking);
+
+    public static IReadOnlyList<ModelReportEntry> OrderModels(
+        IEnumerable<ModelReportEntry> entries, bool authoritative)
+    {
+        var query = entries
+            .OrderByDescending(e => authoritative ? FiniteOrZero(e.Cost) : e.Total)
+            .ThenBy(e => e.Provider, StringComparer.Ordinal)
+            .ThenBy(e => e.Model, StringComparer.Ordinal)
+            .ThenBy(e => e.Client, StringComparer.Ordinal);
+        return [.. query];
+    }
+
+    public static ModelReportEntry? FavoriteModel(
+        IEnumerable<ModelReportEntry> entries, bool authoritative) =>
+        OrderModels(entries, authoritative).FirstOrDefault();
+
+    public static IReadOnlyList<ContributionClient> OrderContributionClients(
+        IEnumerable<ContributionClient> clients, bool authoritative)
+    {
+        var query = clients
+            .OrderByDescending(e => authoritative ? FiniteOrZero(e.Cost) : e.Tokens.Total)
+            .ThenBy(e => e.ProviderId, StringComparer.Ordinal)
+            .ThenBy(e => e.ModelId, StringComparer.Ordinal)
+            .ThenBy(e => e.Client, StringComparer.Ordinal);
+        return [.. query];
+    }
+
+    public static string BestDayText((string Date, double Cost)? bestDay, bool authoritative) =>
+        !authoritative ? Checking
+        : bestDay is { } best ? Format.MonthDay(best.Date) : "—";
+
+    public static ChartMetric EffectiveMetric(bool authoritative, ChartMetric requested) =>
+        authoritative || requested != ChartMetric.Cost ? requested : ChartMetric.Tokens;
+
+    public static string ChartCostLabel(bool authoritative) =>
+        authoritative ? "Price" : "Price · Checking";
+
+    public static IReadOnlyList<DaySegment> OrderDaySegments(
+        IEnumerable<DaySegment> segments,
+        bool authoritative,
+        ChartMetric requested)
+    {
+        var metric = EffectiveMetric(authoritative, requested);
+        var query = metric == ChartMetric.Cost
+            ? segments.OrderByDescending(s => s.Cost)
+            : segments.OrderByDescending(s => s.Tokens);
+        return [.. query.ThenBy(s => s.Key, StringComparer.Ordinal)];
+    }
+
+    public static IReadOnlyList<AgentReportEntry> OrderAgents(
+        IEnumerable<AgentReportEntry> entries, bool authoritative)
+    {
+        var query = entries
+            .OrderByDescending(e => authoritative ? FiniteOrZero(e.Cost) : e.Total)
+            .ThenBy(e => e.Agent, StringComparer.Ordinal);
+        return [.. query];
+    }
+
+    public static double AgentScale(
+        IReadOnlyList<AgentReportEntry> entries, bool authoritative)
+    {
+        var max = entries.Count == 0
+            ? 0
+            : entries.Max(e => authoritative ? FiniteOrZero(e.Cost) : e.Total);
+        return Math.Max(max, authoritative ? 0.0001 : 1);
+    }
+
+    public static double AgentBarValue(AgentReportEntry entry, bool authoritative) =>
+        authoritative ? FiniteOrZero(entry.Cost) : entry.Total;
+
+    public static string AgentsTitle(bool authoritative) =>
+        authoritative ? "Agents by cost" : "Agents by tokens";
+
+    public static string TrayTitle(
+        TrayMode mode,
+        TrayTotals? totals,
+        double? tokensPerMin,
+        double? quotaRemaining,
+        bool authoritative) =>
+        !authoritative
+            && mode is (TrayMode.TodayCost or TrayMode.TotalCost)
+            ? Checking
+            : mode.Title(totals, tokensPerMin, quotaRemaining);
+
+    public static string HourlyCost(double cost, bool authoritative) =>
+        CostText(cost, authoritative);
+
+    public static string DayTipCost(double cost, bool authoritative) =>
+        CostText(cost, authoritative);
+
+    public static string ModelTipCost(double cost, bool authoritative) =>
+        CostText(cost, authoritative);
+
+    private static double FiniteOrZero(double value) => double.IsFinite(value) ? value : 0;
+}

--- a/src/TokenBar.App/DashboardModel.cs
+++ b/src/TokenBar.App/DashboardModel.cs
@@ -657,18 +657,23 @@ public sealed class DashboardModel
 
     private void OnGraphCompleted(GraphRequestCompletion completion)
     {
-        if (!_polling || !_graphState.IsCurrent(completion.RequestId))
+        var decision = GraphCompletionPolicy.Decide(
+            _graphState.IsCurrent(completion.RequestId),
+            _polling,
+            _year == completion.RequestId.Query.Year,
+            Volatile.Read(ref _forceRequested) == 1,
+            _refreshing);
+        if (!decision.IsCurrent)
         {
             return;
         }
 
         Volatile.Write(ref _slowInFlight, 0);
-        if (_year != completion.RequestId.Query.Year
-            || Volatile.Read(ref _forceRequested) == 1)
+        if (decision.ShouldRerun)
         {
             RefreshSlow();
         }
-        else if (_refreshing)
+        else if (decision.ClearRefreshing)
         {
             _refreshing = false;
             _ = _dispatcher.TryEnqueue(() => Updated?.Invoke());

--- a/src/TokenBar.App/DashboardModel.cs
+++ b/src/TokenBar.App/DashboardModel.cs
@@ -146,15 +146,17 @@ public sealed class DashboardModel
     {
         var flag = Environment.GetCommandLineArgs()
             .FirstOrDefault(a => a.StartsWith("--year=", StringComparison.Ordinal));
-        return flag is not null
-            ? (flag["--year=".Length..] is { Length: > 0 } y ? y : null)
+        var year = flag is not null
+            ? flag["--year=".Length..]
             : AppSettings.Store.GetString("tokenbar.dashboard.year");
+        return GraphQuery.Normalize(year).Year;
     }
 
     /// <summary>Switch the year filter and re-fetch every lens for the new
     /// slice (served from the engine's per-year cache when fresh).</summary>
     public void SetYear(string? year)
     {
+        year = GraphQuery.Normalize(year).Year;
         lock (_yearGate)
         {
             if (year == _year)

--- a/src/TokenBar.App/DashboardModel.cs
+++ b/src/TokenBar.App/DashboardModel.cs
@@ -497,9 +497,10 @@ public sealed class DashboardModel
 
         if (previous is { } old && old.Query != requestId.Query)
         {
+            // Year payloads cannot reconstruct hidden-only year visibility.
+            // Keep the retained all-time graph while clearing the rendered query.
             Current = null;
             _lastSnapshot = null;
-            _allTimeGraph = null;
             Updated?.Invoke();
             return;
         }
@@ -560,19 +561,9 @@ public sealed class DashboardModel
             }
 
             var year = publication.RequestId.Query.Year;
-            if (year is not null
-                && !publication.Payload.Years.Any(y => y.Year == year))
+            if (GraphYearPolicy.ShouldClearToAllTime(_year, publication))
             {
-                lock (_yearGate)
-                {
-                    if (_year == year)
-                    {
-                        _year = null;
-                        AppSettings.Store.Remove("tokenbar.dashboard.year");
-                    }
-                }
-
-                Updated?.Invoke();
+                SetYear(null);
                 return;
             }
 

--- a/src/TokenBar.App/DashboardModel.cs
+++ b/src/TokenBar.App/DashboardModel.cs
@@ -55,6 +55,7 @@ public sealed class DashboardModel
     private bool _selectionInitialized;
     private int _lazyInFlight;
     private int _lazyPending;
+    private GraphRequestId? _lazyGraphRequestId;
 
     public string? Year => _year;
 
@@ -175,12 +176,9 @@ public sealed class DashboardModel
             }
         }
 
-        // Drop the old year's lazy lenses now: the graph publishes for the
-        // new year before the lens refetch lands, and a lingering Hourly/
-        // Agents report would render the old year's rows under the new
-        // filter until then.
+        // Drop the old year's lazy lenses now. The next exact graph request
+        // publication schedules their replacement once for that request.
         ClearLazyReports(emptySelection: SelectionIsEmpty());
-        RequestLazyRefresh();
 
         _refreshing = true; // macOS setYear spins the header control too
         RefreshSlow(); // an in-flight lane re-runs itself when the year flips
@@ -611,7 +609,12 @@ public sealed class DashboardModel
             };
             _lastSnapshot = Current;
             Updated?.Invoke();
-            RequestLazyRefresh();
+            if (GraphLazyRefreshPolicy.ShouldRequest(
+                    _lazyGraphRequestId, publication.RequestId))
+            {
+                _lazyGraphRequestId = publication.RequestId;
+                RequestLazyRefresh();
+            }
         });
     }
 

--- a/src/TokenBar.App/DashboardModel.cs
+++ b/src/TokenBar.App/DashboardModel.cs
@@ -428,7 +428,11 @@ public sealed class DashboardModel
         Volatile.Write(ref _slowInFlight, 1);
         var year = _year;
         var force = Interlocked.Exchange(ref _forceRequested, 0) == 1;
-        _graphCoordinator.Request(year, force, OnGraphRequestStarted);
+        _graphCoordinator.Request(
+            year,
+            force,
+            OnGraphRequestStarted,
+            OnGraphPublished);
     }
 
     private void AttachGraph(string? year)

--- a/src/TokenBar.App/DashboardModel.cs
+++ b/src/TokenBar.App/DashboardModel.cs
@@ -16,6 +16,8 @@ public sealed class DashboardModel
     private static Snapshot? _lastSnapshot; // process lifetime, like macOS
 
     private readonly DispatcherQueue _dispatcher;
+    private readonly GraphRequestCoordinator _graphCoordinator;
+    private readonly GraphConsumerState _graphState = new();
     private DispatcherQueueTimer? _slowTimer;
     private DispatcherQueueTimer? _fastTimer;
     // 0/1 via Interlocked throughout: every gate is entered on the UI thread
@@ -39,6 +41,9 @@ public sealed class DashboardModel
     private volatile string? _year = ResolveYear();
     private volatile List<string> _knownYears = [];
     private volatile UsagePayload? _allTimeGraph;
+    private GraphRequestId? _snapshotRequestId;
+    private GraphRequestId? _pendingModelRequestId;
+    private ModelReport? _pendingModel;
 
     // Hourly/Agents are already aggregated across clients, so their FFI scans
     // capture one immutable selection generation. Graph/Models stay all-client.
@@ -176,7 +181,6 @@ public sealed class DashboardModel
         RequestLazyRefresh();
 
         _refreshing = true; // macOS setYear spins the header control too
-        Updated?.Invoke();
         RefreshSlow(); // an in-flight lane re-runs itself when the year flips
     }
 
@@ -185,6 +189,7 @@ public sealed class DashboardModel
     // spinner and holds until the pass that serves the request completes.
     private int _forceRequested;
     private volatile bool _refreshing;
+    private volatile bool _polling;
 
     public bool Refreshing => _refreshing;
 
@@ -203,9 +208,15 @@ public sealed class DashboardModel
         RefreshSlow();
     }
 
-    public DashboardModel(DispatcherQueue dispatcher)
+    public DashboardModel(
+        DispatcherQueue dispatcher,
+        GraphRequestCoordinator graphCoordinator)
     {
         _dispatcher = dispatcher;
+        _graphCoordinator = graphCoordinator;
+        _graphCoordinator.Started += OnGraphStarted;
+        _graphCoordinator.Published += OnGraphPublished;
+        _graphCoordinator.Completed += OnGraphCompleted;
         if (_lastSnapshot is not null)
         {
             Current = _lastSnapshot;
@@ -222,7 +233,8 @@ public sealed class DashboardModel
         AgentUsagePayload? Quota,
         double TokensPerMin,
         IReadOnlyList<TraceBucket> Trace,
-        DateTimeOffset FetchedAt)
+        DateTimeOffset FetchedAt,
+        bool CostAuthoritative = false)
     {
         // Lazily-loaded lenses (macOS ensureData parity): fetched on first
         // visit, then refreshed by the slow lane like everything else.
@@ -362,6 +374,7 @@ public sealed class DashboardModel
     /// both cadences, then 60s / 10s timers.</summary>
     public void Start()
     {
+        _polling = true;
         if (_slowTimer is null)
         {
             _slowTimer = _dispatcher.CreateTimer();
@@ -378,7 +391,7 @@ public sealed class DashboardModel
 
         _slowTimer.Start();
         _fastTimer!.Start();
-        RefreshSlow();
+        AttachGraph(_year);
         RefreshQuota();
         RefreshFast();
     }
@@ -386,111 +399,280 @@ public sealed class DashboardModel
     /// <summary>Stop polling (flyout hidden). State stays for instant reopen.</summary>
     public void Stop()
     {
+        _polling = false;
         _slowTimer?.Stop();
         _fastTimer?.Stop();
     }
 
+    public void Dispose()
+    {
+        Stop();
+        _graphState.Dispose();
+        _pendingModelRequestId = null;
+        _pendingModel = null;
+        _graphCoordinator.Started -= OnGraphStarted;
+        _graphCoordinator.Published -= OnGraphPublished;
+        _graphCoordinator.Completed -= OnGraphCompleted;
+    }
+
     private void RefreshSlow()
     {
-        if (Interlocked.Exchange(ref _slowInFlight, 1) == 1)
+        if (!_polling)
         {
             return;
         }
 
-        _ = Task.Run(() =>
+        // The coordinator coalesces duplicate same-query requests; do not use
+        // one global lane gate here because a year switch must supersede an
+        // older query immediately.
+        Volatile.Write(ref _slowInFlight, 1);
+        var year = _year;
+        var force = Interlocked.Exchange(ref _forceRequested, 0) == 1;
+        _graphCoordinator.Request(year, force, OnGraphRequestStarted);
+    }
+
+    private void AttachGraph(string? year)
+    {
+        Interlocked.Exchange(ref _slowInFlight, 1);
+        var attachment = _graphCoordinator.Attach(year, OnGraphRequestStarted);
+        if (!attachment.InFlight)
         {
-            var year = _year; // one slice per pass; a mid-flight switch re-runs below
-            var force = Interlocked.Exchange(ref _forceRequested, 0) == 1;
-            try
+            Volatile.Write(ref _slowInFlight, 0);
+        }
+
+        if (attachment.Latest is { } latest)
+        {
+            OnGraphPublished(latest);
+        }
+    }
+
+    private void OnGraphStarted(GraphRequestId requestId)
+    {
+        if (!_polling || _year != requestId.Query.Year)
+        {
+            return;
+        }
+
+        OnGraphRequestStarted(requestId);
+    }
+
+    private void OnGraphRequestStarted(GraphRequestId requestId)
+    {
+        if (!_polling || _year != requestId.Query.Year
+            || !_graphState.Begin(requestId))
+        {
+            return;
+        }
+
+        if (_dispatcher.HasThreadAccess)
+        {
+            ApplyGraphRequestStart(requestId);
+        }
+        else
+        {
+            _ = _dispatcher.TryEnqueue(() => ApplyGraphRequestStart(requestId));
+        }
+    }
+
+    private void ApplyGraphRequestStart(GraphRequestId requestId)
+    {
+        if (!_graphState.IsCurrent(requestId))
+        {
+            return;
+        }
+
+        var previous = _snapshotRequestId;
+        _snapshotRequestId = requestId;
+        if (_pendingModelRequestId is { } pending
+            && pending != requestId)
+        {
+            _pendingModelRequestId = null;
+            _pendingModel = null;
+        }
+
+        if (previous is { } old && old.Query != requestId.Query)
+        {
+            Current = null;
+            _lastSnapshot = null;
+            _allTimeGraph = null;
+            Updated?.Invoke();
+            return;
+        }
+
+        if (Current is { } current)
+        {
+            // Keep same-query topology as a visual baseline, but revoke
+            // the old model identity and every cost-bearing surface.
+            Current = current with
             {
-                // macOS parity: the model report runs concurrently with the
-                // graph parse (the engine shares one pass), and neither the
-                // network nor the lazy lenses gate the first paint.
-                var sw = System.Diagnostics.Stopwatch.StartNew();
-                UsagePayload? graph;
-                ModelReport? models;
-                using (ProcessPower.Boost()) // EcoQoS off while parsing
+                Models = null,
+                CostAuthoritative = false,
+                FetchedAt = DateTimeOffset.Now,
+            };
+            _lastSnapshot = Current;
+            Updated?.Invoke();
+        }
+
+    }
+
+    private void OnGraphPublished(GraphPublication publication)
+    {
+        if (!_graphState.TryAcceptGraph(
+                publication.RequestId, publication.Payload, publication.Stage))
+        {
+            return;
+        }
+
+        if (_graphState.TryBeginModel(publication.RequestId))
+        {
+            StartModelReport(publication.RequestId);
+        }
+
+        _ = _dispatcher.TryEnqueue(() =>
+        {
+            // Dispatcher-delayed callbacks repeat the exact state check before
+            // touching Current, so an old query/generation cannot repaint it.
+            if (!_graphState.TryAcceptGraph(
+                    publication.RequestId, publication.Payload, publication.Stage)
+                || _year != publication.RequestId.Query.Year)
+            {
+                return;
+            }
+
+            // A request can begin on a worker completion path. If its
+            // dispatcher begin callback is still queued behind this
+            // publication, apply that revoke first so an old same-query
+            // snapshot cannot receive the new generation's graph/model data.
+            if (_snapshotRequestId != publication.RequestId)
+            {
+                ApplyGraphRequestStart(publication.RequestId);
+            }
+
+            if (!_graphState.IsCurrent(publication.RequestId)
+                || _snapshotRequestId != publication.RequestId)
+            {
+                return;
+            }
+
+            var year = publication.RequestId.Query.Year;
+            if (year is not null
+                && !publication.Payload.Years.Any(y => y.Year == year))
+            {
+                lock (_yearGate)
                 {
-                    var modelsTask = Task.Run(() =>
-                        TryFetch(() => TbCore.ModelReport(year), "modelReport"));
-                    graph = TryFetch(() => force
-                        ? TbCore.RefreshGraph(year) : TbCore.Graph(year), "graph");
-                    models = modelsTask.Result; // joined before the boost lifts
+                    if (_year == year)
+                    {
+                        _year = null;
+                        AppSettings.Store.Remove("tokenbar.dashboard.year");
+                    }
                 }
 
-                DevLog.Write($"slow lane: graph+models={sw.ElapsedMilliseconds}ms " +
-                    $"year={year ?? "all"}{(force ? " force" : "")}");
-                if (graph is not null && year is not null
-                    && !graph.Years.Any(y => y.Year == year))
-                {
-                    // macOS apply() parity: the selected year's logs vanished —
-                    // clear the filter instead of stranding the dashboard on an
-                    // empty slice. Only if it is still THIS pass's year, though:
-                    // a pick the user made mid-flight must survive. The finally
-                    // below re-runs the lane either way.
-                    lock (_yearGate)
-                    {
-                        if (_year == year)
-                        {
-                            _year = null;
-                            AppSettings.Store.Remove("tokenbar.dashboard.year");
-                        }
-                    }
+                Updated?.Invoke();
+                return;
+            }
 
-                    // No publish happens on this path, so nudge the UI to
-                    // resync the year picker with the cleared filter.
-                    _ = _dispatcher.TryEnqueue(() => Updated?.Invoke());
+            RememberYears(publication.Payload);
+            if (year is null)
+            {
+                _allTimeGraph = publication.Payload;
+            }
+
+            var baseline = Current;
+            if (baseline is null)
+            {
+                baseline = new Snapshot(
+                    publication.Payload,
+                    null,
+                    _latestQuota,
+                    0,
+                    [],
+                    DateTimeOffset.Now,
+                    _graphState.CostAuthoritative);
+                DevLog.Write("first snapshot ready");
+            }
+
+            var pendingModel = _pendingModelRequestId == publication.RequestId
+                ? _pendingModel
+                : null;
+            if (pendingModel is not null)
+            {
+                _pendingModelRequestId = null;
+                _pendingModel = null;
+            }
+
+            Current = baseline with
+            {
+                Graph = publication.Payload,
+                Models = pendingModel ?? baseline.Models,
+                CostAuthoritative = _graphState.CostAuthoritative,
+                FetchedAt = DateTimeOffset.Now,
+            };
+            _lastSnapshot = Current;
+            Updated?.Invoke();
+            RequestLazyRefresh();
+        });
+    }
+
+    private void StartModelReport(GraphRequestId requestId)
+    {
+        _ = Task.Run(() =>
+        {
+            var report = TryFetch(
+                () => TbCore.ModelReport(requestId.Query.Year), "modelReport");
+            if (report is null || !_graphState.TryAcceptModel(requestId, report))
+            {
+                return;
+            }
+
+            _ = _dispatcher.TryEnqueue(() =>
+            {
+                // Repeat the exact generation guard at the UI boundary.
+                if (!_graphState.TryAcceptModel(requestId, report)
+                    || _year != requestId.Query.Year)
+                {
                     return;
                 }
 
-                if (_year != year)
+                // ModelReport may beat the graph publication callback to the
+                // dispatcher. Retain it for this exact generation instead of
+                // dropping a valid once-only result when Current is still null
+                // or still carries the prior same-query request.
+                if (Current is null || _snapshotRequestId != requestId)
                 {
-                    return; // stale slice; the finally re-runs with the new year
+                    _pendingModelRequestId = requestId;
+                    _pendingModel = report;
+                    return;
                 }
 
-                if (graph is not null)
+                Current = Current with
                 {
-                    RememberYears(graph);
-                    if (year is null)
-                    {
-                        _allTimeGraph = graph;
-                    }
-
-                    var seeded = graph;
-                    Publish(s => s with
-                    {
-                        Graph = seeded ?? s.Graph,
-                        Models = models ?? s.Models,
-                    }, graph, stillValid: () => _year == year);
-                }
-                else if (models is not null)
-                {
-                    var m = models;
-                    Publish(s => s with { Models = m }, graph: null,
-                        stillValid: () => _year == year);
-                }
-
-                // Lazy reports use their own single-flight coordinator so a
-                // selection/year change can invalidate and retry without
-                // spawning overlapping scans.
-                RequestLazyRefresh();
-            }
-            finally
-            {
-                Volatile.Write(ref _slowInFlight, 0);
-                if (_year != year || Volatile.Read(ref _forceRequested) == 1)
-                {
-                    RefreshSlow(); // stale year or a force queued mid-pass
-                }
-                else if (_refreshing)
-                {
-                    // This pass served the manual refresh / year switch; the
-                    // publishes carry no spinner state, so nudge the UI off.
-                    _refreshing = false;
-                    _ = _dispatcher.TryEnqueue(() => Updated?.Invoke());
-                }
-            }
+                    Models = report,
+                    FetchedAt = DateTimeOffset.Now,
+                };
+                _lastSnapshot = Current;
+                Updated?.Invoke();
+            });
         });
+    }
+
+    private void OnGraphCompleted(GraphRequestCompletion completion)
+    {
+        if (!_polling || !_graphState.IsCurrent(completion.RequestId))
+        {
+            return;
+        }
+
+        Volatile.Write(ref _slowInFlight, 0);
+        if (_year != completion.RequestId.Query.Year
+            || Volatile.Read(ref _forceRequested) == 1)
+        {
+            RefreshSlow();
+        }
+        else if (_refreshing)
+        {
+            _refreshing = false;
+            _ = _dispatcher.TryEnqueue(() => Updated?.Invoke());
+        }
     }
 
     private void RememberYears(UsagePayload graph)

--- a/src/TokenBar.App/DashboardModel.cs
+++ b/src/TokenBar.App/DashboardModel.cs
@@ -444,6 +444,11 @@ public sealed class DashboardModel
         {
             OnGraphPublished(latest);
         }
+
+        if (GraphResumePolicy.ShouldRefreshAfterAttach(attachment))
+        {
+            RefreshSlow();
+        }
     }
 
     private void OnGraphStarted(GraphRequestId requestId)

--- a/src/TokenBar.App/DashboardView.xaml.cs
+++ b/src/TokenBar.App/DashboardView.xaml.cs
@@ -350,7 +350,7 @@ public sealed partial class DashboardView : UserControl
         UpdateRefreshControl(loading: snapshot is null);
         if (snapshot is null)
         {
-            FooterText.Text = "loading usage…";
+            RenderLoadingState();
             return;
         }
 
@@ -359,6 +359,31 @@ public sealed partial class DashboardView : UserControl
         UpdateYearPicker();
         UpdateGraph3DData(snapshot);
         RenderContent(animated: false);
+    }
+
+    private void RenderLoadingState()
+    {
+        TodayValue.Text = "—";
+        TotalValue.Text = "—";
+        RateValue.Text = "—";
+        CostLine.Text = CostSurfaceProjection.Checking;
+        FooterText.Text = "loading usage…";
+        UpdateYearPicker();
+
+        _displayClients = [];
+        _selectedClients = [];
+        _selectedSet = new HashSet<string>(StringComparer.Ordinal);
+        _selectedStats = null;
+        _activeClientTab = ClientRegistry.OverviewTab;
+        _clientTabsSignature = "";
+        ClientTabsPanel.Children.Clear();
+
+        DetachGraph3DContentHost();
+        ContentHost.Content = null;
+        if (!_graph3dDevMode)
+        {
+            _graph3d?.Release();
+        }
     }
 
     private void RefreshSelection(bool animated)

--- a/src/TokenBar.App/DashboardView.xaml.cs
+++ b/src/TokenBar.App/DashboardView.xaml.cs
@@ -238,7 +238,10 @@ public sealed partial class DashboardView : UserControl
         var stats = _selectedStats ?? new UsageStats(snapshot.Graph, _selectedSet);
         var year = _model?.Year ?? Format.TodayKey()[..4];
         var grid = TokenBar.Core.Grid.Build(year, stats.PerDayMap);
-        _graph3d.SetData(grid, ActualTheme == ElementTheme.Dark);
+        _graph3d.SetData(
+            grid,
+            ActualTheme == ElementTheme.Dark,
+            snapshot.CostAuthoritative);
     }
 
     private void DetachGraph3DContentHost()
@@ -409,9 +412,8 @@ public sealed partial class DashboardView : UserControl
         TodayValue.Text = Format.CompactTokens(today?.Tokens ?? 0);
         TotalValue.Text = Format.CompactTokens(stats.TotalTokens);
         RateValue.Text = Format.CompactTokens((long)rate);
-        CostLine.Text =
-            $"{Format.Usd(today?.Cost ?? 0)} today · {Format.Usd(stats.TotalCost)} all time · " +
-            $"{stats.ActiveDays} active days";
+        CostLine.Text = CostSurfaceProjection.HeaderCostLine(
+            today?.Cost ?? 0, stats, snapshot.CostAuthoritative);
         FooterText.Text = $"updated {snapshot.FetchedAt:HH:mm:ss}";
     }
 
@@ -699,20 +701,7 @@ public sealed partial class DashboardView : UserControl
             return BuildGraph3D(snapshot);
         }
 
-        var colors = new ModelColorMap(snapshot.Models);
-        var stats = _selectedStats ?? new UsageStats(snapshot.Graph, _selectedSet);
-        var bars = DayBars.Build(
-            snapshot.Graph,
-            _selectedClients,
-            _chartStackBy,
-            _chartMetric,
-            colors,
-            Format.TodayKey(),
-            rangeEnd: stats.DateRange.End);
-
         var holder = new StackPanel();
-        var canvas = new Canvas { Height = 120 };
-        holder.Children.Add(canvas);
 
         // Stack-by + metric pills, the macOS UsageChartCard secondary row.
         var toggles = new StackPanel
@@ -727,9 +716,20 @@ public sealed partial class DashboardView : UserControl
         byModel.Click += (_, _) => SetStackBy(StackBy.Model);
         byAgent.Click += (_, _) => SetStackBy(StackBy.Agent);
         var byTokens = LensPill("Tokens", _chartMetric == ChartMetric.Tokens);
-        var byCost = LensPill("Price", _chartMetric == ChartMetric.Cost);
+        var costEnabled = CostSurfaceProjection.CanUseCost(
+            snapshot.CostAuthoritative);
+        var byCost = LensPill(
+            CostSurfaceProjection.ChartCostLabel(costEnabled),
+            _chartMetric == ChartMetric.Cost);
+        byCost.IsEnabled = costEnabled;
         byTokens.Click += (_, _) => SetMetric(ChartMetric.Tokens);
-        byCost.Click += (_, _) => SetMetric(ChartMetric.Cost);
+        byCost.Click += (_, _) =>
+        {
+            if (costEnabled)
+            {
+                SetMetric(ChartMetric.Cost);
+            }
+        };
         toggles.Children.Add(byModel);
         toggles.Children.Add(byAgent);
         toggles.Children.Add(new Border { Width = 8 });
@@ -746,15 +746,41 @@ public sealed partial class DashboardView : UserControl
 
         void SetMetric(ChartMetric value)
         {
+            if (value == ChartMetric.Cost && !costEnabled)
+            {
+                return;
+            }
+
             _chartMetric = value;
             AppSettings.Store.SetString("tokenbar.chart.metric",
                 value == ChartMetric.Cost ? "cost" : "tokens");
             RenderContent(false);
         }
         holder.Children.Add(toggles);
+        if (CostSurfaceProjection.IsChartCostChecking(
+                snapshot.CostAuthoritative, _chartMetric))
+        {
+            holder.Children.Add(Ui.Dim(CostSurfaceProjection.ChartChecking));
+            return holder;
+        }
+
+        var colors = new ModelColorMap(snapshot.Models, snapshot.CostAuthoritative);
+        var metric = _chartMetric;
+        var stats = _selectedStats ?? new UsageStats(snapshot.Graph, _selectedSet);
+        var bars = DayBars.Build(
+            snapshot.Graph,
+            _selectedClients,
+            _chartStackBy,
+            metric,
+            colors,
+            Format.TodayKey(),
+            rangeEnd: stats.DateRange.End);
+        var canvas = new Canvas { Height = 120 };
+        holder.Children.Insert(0, canvas);
+
         // Wrapping legend, capped like the macOS FlowLayout (12 + "+N").
         var legend = new WrapRow { Margin = new Thickness(0, 8, 0, 0) };
-        var allSegments = DayBars.Legend(bars, _chartMetric);
+        var allSegments = DayBars.Legend(bars, metric);
         foreach (var seg in allSegments.Take(12))
         {
             var item = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 4 };
@@ -782,9 +808,9 @@ public sealed partial class DashboardView : UserControl
 
             // Bar length follows the metric toggle (tokens or spend).
             double SegValue(DaySegment s) =>
-                _chartMetric == ChartMetric.Cost ? s.Cost : s.Tokens;
+                metric == ChartMetric.Cost ? s.Cost : s.Tokens;
             double BarValue(DayBar b) =>
-                _chartMetric == ChartMetric.Cost ? b.TotalCost : b.TotalTokens;
+                metric == ChartMetric.Cost ? b.TotalCost : b.TotalTokens;
             var maxValue = Math.Max(bars.Max(BarValue), 1e-9);
             const double gap = 3;
             var barWidth = Math.Max(2, (width - gap * (bars.Count - 1)) / bars.Count);
@@ -862,7 +888,9 @@ public sealed partial class DashboardView : UserControl
                         outline.Stroke = hovered
                             ? HoverOutlineBrush()
                             : new SolidColorBrush(Colors.Transparent));
-                    HoverTip.AttachRich(overlay, () => DayTip(capturedBar));
+                    HoverTip.AttachRich(
+                        overlay,
+                        () => DayTip(capturedBar, snapshot.CostAuthoritative));
                     canvas.Children.Add(overlay);
                 }
             }
@@ -1002,7 +1030,8 @@ public sealed partial class DashboardView : UserControl
         row.Children.Add(Metric($"{stats.Streaks.Current}d", "current"));
         row.Children.Add(Metric($"{stats.Streaks.Longest}d", "longest"));
         row.Children.Add(Metric(
-            stats.BestDay is { } best ? Format.MonthDay(best.Date) : "—", "best day"));
+            CostSurfaceProjection.BestDayText(
+                stats.BestDay, snapshot.CostAuthoritative), "best day"));
         return row;
     }
 
@@ -1016,8 +1045,9 @@ public sealed partial class DashboardView : UserControl
         var subtitleParts = new List<string>();
         if (report is not null)
         {
-            subtitleParts.Add($"{entries.Count} models · {Format.Usd(entries.Sum(e => e.Cost))}");
-            if (report.PricingUpdatedAt is { } ts)
+            subtitleParts.Add(CostSurfaceProjection.ModelsSubtitle(
+                entries, snapshot.CostAuthoritative));
+            if (snapshot.CostAuthoritative && report.PricingUpdatedAt is { } ts)
             {
                 subtitleParts.Add($"Prices updated {Format.RelativeTime(ts)}");
             }
@@ -1064,9 +1094,8 @@ public sealed partial class DashboardView : UserControl
     private FrameworkElement BuildModelRows(DashboardModel.Snapshot snapshot, int? maxRows)
     {
         var panel = new StackPanel { Spacing = 8 };
-        var entries = SelectedModelEntries(snapshot)
-            .OrderByDescending(e => e.Cost)
-            .ToList();
+        var entries = CostSurfaceProjection.OrderModels(
+            SelectedModelEntries(snapshot), snapshot.CostAuthoritative).ToList();
         if (maxRows is { } cap)
         {
             entries = entries.Take(cap).ToList();
@@ -1078,7 +1107,8 @@ public sealed partial class DashboardView : UserControl
             return panel;
         }
 
-        var colors = new ModelColorMap(snapshot.Models);
+        var colors = new ModelColorMap(
+            snapshot.Models, snapshot.CostAuthoritative);
         foreach (var entry in entries)
         {
             var block = new StackPanel { Spacing = 3 };
@@ -1090,7 +1120,9 @@ public sealed partial class DashboardView : UserControl
             var trailing = new StackPanel { HorizontalAlignment = HorizontalAlignment.Right };
             var tokensText = Ui.Text(Format.CompactTokens(entry.Total), 11, 0.9);
             tokensText.HorizontalAlignment = HorizontalAlignment.Right;
-            var costText = Ui.Text(Format.Usd(entry.Cost), 10, 0.65);
+            var costText = Ui.Text(
+                CostSurfaceProjection.CostText(
+                    entry.Cost, snapshot.CostAuthoritative), 10, 0.65);
             costText.HorizontalAlignment = HorizontalAlignment.Right;
             trailing.Children.Add(tokensText);
             trailing.Children.Add(costText);
@@ -1126,7 +1158,9 @@ public sealed partial class DashboardView : UserControl
                 barGlow.Opacity = hovered ? 1 : 0;
                 discGlow.Opacity = hovered ? 1 : 0;
             });
-            HoverTip.AttachRich(block, () => ModelTip(captured, colors));
+            HoverTip.AttachRich(
+                block,
+                () => ModelTip(captured, colors, snapshot.CostAuthoritative));
             panel.Children.Add(block);
         }
 
@@ -1195,7 +1229,8 @@ public sealed partial class DashboardView : UserControl
     private UIElement BuildDaily(DashboardModel.Snapshot snapshot)
     {
         var panel = new StackPanel { Spacing = 6 };
-        var colors = new ModelColorMap(snapshot.Models);
+        var colors = new ModelColorMap(
+            snapshot.Models, snapshot.CostAuthoritative);
         var days = DailyRows.Build(snapshot.Graph, _selectedClients);
         if (days.Count == 0)
         {
@@ -1217,7 +1252,9 @@ public sealed partial class DashboardView : UserControl
                 summary += $" · {turns} turns · {scope}";
             }
 
-            summary += $" · {Format.CompactTokens(selectedDay.Tokens)} · {Format.Usd(selectedDay.Cost)}";
+            summary += $" · {Format.CompactTokens(selectedDay.Tokens)} · "
+                + CostSurfaceProjection.CostText(
+                    selectedDay.Cost, snapshot.CostAuthoritative);
             var head = Ui.Row(
                 Ui.Text(Format.MonthDay(selectedDay.Date), 12, bold: true),
                 Ui.Text(summary, 11, 0.8));
@@ -1225,7 +1262,8 @@ public sealed partial class DashboardView : UserControl
 
             if (_expandedDay == selectedDay.Date)
             {
-                foreach (var client in selectedDay.Clients)
+                foreach (var client in CostSurfaceProjection.OrderContributionClients(
+                    selectedDay.Clients, snapshot.CostAuthoritative))
                 {
                     var name = new StackPanel
                     {
@@ -1240,7 +1278,12 @@ public sealed partial class DashboardView : UserControl
                         $"{client.ModelId} · {ClientRegistry.ShortName(client.Client)}", 10, 0.85));
                     var row = Ui.Row(
                         name,
-                        Ui.Text($"{Format.CompactTokens(client.Tokens.Total)} · {Format.Usd(client.Cost)}", 10, 0.7));
+                        Ui.Text(
+                            $"{Format.CompactTokens(client.Tokens.Total)} · "
+                                + CostSurfaceProjection.CostText(
+                                    client.Cost, snapshot.CostAuthoritative),
+                            10,
+                            0.7));
                     var capturedClient = client;
                     // Same treatment as the Models lens: the disc lights up with
                     // the card, so the row the card describes is unambiguous.
@@ -1270,7 +1313,10 @@ public sealed partial class DashboardView : UserControl
                         subDiscGlow.Opacity = hovered ? 1 : 0;
                         rowGlow.Opacity = hovered ? 0.55 : 0;
                     });
-                    HoverTip.AttachRich(rowHost, () => ModelTip(capturedClient, colors));
+                    HoverTip.AttachRich(
+                        rowHost,
+                        () => ModelTip(
+                            capturedClient, colors, snapshot.CostAuthoritative));
                     block.Children.Add(rowHost);
                 }
             }
@@ -1371,7 +1417,11 @@ public sealed partial class DashboardView : UserControl
                 panel.Children.Add(Ui.Row(
                     label,
                     Ui.Text(
-                        $"{Format.CompactTokens(entry.Total)} · {Format.Usd(entry.Cost)}", 11, 0.75)));
+                        $"{Format.CompactTokens(entry.Total)} · "
+                            + CostSurfaceProjection.HourlyCost(
+                                entry.Cost, snapshot.CostAuthoritative),
+                        11,
+                        0.75)));
             }
 
             if (entries.Count > _hourlyWindow)
@@ -1402,16 +1452,18 @@ public sealed partial class DashboardView : UserControl
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
         grid.RowDefinitions.Add(new RowDefinition());
         grid.RowDefinitions.Add(new RowDefinition());
-        var favorite = SelectedModelEntries(snapshot)
-            .OrderByDescending(e => e.Cost)
-            .FirstOrDefault();
+        var favorite = CostSurfaceProjection.FavoriteModel(
+            SelectedModelEntries(snapshot), snapshot.CostAuthoritative);
         (string Value, string Label)[] metrics =
         [
-            (Format.Usd(stats.TotalCost), "total spend"),
+            (CostSurfaceProjection.CostText(
+                stats.TotalCost, snapshot.CostAuthoritative), "total spend"),
             (Format.CompactTokens(stats.TotalTokens), "tokens"),
             ($"{stats.ActiveDays}", "active days"),
-            (Format.Usd(stats.AveragePerDay), "avg/day"),
-            (stats.BestDay is { } b ? Format.MonthDay(b.Date) : "—", "best day"),
+            (CostSurfaceProjection.CostText(
+                stats.AveragePerDay, snapshot.CostAuthoritative), "avg/day"),
+            (CostSurfaceProjection.BestDayText(
+                stats.BestDay, snapshot.CostAuthoritative), "best day"),
         ];
         for (var i = 0; i < metrics.Length; i++)
         {
@@ -1446,17 +1498,25 @@ public sealed partial class DashboardView : UserControl
         }
 
         var panel = new StackPanel { Spacing = 8 };
-        var entries = agents.Entries.OrderByDescending(e => e.Cost).ToList();
-        var maxCost = Math.Max(entries.FirstOrDefault()?.Cost ?? 0, 0.0001);
+        var entries = CostSurfaceProjection.OrderAgents(
+            agents.Entries, snapshot.CostAuthoritative);
+        var maxCost = CostSurfaceProjection.AgentScale(
+            entries, snapshot.CostAuthoritative);
         foreach (var entry in entries)
         {
             var block = new StackPanel { Spacing = 3 };
             block.Children.Add(Ui.Row(
                 Ui.Text(entry.Agent, 11, bold: true),
                 Ui.Text(
-                    $"{entry.Messages} msgs · {Format.CompactTokens(entry.Total)} · {Format.Usd(entry.Cost)}",
-                    10, 0.75)));
-            block.Children.Add(Ui.ShareBar(entry.Cost / maxCost, "#3b82f6"));
+                    $"{entry.Messages} msgs · {Format.CompactTokens(entry.Total)} · "
+                        + CostSurfaceProjection.CostText(
+                            entry.Cost, snapshot.CostAuthoritative),
+                    10,
+                    0.75)));
+            block.Children.Add(Ui.ShareBar(
+                CostSurfaceProjection.AgentBarValue(
+                    entry, snapshot.CostAuthoritative) / maxCost,
+                "#3b82f6"));
             block.Children.Add(Ui.Dim(string.Join(", ",
                 entry.Clients.Select(ClientRegistry.ShortName)), 9));
             panel.Children.Add(block);
@@ -1468,7 +1528,9 @@ public sealed partial class DashboardView : UserControl
         }
 
         stack.Children.Add(Ui.Card(
-            "Agents by cost", panel, $"{agents.TotalMessages} messages"));
+            CostSurfaceProjection.AgentsTitle(snapshot.CostAuthoritative),
+            panel,
+            $"{agents.TotalMessages} messages"));
         return stack;
     }
 
@@ -1546,21 +1608,22 @@ public sealed partial class DashboardView : UserControl
 
     /// <summary>Whole-day chart tooltip: date, totals row, then one dotted
     /// line per segment — the macOS bar tooltip.</summary>
-    private UIElement DayTip(DayBar bar)
+    private UIElement DayTip(DayBar bar, bool costAuthoritative)
     {
         var panel = new StackPanel { Spacing = 5, MinWidth = 200 };
         panel.Children.Add(TipText(Format.MonthDay(bar.Date), 12, bold: true));
         panel.Children.Add(TipRow(
             TipText($"{Format.ExactTokens(bar.TotalTokens)} tokens", 11, 0.9),
-            Format.Usd(bar.TotalCost), 0.9));
-        var ordered = _chartMetric == ChartMetric.Cost
-            ? bar.Segments.OrderByDescending(s => s.Cost)
-            : bar.Segments.OrderByDescending(s => s.Tokens);
+            CostSurfaceProjection.DayTipCost(bar.TotalCost, costAuthoritative), 0.9));
+        var ordered = CostSurfaceProjection.OrderDaySegments(
+            bar.Segments, costAuthoritative, _chartMetric);
         foreach (var seg in ordered)
         {
             panel.Children.Add(TipRow(
                 TipLabel(seg.Color, seg.Label),
-                $"{Format.CompactTokens(seg.Tokens)} · {Format.Usd(seg.Cost)}"));
+                $"{Format.CompactTokens(seg.Tokens)} · "
+                    + CostSurfaceProjection.DayTipCost(
+                        seg.Cost, costAuthoritative)));
         }
 
         return panel;
@@ -1569,7 +1632,10 @@ public sealed partial class DashboardView : UserControl
     /// <summary>Model-row tooltip: header disc + name, source line, totals,
     /// then per-kind colored rows with share percentages — the macOS
     /// ModelBreakdownCard hover.</summary>
-    private static UIElement ModelTip(ContributionClient entry, ModelColorMap colors) =>
+    private static UIElement ModelTip(
+        ContributionClient entry,
+        ModelColorMap colors,
+        bool costAuthoritative) =>
         ModelTip(new ModelReportEntry(
             entry.Client,
             entry.ModelId,
@@ -1581,10 +1647,16 @@ public sealed partial class DashboardView : UserControl
             entry.Tokens.Reasoning,
             entry.Tokens.Total,
             entry.Messages,
-            entry.Cost), colors, includeZeroKinds: true);
+            entry.Cost),
+            colors,
+            costAuthoritative,
+            includeZeroKinds: true);
 
     private static UIElement ModelTip(
-        ModelReportEntry entry, ModelColorMap colors, bool includeZeroKinds = false)
+        ModelReportEntry entry,
+        ModelColorMap colors,
+        bool costAuthoritative,
+        bool includeZeroKinds = false)
     {
         long[] values =
             [entry.Input, entry.Output, entry.CacheRead, entry.CacheWrite, entry.Reasoning];
@@ -1602,7 +1674,8 @@ public sealed partial class DashboardView : UserControl
             $"{ClientRegistry.ShortName(entry.Client)} · {entry.Provider}", 10, 0.6));
         panel.Children.Add(TipRow(
             TipText($"{Format.CompactTokens(entry.Total)} tokens", 11, 0.9),
-            Format.Usd(entry.Cost), 0.9));
+            CostSurfaceProjection.ModelTipCost(
+                entry.Cost, costAuthoritative), 0.9));
         (string Label, string Color)[] kinds =
         [
             ("Input", Ui.TokenKinds[0].Color),

--- a/src/TokenBar.App/FlyoutWindow.xaml.cs
+++ b/src/TokenBar.App/FlyoutWindow.xaml.cs
@@ -22,11 +22,12 @@ public sealed partial class FlyoutWindow : Window
 
     private readonly DashboardModel _model;
 
-    public FlyoutWindow()
+    public FlyoutWindow(GraphRequestCoordinator graphCoordinator)
     {
         InitializeComponent();
 
-        _model = new DashboardModel(DispatcherQueue);
+        _model = new DashboardModel(DispatcherQueue, graphCoordinator);
+        Closed += (_, _) => _model.Dispose();
         _model.Updated += RenderSnapshot;
         Dashboard.Bind(_model);
         Dashboard.HideRequested += HideFlyout;

--- a/src/TokenBar.App/Graph3DPanel.cs
+++ b/src/TokenBar.App/Graph3DPanel.cs
@@ -26,6 +26,7 @@ internal sealed class Graph3DPanel : SwapChainPanel
     private Graph3DRenderer? _renderer;
     private GridLayout? _grid;
     private bool _dark;
+    private bool _costAuthoritative;
     private bool _hasData;
     private bool _active;
     private bool _creating;
@@ -65,13 +66,14 @@ internal sealed class Graph3DPanel : SwapChainPanel
 
     /// <summary>Cache data regardless of visibility. If a renderer exists,
     /// rebuild it and render exactly one updated frame.</summary>
-    public void SetData(GridLayout grid, bool dark)
+    public void SetData(GridLayout grid, bool dark, bool costAuthoritative)
     {
-        var signature = DataSignature(grid, dark);
+        var signature = DataSignature(grid, dark, costAuthoritative);
         var changed = signature != _dataSignature;
         _dataSignature = signature;
         _grid = grid;
         _dark = dark;
+        _costAuthoritative = costAuthoritative;
         _hasData = true;
         if (!_active)
         {
@@ -561,13 +563,14 @@ internal sealed class Graph3DPanel : SwapChainPanel
         _dragRenderTicks = 0;
     }
 
-    private static UIElement BuildTooltip(GridCell cell)
+    private UIElement BuildTooltip(GridCell cell)
     {
         var panel = new StackPanel { Spacing = 4, MinWidth = 150 };
         panel.Children.Add(TooltipText(Format.MonthDay(cell.Date), 12, bold: true));
         panel.Children.Add(TooltipText(
             $"{Format.ExactTokens(cell.Tokens)} tokens", 11, 0.9));
-        panel.Children.Add(TooltipText(Format.Usd(cell.Cost), 11, 0.9));
+        panel.Children.Add(TooltipText(
+            CostSurfaceProjection.CostText(cell.Cost, _costAuthoritative), 11, 0.9));
         return panel;
     }
 
@@ -586,7 +589,8 @@ internal sealed class Graph3DPanel : SwapChainPanel
     /// <summary>The Swift reference gates on cols|maxTokens|activeCount|theme.
     /// Keep that contract, plus a compact content fingerprint so two years with
     /// coincidentally equal aggregates cannot retain stale geometry/tooltips.</summary>
-    private static string DataSignature(GridLayout grid, bool dark)
+    private static string DataSignature(
+        GridLayout grid, bool dark, bool costAuthoritative)
     {
         const ulong offset = 14695981039346656037;
         const ulong prime = 1099511628211;
@@ -623,7 +627,7 @@ internal sealed class Graph3DPanel : SwapChainPanel
             }
         }
 
-        return $"{grid.Cols}|{grid.MaxTokens}|{activeCount}|{dark}|{fingerprint:X16}";
+        return $"{grid.Cols}|{grid.MaxTokens}|{activeCount}|{dark}|{costAuthoritative}|{fingerprint:X16}";
     }
 
     /// <summary>Device-removed/reset (TDR, driver update, GPU reset): count it

--- a/src/TokenBar.App/GraphConsumerState.cs
+++ b/src/TokenBar.App/GraphConsumerState.cs
@@ -2,6 +2,25 @@ using TokenBar.Interop;
 
 namespace TokenBar.App;
 
+public static class GraphCompletionPolicy
+{
+    public static (bool IsCurrent, bool ShouldRerun, bool ClearRefreshing) Decide(
+        bool isCurrent,
+        bool polling,
+        bool sameYear,
+        bool forceRequested,
+        bool refreshing)
+    {
+        if (!isCurrent)
+        {
+            return default;
+        }
+
+        var shouldRerun = polling && (!sameYear || forceRequested);
+        return (true, shouldRerun, refreshing && !shouldRerun);
+    }
+}
+
 /// <summary>Pure consumer gate for one retained graph pipeline. UI-facing
 /// properties may only change after these exact request/generation checks.</summary>
 public sealed class GraphConsumerState : IDisposable

--- a/src/TokenBar.App/GraphConsumerState.cs
+++ b/src/TokenBar.App/GraphConsumerState.cs
@@ -27,6 +27,16 @@ public static class GraphResumePolicy
         attachment.RequestId.Query.Year is not null && !attachment.InFlight;
 }
 
+public static class GraphYearPolicy
+{
+    public static bool ShouldClearToAllTime(
+        string? selectedYear,
+        GraphPublication publication) =>
+        selectedYear is not null
+        && publication.RequestId.Query.Year == selectedYear
+        && !publication.Payload.Years.Any(year => year.Year == selectedYear);
+}
+
 /// <summary>Pure consumer gate for one retained graph pipeline. UI-facing
 /// properties may only change after these exact request/generation checks.</summary>
 public sealed class GraphConsumerState : IDisposable

--- a/src/TokenBar.App/GraphConsumerState.cs
+++ b/src/TokenBar.App/GraphConsumerState.cs
@@ -21,6 +21,12 @@ public static class GraphCompletionPolicy
     }
 }
 
+public static class GraphResumePolicy
+{
+    public static bool ShouldRefreshAfterAttach(GraphAttachment attachment) =>
+        attachment.RequestId.Query.Year is not null && !attachment.InFlight;
+}
+
 /// <summary>Pure consumer gate for one retained graph pipeline. UI-facing
 /// properties may only change after these exact request/generation checks.</summary>
 public sealed class GraphConsumerState : IDisposable

--- a/src/TokenBar.App/GraphConsumerState.cs
+++ b/src/TokenBar.App/GraphConsumerState.cs
@@ -37,6 +37,14 @@ public static class GraphYearPolicy
         && !publication.Payload.Years.Any(year => year.Year == selectedYear);
 }
 
+public static class GraphLazyRefreshPolicy
+{
+    public static bool ShouldRequest(
+        GraphRequestId? scheduledRequestId,
+        GraphRequestId requestId) =>
+        scheduledRequestId != requestId;
+}
+
 /// <summary>Pure consumer gate for one retained graph pipeline. UI-facing
 /// properties may only change after these exact request/generation checks.</summary>
 public sealed class GraphConsumerState : IDisposable

--- a/src/TokenBar.App/GraphConsumerState.cs
+++ b/src/TokenBar.App/GraphConsumerState.cs
@@ -1,0 +1,185 @@
+using TokenBar.Interop;
+
+namespace TokenBar.App;
+
+/// <summary>Pure consumer gate for one retained graph pipeline. UI-facing
+/// properties may only change after these exact request/generation checks.</summary>
+public sealed class GraphConsumerState : IDisposable
+{
+    private readonly object _gate = new();
+    private GraphRequestId? _desired;
+    private GraphRequestId? _acceptedId;
+    private UsagePayload? _acceptedGraph;
+    private GraphPublicationStage? _acceptedStage;
+    private bool _localAccepted;
+    private bool _costAuthoritative;
+    private bool _modelStarted;
+    private bool _modelAccepted;
+    private bool _disposed;
+
+    public GraphRequestId? DesiredId
+    {
+        get { lock (_gate) return _desired; }
+    }
+
+    public GraphRequestId? AcceptedId
+    {
+        get { lock (_gate) return _acceptedId; }
+    }
+
+    public UsagePayload? AcceptedGraph
+    {
+        get { lock (_gate) return _acceptedGraph; }
+    }
+
+    public GraphPublicationStage? AcceptedStage
+    {
+        get { lock (_gate) return _acceptedStage; }
+    }
+
+    public bool LocalAccepted
+    {
+        get { lock (_gate) return _localAccepted; }
+    }
+
+    public bool CostAuthoritative
+    {
+        get { lock (_gate) return _costAuthoritative; }
+    }
+
+    public bool ModelStarted
+    {
+        get { lock (_gate) return _modelStarted; }
+    }
+
+    public bool ModelAccepted
+    {
+        get { lock (_gate) return _modelAccepted; }
+    }
+
+    public bool IsDisposed
+    {
+        get { lock (_gate) return _disposed; }
+    }
+
+    /// <summary>Revoke the previous generation immediately. A same-query
+    /// refresh may keep a caller's old topology, but this state exposes no old
+    /// graph or cost authority as current.</summary>
+    public bool Begin(GraphRequestId requestId)
+    {
+        lock (_gate)
+        {
+            if (_disposed || _desired == requestId)
+            {
+                return false;
+            }
+
+            if (_desired is { } desired
+                && desired.Query == requestId.Query
+                && requestId.Generation < desired.Generation)
+            {
+                return false;
+            }
+
+            _desired = requestId;
+            _acceptedId = null;
+            _acceptedGraph = null;
+            _acceptedStage = null;
+            _localAccepted = false;
+            _costAuthoritative = false;
+            _modelStarted = false;
+            _modelAccepted = false;
+            return true;
+        }
+    }
+
+    /// <summary>Accept only the exact desired query+generation. A richer
+    /// retained publication also proves the local stage for late observers.</summary>
+    public bool TryAcceptGraph(
+        GraphRequestId requestId,
+        UsagePayload graph,
+        GraphPublicationStage stage)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        lock (_gate)
+        {
+            if (_disposed || _desired != requestId)
+            {
+                return false;
+            }
+
+            // Attach returns a retained snapshot after releasing the coordinator
+            // lock. A same-generation richer event can therefore arrive before
+            // the retained local snapshot is replayed; never let that replay
+            // regress the accepted stage or revoke richer cost authority.
+            if (_acceptedId == requestId
+                && _acceptedStage == GraphPublicationStage.Richer
+                && stage == GraphPublicationStage.LocalFirst)
+            {
+                return false;
+            }
+
+            _acceptedId = requestId;
+            _acceptedGraph = graph;
+            _acceptedStage = stage;
+            _localAccepted = true;
+            _costAuthoritative = CostSurfaceProjection.IsAuthoritative(graph);
+            return true;
+        }
+    }
+
+    /// <summary>ModelReport may start once, and only after exact-generation
+    /// LocalAccepted (including a retained richer attachment).</summary>
+    public bool TryBeginModel(GraphRequestId requestId)
+    {
+        lock (_gate)
+        {
+            if (_disposed || _desired != requestId || !_localAccepted || _modelStarted)
+            {
+                return false;
+            }
+
+            _modelStarted = true;
+            return true;
+        }
+    }
+
+    public bool TryAcceptModel(GraphRequestId requestId, ModelReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        lock (_gate)
+        {
+            if (_disposed || _desired != requestId || !_modelStarted)
+            {
+                return false;
+            }
+
+            _modelAccepted = true;
+            return true;
+        }
+    }
+
+    public bool IsCurrent(GraphRequestId requestId)
+    {
+        lock (_gate)
+        {
+            return !_disposed && _desired == requestId;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+            _desired = null;
+            _acceptedId = null;
+            _acceptedGraph = null;
+            _acceptedStage = null;
+            _localAccepted = false;
+            _costAuthoritative = false;
+            _modelStarted = false;
+            _modelAccepted = false;
+        }
+    }
+}

--- a/src/TokenBar.App/GraphRequestCoordinator.cs
+++ b/src/TokenBar.App/GraphRequestCoordinator.cs
@@ -50,21 +50,33 @@ public sealed class GraphRequestCoordinator
         public bool CurrentSucceeded;
     }
 
+    private sealed class NoopScope : IDisposable
+    {
+        public static readonly NoopScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+
     private readonly object _gate = new();
     private readonly Dictionary<GraphQuery, QueryState> _states = [];
     private readonly Func<string?, UsagePayload> _localFirst;
     private readonly Func<string?, UsagePayload> _graph;
     private readonly Func<string?, UsagePayload> _refreshGraph;
+    private readonly Func<IDisposable> _boost;
     private long _nextGeneration;
 
     public GraphRequestCoordinator(
         Func<string?, UsagePayload>? localFirst = null,
         Func<string?, UsagePayload>? graph = null,
-        Func<string?, UsagePayload>? refreshGraph = null)
+        Func<string?, UsagePayload>? refreshGraph = null,
+        Func<IDisposable>? boost = null)
     {
         _localFirst = localFirst ?? TbCore.GraphLocalFirst;
         _graph = graph ?? refreshGraph ?? TbCore.RefreshGraph;
         _refreshGraph = refreshGraph ?? graph ?? TbCore.RefreshGraph;
+        _boost = boost ?? (() => NoopScope.Instance);
     }
 
     public event Action<GraphRequestId>? Started;
@@ -132,7 +144,8 @@ public sealed class GraphRequestCoordinator
     public GraphRequestId Request(
         string? year,
         bool force = false,
-        Action<GraphRequestId>? onBegin = null)
+        Action<GraphRequestId>? onBegin = null,
+        Action<GraphPublication>? onReplay = null)
     {
         var query = GraphQuery.Normalize(year);
         QueryState state;
@@ -159,6 +172,23 @@ public sealed class GraphRequestCoordinator
         }
 
         onBegin?.Invoke(requestId);
+        if (!start && onReplay is not null)
+        {
+            GraphPublication? latest;
+            lock (_gate)
+            {
+                // The consumer begins outside the coordinator lock. Reacquire
+                // the newest exact stage so a publication racing that handoff
+                // cannot be lost or replayed behind a newer richer stage.
+                latest = state.Latest?.RequestId == requestId ? state.Latest : null;
+            }
+
+            if (latest is not null)
+            {
+                onReplay(latest);
+            }
+        }
+
         if (start)
         {
             StartPipeline(state, requestId, force);
@@ -202,7 +232,11 @@ public sealed class GraphRequestCoordinator
             UsagePayload local;
             try
             {
-                local = _localFirst(requestId.Query.Year);
+                using (_boost())
+                {
+                    local = _localFirst(requestId.Query.Year);
+                }
+
                 localSucceeded = true;
             }
             catch
@@ -219,7 +253,12 @@ public sealed class GraphRequestCoordinator
 
             try
             {
-                var richer = (force ? _refreshGraph : _graph)(requestId.Query.Year);
+                UsagePayload richer;
+                using (_boost())
+                {
+                    richer = (force ? _refreshGraph : _graph)(requestId.Query.Year);
+                }
+
                 richerSucceeded = true;
                 PublishIfCurrent(state, requestId,
                     new GraphPublication(requestId, GraphPublicationStage.Richer, richer));

--- a/src/TokenBar.App/GraphRequestCoordinator.cs
+++ b/src/TokenBar.App/GraphRequestCoordinator.cs
@@ -1,0 +1,326 @@
+using TokenBar.Interop;
+
+namespace TokenBar.App;
+
+public enum GraphPublicationStage
+{
+    LocalFirst,
+    Richer,
+}
+
+public readonly record struct GraphQuery(string? Year)
+{
+    public static GraphQuery Normalize(string? year) =>
+        new(string.IsNullOrWhiteSpace(year) ? null : year.Trim());
+}
+
+public readonly record struct GraphRequestId(GraphQuery Query, long Generation);
+
+public sealed record GraphPublication(
+    GraphRequestId RequestId,
+    GraphPublicationStage Stage,
+    UsagePayload Payload);
+
+public sealed record GraphRequestCompletion(
+    GraphRequestId RequestId,
+    bool LocalSucceeded,
+    bool RicherSucceeded)
+{
+    public bool Succeeded => LocalSucceeded && RicherSucceeded;
+
+    public bool IsSuccessfulRicherFor(GraphRequestId requestId) =>
+        RequestId == requestId && RicherSucceeded;
+}
+
+public readonly record struct GraphAttachment(
+    GraphRequestId RequestId,
+    GraphPublication? Latest,
+    bool InFlight);
+
+/// <summary>Process-shared graph pipeline. Every production graph call enters
+/// here, so local-first publication and request supersession have one owner.</summary>
+public sealed class GraphRequestCoordinator
+{
+    private sealed class QueryState(GraphQuery query)
+    {
+        public GraphQuery Query { get; } = query;
+        public GraphRequestId Current;
+        public GraphPublication? Latest;
+        public bool InFlight;
+        public bool CurrentSucceeded;
+    }
+
+    private readonly object _gate = new();
+    private readonly Dictionary<GraphQuery, QueryState> _states = [];
+    private readonly Func<string?, UsagePayload> _localFirst;
+    private readonly Func<string?, UsagePayload> _graph;
+    private readonly Func<string?, UsagePayload> _refreshGraph;
+    private long _nextGeneration;
+
+    public GraphRequestCoordinator(
+        Func<string?, UsagePayload>? localFirst = null,
+        Func<string?, UsagePayload>? graph = null,
+        Func<string?, UsagePayload>? refreshGraph = null)
+    {
+        _localFirst = localFirst ?? TbCore.GraphLocalFirst;
+        _graph = graph ?? TbCore.Graph;
+        _refreshGraph = refreshGraph ?? TbCore.RefreshGraph;
+    }
+
+    public event Action<GraphRequestId>? Started;
+    public event Action<GraphPublication>? Published;
+    public event Action<GraphRequestCompletion>? Completed;
+
+    /// <summary>Attach an observer's exact query. A retained exact publication
+    /// is returned synchronously; otherwise one pipeline is started.</summary>
+    public GraphAttachment Attach(
+        string? year,
+        Action<GraphRequestId>? onBegin = null)
+    {
+        var query = GraphQuery.Normalize(year);
+        QueryState state;
+        GraphRequestId requestId;
+        GraphPublication? latest;
+        bool start;
+        bool inFlight;
+        lock (_gate)
+        {
+            state = GetState(query);
+            if (state.InFlight)
+            {
+                requestId = state.Current;
+                start = false;
+            }
+            else if (state.CurrentSucceeded && state.Latest?.RequestId == state.Current)
+            {
+                requestId = state.Current;
+                start = false;
+            }
+            else
+            {
+                requestId = BeginLocked(state);
+                start = true;
+            }
+
+        }
+
+        if (start)
+        {
+            InvokeStarted(requestId);
+        }
+
+        onBegin?.Invoke(requestId);
+        lock (_gate)
+        {
+            // The handoff callback may let a publication race before the
+            // consumer begins. Replay the newest exact publication instead of
+            // returning the snapshot captured before that handoff.
+            latest = state.Latest?.RequestId == requestId ? state.Latest : null;
+            inFlight = state.InFlight;
+        }
+
+        if (start)
+        {
+            StartPipeline(state, requestId, force: false);
+        }
+
+        return new GraphAttachment(requestId, latest, inFlight);
+    }
+
+    /// <summary>Start a newer generation unless the exact query is already
+    /// running. Force always supersedes the previous generation.</summary>
+    public GraphRequestId Request(
+        string? year,
+        bool force = false,
+        Action<GraphRequestId>? onBegin = null)
+    {
+        var query = GraphQuery.Normalize(year);
+        QueryState state;
+        GraphRequestId requestId;
+        bool start;
+        lock (_gate)
+        {
+            state = GetState(query);
+            if (!force && state.InFlight)
+            {
+                requestId = state.Current;
+                start = false;
+            }
+            else
+            {
+                requestId = BeginLocked(state);
+                start = true;
+            }
+        }
+
+        if (start)
+        {
+            InvokeStarted(requestId);
+        }
+
+        onBegin?.Invoke(requestId);
+        if (start)
+        {
+            StartPipeline(state, requestId, force);
+        }
+
+        return requestId;
+    }
+
+    private QueryState GetState(GraphQuery query)
+    {
+        if (_states.TryGetValue(query, out var state))
+        {
+            return state;
+        }
+
+        state = new QueryState(query);
+        _states.Add(query, state);
+        return state;
+    }
+
+    private GraphRequestId BeginLocked(QueryState state)
+    {
+        var requestId = new GraphRequestId(state.Query, ++_nextGeneration);
+        state.Current = requestId;
+        state.InFlight = true;
+        state.CurrentSucceeded = false;
+        return requestId;
+    }
+
+    private void StartPipeline(QueryState state, GraphRequestId requestId, bool force)
+    {
+        _ = Task.Run(() => RunPipeline(state, requestId, force));
+    }
+
+    private void RunPipeline(QueryState state, GraphRequestId requestId, bool force)
+    {
+        var localSucceeded = false;
+        var richerSucceeded = false;
+        try
+        {
+            UsagePayload local;
+            try
+            {
+                local = _localFirst(requestId.Query.Year);
+                localSucceeded = true;
+            }
+            catch
+            {
+                return;
+            }
+
+            if (!PublishIfCurrent(state, requestId,
+                    new GraphPublication(
+                        requestId, GraphPublicationStage.LocalFirst, local)))
+            {
+                return;
+            }
+
+            try
+            {
+                var richer = (force ? _refreshGraph : _graph)(requestId.Query.Year);
+                richerSucceeded = true;
+                PublishIfCurrent(state, requestId,
+                    new GraphPublication(requestId, GraphPublicationStage.Richer, richer));
+            }
+            catch
+            {
+                // Local-first is still useful; no richer success is published.
+            }
+        }
+        finally
+        {
+            var current = false;
+            lock (_gate)
+            {
+                if (state.Current == requestId)
+                {
+                    state.InFlight = false;
+                    state.CurrentSucceeded = localSucceeded;
+                    current = true;
+                }
+            }
+
+            if (current)
+            {
+                InvokeCompleted(new GraphRequestCompletion(
+                    requestId, localSucceeded, richerSucceeded));
+            }
+        }
+    }
+
+    private bool PublishIfCurrent(
+        QueryState state, GraphRequestId requestId, GraphPublication publication)
+    {
+        var current = false;
+        lock (_gate)
+        {
+            if (state.Current == requestId)
+            {
+                state.Latest = publication;
+                state.CurrentSucceeded = true;
+                current = true;
+            }
+        }
+
+        if (!current)
+        {
+            return false;
+        }
+
+        InvokePublished(publication);
+        lock (_gate)
+        {
+            return state.Current == requestId;
+        }
+    }
+
+    private void InvokeStarted(GraphRequestId requestId)
+    {
+        foreach (var observer in Started?.GetInvocationList()
+            .Cast<Action<GraphRequestId>>() ?? [])
+        {
+            try
+            {
+                observer(requestId);
+            }
+            catch
+            {
+                // One consumer cannot prevent the others from revoking stale state.
+            }
+        }
+    }
+
+    private void InvokePublished(GraphPublication publication)
+    {
+        foreach (var observer in Published?.GetInvocationList()
+            .Cast<Action<GraphPublication>>() ?? [])
+        {
+            try
+            {
+                observer(publication);
+            }
+            catch
+            {
+                // A consumer must not stop the shared pipeline for its peers.
+            }
+        }
+    }
+
+    private void InvokeCompleted(GraphRequestCompletion completion)
+    {
+        foreach (var observer in Completed?.GetInvocationList()
+            .Cast<Action<GraphRequestCompletion>>() ?? [])
+        {
+            try
+            {
+                observer(completion);
+            }
+            catch
+            {
+                // Completion is advisory; consumer failures cannot poison peers.
+            }
+        }
+    }
+}

--- a/src/TokenBar.App/GraphRequestCoordinator.cs
+++ b/src/TokenBar.App/GraphRequestCoordinator.cs
@@ -63,8 +63,8 @@ public sealed class GraphRequestCoordinator
         Func<string?, UsagePayload>? refreshGraph = null)
     {
         _localFirst = localFirst ?? TbCore.GraphLocalFirst;
-        _graph = graph ?? TbCore.Graph;
-        _refreshGraph = refreshGraph ?? TbCore.RefreshGraph;
+        _graph = graph ?? refreshGraph ?? TbCore.RefreshGraph;
+        _refreshGraph = refreshGraph ?? graph ?? TbCore.RefreshGraph;
     }
 
     public event Action<GraphRequestId>? Started;

--- a/src/TokenBar.App/TrayFeed.cs
+++ b/src/TokenBar.App/TrayFeed.cs
@@ -15,11 +15,14 @@ namespace TokenBar.App;
 public sealed class TrayFeed : IDisposable
 {
     private readonly DispatcherQueue _dispatcher;
+    private readonly GraphRequestCoordinator _graphCoordinator;
+    private readonly GraphConsumerState _graphState = new();
     private readonly DispatcherQueueTimer _fast;
     private readonly DispatcherQueueTimer _slow;
     private readonly Action<string> _onStoreChanged;
     private int _fastInFlight; // Interlocked: reset in a background finally
     private int _slowInFlight;
+    private int _quotaInFlight;
     private bool _disposed;
 
     public UsagePayload? Graph { get; private set; }
@@ -32,6 +35,8 @@ public sealed class TrayFeed : IDisposable
 
     public AgentUsagePayload? Quota { get; private set; }
 
+    public bool CostAuthoritative => _graphState.CostAuthoritative;
+
     private bool _hasTrace;
     private string? _cachedQuotaSelection;
     private double? _cachedQuotaRemaining;
@@ -43,9 +48,15 @@ public sealed class TrayFeed : IDisposable
 
     public event Action? Changed;
 
-    public TrayFeed(DispatcherQueue dispatcher)
+    public TrayFeed(
+        DispatcherQueue dispatcher,
+        GraphRequestCoordinator graphCoordinator)
     {
         _dispatcher = dispatcher;
+        _graphCoordinator = graphCoordinator;
+        _graphCoordinator.Started += OnGraphStarted;
+        _graphCoordinator.Published += OnGraphPublished;
+        _graphCoordinator.Completed += OnGraphCompleted;
         var persistedSelection = AppSettings.Store.GetString(
             "tokenbar.quota.lastSelection");
         var currentSelection = AppSettings.Store.GetString(
@@ -66,8 +77,9 @@ public sealed class TrayFeed : IDisposable
         _slow.Interval = TimeSpan.FromSeconds(300);
         _slow.Tick += (_, _) => RefreshSlow();
         _slow.Start();
+        AttachGraph();
         RefreshFast();
-        RefreshSlow();
+        RefreshQuota();
 
         _onStoreChanged = key =>
         {
@@ -97,6 +109,10 @@ public sealed class TrayFeed : IDisposable
     public void Dispose()
     {
         _disposed = true; // fences any in-flight lane's enqueued callback
+        _graphState.Dispose();
+        _graphCoordinator.Started -= OnGraphStarted;
+        _graphCoordinator.Published -= OnGraphPublished;
+        _graphCoordinator.Completed -= OnGraphCompleted;
         _fast.Stop();
         _slow.Stop();
         AppSettings.Store.Changed -= _onStoreChanged;
@@ -143,7 +159,8 @@ public sealed class TrayFeed : IDisposable
     // the cached path keeps data fresh continuously; this is the macOS title
     // loop's belt against anything the incremental scan misses. An instance
     // field, so restarting timers never triggers an immediate re-read.
-    private DateTimeOffset _lastFullRefresh = DateTimeOffset.Now;
+    private long _lastFullRefreshTicks = DateTimeOffset.UtcNow.Ticks;
+    private long _forcedRefreshGeneration;
 
     private void RefreshSlow()
     {
@@ -153,44 +170,137 @@ public sealed class TrayFeed : IDisposable
         }
 
         var intervalMin = Math.Max(1, AppSettings.Store.GetInt("tokenbar.refresh.intervalMin", 30));
-        var force = DateTimeOffset.Now - _lastFullRefresh >= TimeSpan.FromMinutes(intervalMin);
+        var lastFullRefresh = new DateTimeOffset(
+            Volatile.Read(ref _lastFullRefreshTicks), TimeSpan.Zero);
+        var force = DateTimeOffset.UtcNow - lastFullRefresh
+            >= TimeSpan.FromMinutes(intervalMin);
+
+        _graphCoordinator.Request(null, force, requestId =>
+        {
+            OnGraphStarted(requestId);
+            if (force)
+            {
+                Volatile.Write(ref _forcedRefreshGeneration, requestId.Generation);
+            }
+        });
+        RefreshQuota();
+    }
+
+    private void AttachGraph()
+    {
+        Interlocked.Exchange(ref _slowInFlight, 1);
+        var attachment = _graphCoordinator.Attach(null, OnGraphRequestStarted);
+        if (!attachment.InFlight)
+        {
+            Volatile.Write(ref _slowInFlight, 0);
+        }
+
+        if (attachment.Latest is { } latest)
+        {
+            OnGraphPublished(latest);
+        }
+    }
+
+    private void OnGraphStarted(GraphRequestId requestId)
+    {
+        if (requestId.Query.Year is not null || !_graphState.Begin(requestId))
+        {
+            return;
+        }
+
+        // Revoke cost authority before the graph callback lands; token/rate/
+        // quota projections remain usable from the retained topology.
+        _ = _dispatcher.TryEnqueue(() =>
+        {
+            if (!_disposed && _graphState.IsCurrent(requestId))
+            {
+                Changed?.Invoke();
+            }
+        });
+    }
+
+    private void OnGraphRequestStarted(GraphRequestId requestId) =>
+        OnGraphStarted(requestId);
+
+    private void OnGraphPublished(GraphPublication publication)
+    {
+        if (!_graphState.TryAcceptGraph(
+                publication.RequestId, publication.Payload, publication.Stage))
+        {
+            return;
+        }
+
+        _ = _dispatcher.TryEnqueue(() =>
+        {
+            // Repeat the exact request/generation/disposal gate after dispatch.
+            if (_disposed || !_graphState.TryAcceptGraph(
+                    publication.RequestId, publication.Payload, publication.Stage))
+            {
+                return;
+            }
+
+            Graph = publication.Payload;
+            RecomputeVisibleUsage();
+            ResolveRemaining();
+            Changed?.Invoke();
+        });
+    }
+
+    private void OnGraphCompleted(GraphRequestCompletion completion)
+    {
+        if (!_graphState.IsCurrent(completion.RequestId))
+        {
+            return;
+        }
+
+        Volatile.Write(ref _slowInFlight, 0);
+        var forcedGeneration = Volatile.Read(ref _forcedRefreshGeneration);
+        var forcedRequest = new GraphRequestId(
+            GraphQuery.Normalize(null), forcedGeneration);
+        if (forcedGeneration != 0
+            && completion.IsSuccessfulRicherFor(forcedRequest)
+            && Interlocked.CompareExchange(
+                ref _forcedRefreshGeneration, 0, forcedGeneration)
+                == forcedGeneration)
+        {
+            Interlocked.Exchange(
+                ref _lastFullRefreshTicks, DateTimeOffset.UtcNow.Ticks);
+        }
+    }
+
+    private void RefreshQuota()
+    {
+        if (Interlocked.Exchange(ref _quotaInFlight, 1) == 1)
+        {
+            return;
+        }
+
         _ = Task.Run(() =>
         {
             try
             {
-                UsagePayload? graph;
-                using (ProcessPower.Boost())
-                {
-                    graph = TryFetch(() => force
-                        ? TbCore.RefreshGraph() : TbCore.Graph(), "tray graph");
-                }
-
-                if (force && graph is not null)
-                {
-                    _lastFullRefresh = DateTimeOffset.Now;
-                }
-
                 var quota = TryFetch(
                     () => AgentUsageFetchCoordinator.Shared.FetchAsync().GetAwaiter().GetResult(),
                     "tray quota");
+                if (quota is null)
+                {
+                    return;
+                }
+
                 _ = _dispatcher.TryEnqueue(() =>
                 {
                     if (_disposed)
                     {
-                        return; // don't touch the tray icon after shutdown
+                        return;
                     }
 
-                    Graph = graph ?? Graph;
-                    Quota = quota ?? Quota;
-                    if (quota is not null)
+                    Quota = quota;
+                    var persistedSelection = AppSettings.Store.GetString(
+                        "tokenbar.quota.source", QuotaResolver.Auto) ?? QuotaResolver.Auto;
+                    if (QuotaSelectionPolicy.MigrationToPersist(quota, persistedSelection)
+                        is { } migrated)
                     {
-                        var persistedSelection = AppSettings.Store.GetString(
-                            "tokenbar.quota.source", QuotaResolver.Auto) ?? QuotaResolver.Auto;
-                        if (QuotaSelectionPolicy.MigrationToPersist(quota, persistedSelection)
-                            is { } migrated)
-                        {
-                            AppSettings.Store.SetString("tokenbar.quota.source", migrated);
-                        }
+                        AppSettings.Store.SetString("tokenbar.quota.source", migrated);
                     }
 
                     RecomputeVisibleUsage();
@@ -200,7 +310,7 @@ public sealed class TrayFeed : IDisposable
             }
             finally
             {
-                Volatile.Write(ref _slowInFlight, 0);
+                Volatile.Write(ref _quotaInFlight, 0);
             }
         });
     }

--- a/src/TokenBar.App/TrayService.cs
+++ b/src/TokenBar.App/TrayService.cs
@@ -38,7 +38,7 @@ public sealed class TrayService : IDisposable
     private TaskCompletionSource<bool>? _readyTcs;
     private bool _trayCreationFailed;
 
-    public TrayService(FlyoutWindow flyout)
+    public TrayService(FlyoutWindow flyout, GraphRequestCoordinator graphCoordinator)
     {
         _icon = new TaskbarIcon
         {
@@ -59,7 +59,7 @@ public sealed class TrayService : IDisposable
         _icon.ContextMenuMode = ContextMenuMode.PopupMenu;
 
         _dispatcher = DispatcherQueue.GetForCurrentThread();
-        _feed = new TrayFeed(_dispatcher);
+        _feed = new TrayFeed(_dispatcher, graphCoordinator);
         _animator = new TrayAnimator(_dispatcher, () => _feed.TokensPerMin, ApplyCachedIcon);
         OpenSettings = ShowSettings;
         _feed.Changed += () =>
@@ -348,8 +348,10 @@ public sealed class TrayService : IDisposable
         var lines = new List<string>
         {
             ProductIdentity.Name,
-            $"Today {Format.CompactTokens(totals.TodayTokens)} · {Format.Usd(totals.TodayCost)}",
-            $"All time {Format.CompactTokens(totals.TotalTokens)} · {Format.Usd(totals.TotalCost)}",
+            $"Today {Format.CompactTokens(totals.TodayTokens)} · "
+                + CostSurfaceProjection.CostText(totals.TodayCost, _feed.CostAuthoritative),
+            $"All time {Format.CompactTokens(totals.TotalTokens)} · "
+                + CostSurfaceProjection.CostText(totals.TotalCost, _feed.CostAuthoritative),
         };
         var persistedSelection = AppSettings.Store.GetString(
             "tokenbar.quota.source", QuotaResolver.Auto) ?? QuotaResolver.Auto;
@@ -372,7 +374,12 @@ public sealed class TrayService : IDisposable
             AppSettings.Store.GetString("tokenbar.icon.coloring"));
         var dark = IsSystemDark();
         var remaining = _feed.QuotaRemaining;
-        var title = mode.Title(_feed.VisibleTotals, _feed.TokensPerMin, remaining);
+        var title = CostSurfaceProjection.TrayTitle(
+            mode,
+            _feed.VisibleTotals,
+            _feed.TokensPerMin,
+            remaining,
+            _feed.CostAuthoritative);
 
         // The tooltip is the summary layer (parity table #1): it carries the
         // full figures whatever the icon shows — including the icon-only

--- a/src/TokenBar.Core.Tests/CostSurfaceProjectionTests.cs
+++ b/src/TokenBar.Core.Tests/CostSurfaceProjectionTests.cs
@@ -1,0 +1,200 @@
+using TokenBar.App;
+using TokenBar.Core;
+using TokenBar.Interop;
+
+namespace TokenBar.Core.Tests;
+
+public class CostSurfaceProjectionTests
+{
+    private static readonly ModelReportEntry ExpensiveFewTokens =
+        new("claude", "model-a", "anthropic", 1, 0, 0, 0, 0, 1, 1, 100);
+
+    private static readonly ModelReportEntry CheapManyTokens =
+        new("claude", "model-b", "anthropic", 100, 0, 0, 0, 0, 100, 1, 1);
+
+    private static readonly AgentReportEntry ExpensiveAgent =
+        new("agent-a", [], 1, 0, 0, 0, 0, 1, 100, 1);
+
+    private static readonly AgentReportEntry TokenAgent =
+        new("agent-b", [], 100, 0, 0, 0, 0, 100, 1, 1);
+
+    private static UsagePayload Payload(
+        PricingMode pricing = PricingMode.BestEffort,
+        CostCoverage coverage = CostCoverage.Complete) =>
+        new(
+            new UsageMeta(
+                "generated",
+                "test",
+                new DateRange("2026-01-01", "2026-01-02"),
+                pricing,
+                coverage),
+            new UsageSummary(100, 100, 1, 1, 100, 100, ["claude"], ["model-a"]),
+            [],
+            [new Contribution(
+                "2026-01-02",
+                new ContributionTotals(100, 100, 1),
+                1,
+                new TokenBreakdown(100, 0, 0, 0, 0),
+                [new ContributionClient(
+                    "claude", "model-a", "anthropic",
+                    new TokenBreakdown(100, 0, 0, 0, 0), 100, 1)])]);
+
+    [Theory]
+    [InlineData(PricingMode.LocalOnly, CostCoverage.Complete, false)]
+    [InlineData(PricingMode.LocalOnly, CostCoverage.Partial, false)]
+    [InlineData(PricingMode.LocalOnly, CostCoverage.None, false)]
+    [InlineData(PricingMode.BestEffort, CostCoverage.Partial, false)]
+    [InlineData(PricingMode.BestEffort, CostCoverage.None, false)]
+    [InlineData(PricingMode.BestEffort, CostCoverage.Complete, true)]
+    public void MetadataMatrixIsTheOnlyCostAuthority(
+        PricingMode pricing, CostCoverage coverage, bool expected)
+    {
+        Assert.Equal(expected, CostSurfaceProjection.IsAuthoritative(
+            Payload(pricing, coverage)));
+    }
+
+    [Fact]
+    public void CheckingPolicyUsesTokenFallbacksAcrossNamedSurfaces()
+    {
+        var entries = new[] { ExpensiveFewTokens, CheapManyTokens };
+        var agents = new[] { ExpensiveAgent, TokenAgent };
+        var payload = Payload();
+        var stats = new UsageStats(payload, new HashSet<string> { "claude" });
+
+        Assert.Equal("Checking · 1 active days",
+            CostSurfaceProjection.HeaderCostLine(stats, false));
+        Assert.Equal(ChartMetric.Tokens,
+            CostSurfaceProjection.EffectiveMetric(false, ChartMetric.Cost));
+        Assert.Equal("Price · Checking",
+            CostSurfaceProjection.ChartCostLabel(false));
+        Assert.True(CostSurfaceProjection.IsChartCostChecking(
+            false, ChartMetric.Cost));
+        Assert.False(CostSurfaceProjection.IsChartCostChecking(
+            false, ChartMetric.Tokens));
+        Assert.False(CostSurfaceProjection.IsChartCostChecking(
+            true, ChartMetric.Cost));
+        Assert.Equal("Checking cost…", CostSurfaceProjection.ChartChecking);
+        Assert.Equal("2 models · Checking",
+            CostSurfaceProjection.ModelsSubtitle(entries, false));
+        Assert.Equal("Checking",
+            CostSurfaceProjection.CostText(100, false));
+        Assert.Equal("Checking",
+            CostSurfaceProjection.DayTipCost(100, false));
+        Assert.Equal("Checking",
+            CostSurfaceProjection.HourlyCost(100, false));
+        Assert.Equal("Checking",
+            CostSurfaceProjection.ModelTipCost(100, false));
+        Assert.Equal("Checking",
+            CostSurfaceProjection.BestDayText(stats.BestDay, false));
+        Assert.Equal("Agents by tokens",
+            CostSurfaceProjection.AgentsTitle(false));
+        Assert.Equal("Checking",
+            CostSurfaceProjection.TrayTitle(
+                TrayMode.TodayCost,
+                new TrayTotals(1, 100, 1, 100),
+                null,
+                null,
+                false));
+        Assert.Equal("Checking",
+            CostSurfaceProjection.TrayTitle(
+                TrayMode.TotalCost,
+                new TrayTotals(1, 100, 1, 100),
+                null,
+                null,
+                false));
+
+        Assert.Equal("model-b",
+            CostSurfaceProjection.OrderModels(entries, false).First().Model);
+        var segments = new[]
+        {
+            new DaySegment("a", "a", "#000000") { Tokens = 1, Cost = 100 },
+            new DaySegment("b", "b", "#000000") { Tokens = 100, Cost = 1 },
+        };
+        Assert.Equal("b",
+            CostSurfaceProjection.OrderDaySegments(
+                segments, false, ChartMetric.Cost).First().Key);
+        Assert.Equal("agent-b",
+            CostSurfaceProjection.OrderAgents(agents, false).First().Agent);
+        Assert.Equal(100,
+            CostSurfaceProjection.AgentBarValue(TokenAgent, false));
+        Assert.Equal(100, CostSurfaceProjection.AgentScale(agents, false));
+
+        var colors = new ModelColorMap(entries.Select(e =>
+            (e.Provider, e.Model, e.Cost)), costAuthoritative: false);
+        Assert.Equal("#da7756", colors.Color("anthropic", "model-a"));
+        Assert.NotEqual("#da7756", colors.Color("anthropic", "model-b"));
+
+        var clients = new[]
+        {
+            new ContributionClient(
+                "claude", "model-a", "anthropic",
+                new TokenBreakdown(1, 0, 0, 0, 0), 100, 1),
+            new ContributionClient(
+                "claude", "model-b", "anthropic",
+                new TokenBreakdown(100, 0, 0, 0, 0), 1, 1),
+        };
+        Assert.Equal("model-b",
+            CostSurfaceProjection.OrderContributionClients(clients, false).First().ModelId);
+    }
+
+    [Fact]
+    public void ExactCompleteRestoresCostOrderScaleAndFormatting()
+    {
+        var entries = new[] { ExpensiveFewTokens, CheapManyTokens };
+        var agents = new[] { ExpensiveAgent, TokenAgent };
+        var payload = Payload();
+        var stats = new UsageStats(payload, new HashSet<string> { "claude" });
+
+        Assert.Equal("$100.00 today · $100.00 all time · 1 active days",
+            CostSurfaceProjection.HeaderCostLine(100, stats, true));
+        Assert.Equal(ChartMetric.Cost,
+            CostSurfaceProjection.EffectiveMetric(true, ChartMetric.Cost));
+        Assert.Equal("2 models · $101.00",
+            CostSurfaceProjection.ModelsSubtitle(entries, true));
+        Assert.Equal("$100.00", CostSurfaceProjection.CostText(100, true));
+        Assert.Equal("model-a",
+            CostSurfaceProjection.OrderModels(entries, true).First().Model);
+        Assert.Equal("agent-a",
+            CostSurfaceProjection.OrderAgents(agents, true).First().Agent);
+        Assert.Equal(100, CostSurfaceProjection.AgentScale(agents, true));
+        Assert.Equal("Agents by cost", CostSurfaceProjection.AgentsTitle(true));
+        Assert.Equal("$100.00",
+            CostSurfaceProjection.TrayTitle(
+                TrayMode.TodayCost,
+                new TrayTotals(1, 100, 1, 100),
+                null,
+                null,
+                true));
+    }
+
+    [Fact]
+    public void DelayedOldGenerationCannotRestoreCostAuthority()
+    {
+        var state = new GraphConsumerState();
+        var old = new GraphRequestId(GraphQuery.Normalize(null), 1);
+        var current = new GraphRequestId(GraphQuery.Normalize(null), 2);
+        var query2 = new GraphRequestId(GraphQuery.Normalize("2025"), 3);
+
+        state.Begin(old);
+        Assert.True(state.TryAcceptGraph(
+            old, Payload(), GraphPublicationStage.Richer));
+        Assert.True(state.CostAuthoritative);
+
+        state.Begin(current);
+        Assert.False(state.CostAuthoritative);
+        Assert.False(state.TryAcceptGraph(
+            old, Payload(), GraphPublicationStage.Richer));
+        Assert.Equal("Checking", CostSurfaceProjection.CostText(100, false));
+
+        state.Begin(query2);
+        Assert.False(state.TryAcceptGraph(
+            current, Payload(), GraphPublicationStage.Richer));
+        Assert.False(state.CostAuthoritative);
+
+        // A blocked/failed local stage leaves the new query checking until the
+        // exact current richer result is accepted.
+        Assert.True(state.TryAcceptGraph(
+            query2, Payload(), GraphPublicationStage.Richer));
+        Assert.True(state.CostAuthoritative);
+    }
+}

--- a/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
+++ b/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
@@ -1,0 +1,164 @@
+using TokenBar.App;
+using TokenBar.Interop;
+
+namespace TokenBar.Core.Tests;
+
+public class GraphConsumerStateTests
+{
+    private static UsagePayload Payload(
+        PricingMode pricing = PricingMode.BestEffort,
+        CostCoverage coverage = CostCoverage.Complete) =>
+        new(
+            new UsageMeta(
+                "generated",
+                "test",
+                new DateRange("2026-01-01", "2026-12-31"),
+                pricing,
+                coverage),
+            new UsageSummary(1, 2, 1, 1, 2, 2, [], []),
+            [],
+            []);
+
+    private static GraphRequestId Id(string? year, long generation) =>
+        new(GraphQuery.Normalize(year), generation);
+
+    [Fact]
+    public void BeginRevokesOldGraphAndRejectsDelayedCallback()
+    {
+        var state = new GraphConsumerState();
+        var first = Id("2026", 1);
+        var second = Id("2026", 2);
+        var querySwitch = Id("2025", 3);
+
+        Assert.True(state.Begin(first));
+        Assert.True(state.TryAcceptGraph(
+            first, Payload(), GraphPublicationStage.Richer));
+        Assert.True(state.CostAuthoritative);
+
+        Assert.True(state.Begin(second));
+        Assert.False(state.LocalAccepted);
+        Assert.False(state.CostAuthoritative);
+        Assert.Null(state.AcceptedGraph);
+        Assert.False(state.TryAcceptGraph(
+            first, Payload(), GraphPublicationStage.Richer));
+
+        Assert.True(state.Begin(querySwitch));
+        Assert.Null(state.AcceptedGraph);
+        Assert.False(state.TryAcceptGraph(
+            second, Payload(), GraphPublicationStage.Richer));
+    }
+
+    [Fact]
+    public void BeginRejectsOlderSameQueryButAllowsOlderDifferentQuery()
+    {
+        var state = new GraphConsumerState();
+        var current = Id(null, 9);
+        var olderSameQuery = Id(null, 8);
+        var olderDifferentQuery = Id("2025", 1);
+
+        Assert.True(state.Begin(current));
+        Assert.True(state.TryAcceptGraph(
+            current, Payload(), GraphPublicationStage.Richer));
+        Assert.False(state.Begin(olderSameQuery));
+        Assert.Equal(current, state.DesiredId);
+        Assert.True(state.CostAuthoritative);
+
+        Assert.True(state.Begin(olderDifferentQuery));
+        Assert.Equal(olderDifferentQuery, state.DesiredId);
+        Assert.False(state.CostAuthoritative);
+    }
+
+    [Fact]
+    public void RetainedLocalCannotRegressSameGenerationRicherPublication()
+    {
+        var state = new GraphConsumerState();
+        var id = Id(null, 1);
+        var richer = Payload();
+        var retainedLocal = Payload(PricingMode.LocalOnly, CostCoverage.None);
+        state.Begin(id);
+
+        Assert.True(state.TryAcceptGraph(
+            id, richer, GraphPublicationStage.Richer));
+        Assert.False(state.TryAcceptGraph(
+            id, retainedLocal, GraphPublicationStage.LocalFirst));
+
+        Assert.Same(richer, state.AcceptedGraph);
+        Assert.Equal(GraphPublicationStage.Richer, state.AcceptedStage);
+        Assert.True(state.LocalAccepted);
+        Assert.True(state.CostAuthoritative);
+    }
+
+    [Theory]
+    [InlineData(PricingMode.LocalOnly, CostCoverage.Complete)]
+    [InlineData(PricingMode.LocalOnly, CostCoverage.Partial)]
+    [InlineData(PricingMode.LocalOnly, CostCoverage.None)]
+    [InlineData(PricingMode.BestEffort, CostCoverage.Partial)]
+    [InlineData(PricingMode.BestEffort, CostCoverage.None)]
+    public void NonAuthoritativeMetadataStaysChecking(
+        PricingMode pricing, CostCoverage coverage)
+    {
+        var state = new GraphConsumerState();
+        var id = Id(null, 1);
+        state.Begin(id);
+
+        Assert.True(state.TryAcceptGraph(
+            id, Payload(pricing, coverage), GraphPublicationStage.LocalFirst));
+        Assert.True(state.LocalAccepted);
+        Assert.False(state.CostAuthoritative);
+    }
+
+    [Fact]
+    public void BlockedOrFailedLocalLeavesLocalAcceptedFalse()
+    {
+        var state = new GraphConsumerState();
+        var id = Id(null, 1);
+        state.Begin(id);
+
+        Assert.False(state.LocalAccepted);
+        Assert.False(state.TryBeginModel(id));
+        Assert.False(state.CostAuthoritative);
+    }
+
+    [Fact]
+    public void ExactCurrentCompleteRestoresAuthorityAndModelStartsOnce()
+    {
+        var state = new GraphConsumerState();
+        var id = Id(null, 4);
+        state.Begin(id);
+
+        // A retained richer publication is enough for a late observer to prove
+        // the local stage and start ModelReport exactly once.
+        Assert.True(state.TryAcceptGraph(
+            id, Payload(), GraphPublicationStage.Richer));
+        Assert.True(state.TryBeginModel(id));
+        Assert.False(state.TryBeginModel(id));
+        Assert.True(state.TryAcceptModel(id, new ModelReport([], 0, 0, 0, 0, 0, 0)));
+        Assert.True(state.ModelAccepted);
+
+        var newer = Id(null, 5);
+        Assert.True(state.Begin(newer));
+        Assert.False(state.CostAuthoritative);
+        Assert.False(state.TryAcceptModel(
+            id, new ModelReport([], 0, 0, 0, 0, 0, 0)));
+        Assert.True(state.TryAcceptGraph(
+            newer, Payload(), GraphPublicationStage.Richer));
+        Assert.True(state.CostAuthoritative);
+    }
+
+    [Fact]
+    public void DisposeFencesGraphAndModelTransitions()
+    {
+        var state = new GraphConsumerState();
+        var id = Id(null, 1);
+        state.Begin(id);
+        state.Dispose();
+
+        Assert.True(state.IsDisposed);
+        Assert.False(state.Begin(Id(null, 2)));
+        Assert.False(state.TryAcceptGraph(
+            id, Payload(), GraphPublicationStage.Richer));
+        Assert.False(state.TryBeginModel(id));
+        Assert.False(state.TryAcceptModel(
+            id, new ModelReport([], 0, 0, 0, 0, 0, 0)));
+    }
+}

--- a/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
+++ b/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
@@ -85,6 +85,19 @@ public class GraphConsumerStateTests
     }
 
     [Fact]
+    public void LazyRefreshSchedulesOncePerExactGraphRequest()
+    {
+        var first = Id(null, 1);
+        var second = Id(null, 2);
+        var otherQuery = Id("2026", 1);
+
+        Assert.True(GraphLazyRefreshPolicy.ShouldRequest(null, first));
+        Assert.False(GraphLazyRefreshPolicy.ShouldRequest(first, first));
+        Assert.True(GraphLazyRefreshPolicy.ShouldRequest(first, second));
+        Assert.True(GraphLazyRefreshPolicy.ShouldRequest(first, otherQuery));
+    }
+
+    [Fact]
     public void BeginRevokesOldGraphAndRejectsDelayedCallback()
     {
         var state = new GraphConsumerState();

--- a/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
+++ b/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
@@ -7,7 +7,8 @@ public class GraphConsumerStateTests
 {
     private static UsagePayload Payload(
         PricingMode pricing = PricingMode.BestEffort,
-        CostCoverage coverage = CostCoverage.Complete) =>
+        CostCoverage coverage = CostCoverage.Complete,
+        IReadOnlyList<YearMeta>? years = null) =>
         new(
             new UsageMeta(
                 "generated",
@@ -16,7 +17,7 @@ public class GraphConsumerStateTests
                 pricing,
                 coverage),
             new UsageSummary(1, 2, 1, 1, 2, 2, [], []),
-            [],
+            years ?? [],
             []);
 
     private static GraphRequestId Id(string? year, long generation) =>
@@ -54,6 +55,33 @@ public class GraphConsumerStateTests
         Assert.True(rerun.IsCurrent);
         Assert.True(rerun.ShouldRerun);
         Assert.False(rerun.ClearRefreshing);
+    }
+
+    [Fact]
+    public void MissingYearPolicyClearsOnlyTheExactSelectedYear()
+    {
+        var missing = new GraphPublication(
+            Id("2026", 1),
+            GraphPublicationStage.LocalFirst,
+            Payload());
+        var present = missing with
+        {
+            Payload = Payload(years:
+            [
+                new YearMeta(
+                    "2026",
+                    1,
+                    2,
+                    new DateRange("2026-01-01", "2026-12-31")),
+            ]),
+        };
+        var allTime = missing with { RequestId = Id(null, 2) };
+
+        Assert.True(GraphYearPolicy.ShouldClearToAllTime("2026", missing));
+        Assert.False(GraphYearPolicy.ShouldClearToAllTime("2025", missing));
+        Assert.False(GraphYearPolicy.ShouldClearToAllTime(null, missing));
+        Assert.False(GraphYearPolicy.ShouldClearToAllTime("2026", present));
+        Assert.False(GraphYearPolicy.ShouldClearToAllTime("2026", allTime));
     }
 
     [Fact]

--- a/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
+++ b/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
@@ -23,6 +23,40 @@ public class GraphConsumerStateTests
         new(GraphQuery.Normalize(year), generation);
 
     [Fact]
+    public void CompletionPolicyFencesStaleSettlesHiddenAndKeepsRerunSpinner()
+    {
+        var stale = GraphCompletionPolicy.Decide(
+            isCurrent: false,
+            polling: true,
+            sameYear: true,
+            forceRequested: false,
+            refreshing: true);
+        Assert.False(stale.IsCurrent);
+        Assert.False(stale.ShouldRerun);
+        Assert.False(stale.ClearRefreshing);
+
+        var hidden = GraphCompletionPolicy.Decide(
+            isCurrent: true,
+            polling: false,
+            sameYear: false,
+            forceRequested: true,
+            refreshing: true);
+        Assert.True(hidden.IsCurrent);
+        Assert.False(hidden.ShouldRerun);
+        Assert.True(hidden.ClearRefreshing);
+
+        var rerun = GraphCompletionPolicy.Decide(
+            isCurrent: true,
+            polling: true,
+            sameYear: false,
+            forceRequested: false,
+            refreshing: true);
+        Assert.True(rerun.IsCurrent);
+        Assert.True(rerun.ShouldRerun);
+        Assert.False(rerun.ClearRefreshing);
+    }
+
+    [Fact]
     public void BeginRevokesOldGraphAndRejectsDelayedCallback()
     {
         var state = new GraphConsumerState();

--- a/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
+++ b/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
@@ -23,6 +23,14 @@ public class GraphRequestCoordinatorTests
             []);
 
     [Fact]
+    public void GraphQueryNormalizesDashboardYearIdentity()
+    {
+        Assert.Equal("2026", GraphQuery.Normalize(" 2026 ").Year);
+        Assert.Null(GraphQuery.Normalize(" ").Year);
+        Assert.Null(GraphQuery.Normalize(null).Year);
+    }
+
+    [Fact]
     public async Task LocalPublishesBeforeBlockedRicherAndRetainedAttachAddsNoCalls()
     {
         var richerGate = new TaskCompletionSource<bool>(

--- a/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
+++ b/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
@@ -1,0 +1,548 @@
+using System.Collections.Concurrent;
+using TokenBar.App;
+using TokenBar.Interop;
+
+namespace TokenBar.Core.Tests;
+
+public class GraphRequestCoordinatorTests
+{
+    private static UsagePayload Payload(
+        string? year,
+        PricingMode pricing = PricingMode.LocalOnly,
+        CostCoverage coverage = CostCoverage.Complete) =>
+        new(
+            new UsageMeta(
+                "generated",
+                "test",
+                new DateRange("2026-01-01", "2026-12-31"),
+                pricing,
+                coverage),
+            new UsageSummary(1, 2, 1, 1, 2, 2, [], []),
+            year is null ? [] : [new YearMeta(year, 1, 2,
+                new DateRange($"{year}-01-01", $"{year}-12-31"))],
+            []);
+
+    [Fact]
+    public async Task LocalPublishesBeforeBlockedRicherAndRetainedAttachAddsNoCalls()
+    {
+        var richerGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var richerStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var localPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var publications = new ConcurrentQueue<GraphPublication>();
+        var localCalls = 0;
+        var richerCalls = 0;
+        var local = Payload(null);
+        var richer = Payload(null, PricingMode.BestEffort, CostCoverage.Complete);
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                Interlocked.Increment(ref localCalls);
+                return local;
+            },
+            _ =>
+            {
+                Interlocked.Increment(ref richerCalls);
+                richerStarted.TrySetResult(true);
+                richerGate.Task.GetAwaiter().GetResult();
+                return richer;
+            });
+        coordinator.Published += publication =>
+        {
+            publications.Enqueue(publication);
+            if (publication.Stage == GraphPublicationStage.LocalFirst)
+            {
+                localPublished.TrySetResult(true);
+            }
+        };
+        coordinator.Completed += completion => completed.TrySetResult(completion);
+
+        var requestId = coordinator.Request(null);
+        await localPublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(GraphPublicationStage.LocalFirst,
+            publications.First().Stage);
+        await richerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, localCalls);
+        Assert.Equal(1, richerCalls);
+
+        var retained = coordinator.Attach(null);
+        Assert.Equal(requestId, retained.RequestId);
+        Assert.True(retained.InFlight);
+        Assert.Equal(GraphPublicationStage.LocalFirst, retained.Latest?.Stage);
+
+        richerGate.TrySetResult(true);
+        var result = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(result.Succeeded);
+        Assert.Equal(2, publications.Count);
+
+        var late = coordinator.Attach(null);
+        Assert.Equal(requestId, late.RequestId);
+        Assert.False(late.InFlight);
+        Assert.Equal(GraphPublicationStage.Richer, late.Latest?.Stage);
+        var consumer = new GraphConsumerState();
+        consumer.Begin(late.RequestId);
+        Assert.True(consumer.TryAcceptGraph(
+            late.RequestId,
+            late.Latest!.Payload,
+            late.Latest.Stage));
+        Assert.True(consumer.LocalAccepted);
+        Assert.Equal(1, localCalls);
+        Assert.Equal(1, richerCalls);
+    }
+
+    [Fact]
+    public async Task AttachReplaysRicherPublishedBeforeBegin()
+    {
+        var localPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var richerStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var richerPublishedRejected = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var richerGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                localPublished.TrySetResult(true);
+                return Payload(null, PricingMode.LocalOnly, CostCoverage.Complete);
+            },
+            _ =>
+            {
+                richerStarted.TrySetResult(true);
+                richerGate.Task.GetAwaiter().GetResult();
+                return Payload(null, PricingMode.BestEffort, CostCoverage.Complete);
+            });
+        coordinator.Published += publication =>
+        {
+            if (publication.Stage == GraphPublicationStage.LocalFirst)
+            {
+                localPublished.TrySetResult(true);
+            }
+        };
+
+        var requestId = coordinator.Request(null);
+        await localPublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await richerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var retained = coordinator.Attach(null);
+        Assert.Equal(requestId, retained.RequestId);
+        Assert.Equal(GraphPublicationStage.LocalFirst, retained.Latest?.Stage);
+
+        var consumer = new GraphConsumerState();
+        coordinator.Published += publication =>
+        {
+            if (publication.RequestId == requestId
+                && publication.Stage == GraphPublicationStage.Richer
+                && !consumer.TryAcceptGraph(
+                    publication.RequestId, publication.Payload, publication.Stage))
+            {
+                richerPublishedRejected.TrySetResult(true);
+            }
+        };
+
+        var beginEntered = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowBegin = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachmentTask = Task.Run(() => coordinator.Attach(
+            null,
+            id =>
+            {
+                beginEntered.TrySetResult(true);
+                allowBegin.Task.GetAwaiter().GetResult();
+                Assert.True(consumer.Begin(id));
+            }));
+
+        await beginEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Null(consumer.DesiredId);
+        richerGate.TrySetResult(true);
+        await richerPublishedRejected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Null(consumer.DesiredId);
+
+        allowBegin.TrySetResult(true);
+        var attachment = await attachmentTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(requestId, attachment.RequestId);
+        Assert.Equal(GraphPublicationStage.Richer, attachment.Latest?.Stage);
+        Assert.True(consumer.TryAcceptGraph(
+            attachment.RequestId,
+            attachment.Latest!.Payload,
+            attachment.Latest.Stage));
+        Assert.True(consumer.CostAuthoritative);
+    }
+
+    [Fact]
+    public async Task AttachAndNonForceRequestCoalesceInFlight()
+    {
+        var localGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                Interlocked.Increment(ref calls);
+                started.TrySetResult(true);
+                localGate.Task.GetAwaiter().GetResult();
+                return Payload("2026");
+            },
+            _ => Payload("2026", PricingMode.BestEffort, CostCoverage.Complete));
+        coordinator.Completed += _ => completion.TrySetResult(true);
+
+        var first = coordinator.Attach(" 2026 ");
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var second = coordinator.Attach("2026");
+        var third = coordinator.Request("2026");
+
+        Assert.Equal(first.RequestId, second.RequestId);
+        Assert.Equal(second.RequestId, third);
+        Assert.Equal(1, calls);
+
+        localGate.TrySetResult(true);
+        await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ForceSupersedesOldRicherAndPublishesOnlyCurrentRicher()
+    {
+        var oldRicherGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var oldRicherStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var completions = new ConcurrentQueue<GraphRequestCompletion>();
+        var publications = new ConcurrentQueue<GraphPublication>();
+        var localCalls = 0;
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                Interlocked.Increment(ref localCalls);
+                return Payload(null);
+            },
+            _ =>
+            {
+                oldRicherStarted.TrySetResult(true);
+                oldRicherGate.Task.GetAwaiter().GetResult();
+                return Payload(null, PricingMode.BestEffort, CostCoverage.Complete);
+            },
+            _ => Payload(null, PricingMode.BestEffort, CostCoverage.Complete));
+        coordinator.Published += publications.Enqueue;
+        coordinator.Completed += completions.Enqueue;
+
+        var oldId = coordinator.Request(null);
+        await oldRicherStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var currentId = coordinator.Request(null, force: true);
+        Assert.True(currentId.Generation > oldId.Generation);
+
+        await WaitUntil(() => completions.Any(c => c.RequestId == currentId));
+        oldRicherGate.TrySetResult(true);
+        await Task.Delay(50);
+
+        Assert.Equal(2, localCalls);
+        Assert.Contains(publications, p => p.RequestId == currentId
+            && p.Stage == GraphPublicationStage.Richer);
+        Assert.DoesNotContain(publications, p => p.RequestId == oldId
+            && p.Stage == GraphPublicationStage.Richer);
+    }
+
+    [Fact]
+    public async Task StartedBroadcastKeepsAllTimeConsumersOnOneGeneration()
+    {
+        var secondLocalGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCompletion = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondCompletion = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var localCalls = 0;
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                if (Interlocked.Increment(ref localCalls) == 2)
+                {
+                    secondLocalGate.Task.GetAwaiter().GetResult();
+                }
+
+                return Payload(null, PricingMode.BestEffort, CostCoverage.Complete);
+            },
+            _ => Payload(null, PricingMode.BestEffort, CostCoverage.Complete),
+            _ => Payload(null, PricingMode.BestEffort, CostCoverage.Complete));
+        var tray = new GraphConsumerState();
+        var dashboard = new GraphConsumerState();
+        var starts = new ConcurrentQueue<GraphRequestId>();
+        coordinator.Started += _ => throw new InvalidOperationException("observer");
+        coordinator.Started += id =>
+        {
+            starts.Enqueue(id);
+            if (id.Query.Year is null)
+            {
+                tray.Begin(id);
+            }
+        };
+        coordinator.Started += id =>
+        {
+            if (id.Query.Year is null)
+            {
+                dashboard.Begin(id);
+            }
+        };
+        coordinator.Published += publication =>
+        {
+            tray.TryAcceptGraph(
+                publication.RequestId, publication.Payload, publication.Stage);
+            dashboard.TryAcceptGraph(
+                publication.RequestId, publication.Payload, publication.Stage);
+        };
+        coordinator.Completed += completion =>
+        {
+            if (completion.RequestId.Generation == 1)
+            {
+                firstCompletion.TrySetResult(completion);
+            }
+            else
+            {
+                secondCompletion.TrySetResult(completion);
+            }
+        };
+
+        var first = coordinator.Request(null);
+        await firstCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(tray.CostAuthoritative);
+        Assert.True(dashboard.CostAuthoritative);
+
+        var second = coordinator.Request(null, force: true,
+            onBegin: id => dashboard.Begin(id));
+        Assert.Equal(second, tray.DesiredId);
+        Assert.Equal(second, dashboard.DesiredId);
+        Assert.False(tray.CostAuthoritative);
+        Assert.False(dashboard.CostAuthoritative);
+
+        secondLocalGate.TrySetResult(true);
+        await secondCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(tray.CostAuthoritative);
+        Assert.True(dashboard.CostAuthoritative);
+
+        var retained = coordinator.Attach(null);
+        Assert.Equal(second, retained.RequestId);
+        Assert.Equal(2, starts.Count);
+    }
+
+    [Fact]
+    public async Task YearStartedDoesNotMoveAllTimeTrayState()
+    {
+        var firstCompletion = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var yearCompletion = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new GraphRequestCoordinator(
+            year => Payload(year, PricingMode.BestEffort, CostCoverage.Complete),
+            year => Payload(year, PricingMode.BestEffort, CostCoverage.Complete));
+        var tray = new GraphConsumerState();
+        var dashboard = new GraphConsumerState();
+        coordinator.Started += id =>
+        {
+            if (id.Query.Year is null)
+            {
+                tray.Begin(id);
+            }
+        };
+        coordinator.Started += id =>
+        {
+            if (id.Query.Year == "2026")
+            {
+                dashboard.Begin(id);
+            }
+        };
+        coordinator.Published += publication =>
+        {
+            tray.TryAcceptGraph(
+                publication.RequestId, publication.Payload, publication.Stage);
+            dashboard.TryAcceptGraph(
+                publication.RequestId, publication.Payload, publication.Stage);
+        };
+        coordinator.Completed += completion =>
+        {
+            if (completion.RequestId.Query.Year is null)
+            {
+                firstCompletion.TrySetResult(completion);
+            }
+            else
+            {
+                yearCompletion.TrySetResult(completion);
+            }
+        };
+
+        var allTime = coordinator.Request(null);
+        await firstCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(tray.CostAuthoritative);
+
+        var year = coordinator.Request("2026");
+        Assert.Equal(allTime, tray.DesiredId);
+        Assert.True(tray.CostAuthoritative);
+        Assert.Equal(year, dashboard.DesiredId);
+
+        await yearCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(allTime, tray.DesiredId);
+        Assert.True(tray.CostAuthoritative);
+        Assert.True(dashboard.CostAuthoritative);
+    }
+
+    [Fact]
+    public async Task SupersededBlockedLocalSkipsOldRicherDelegate()
+    {
+        var oldLocalStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var oldLocalGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var newerCompletion = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var localCalls = 0;
+        var normalRicherCalls = 0;
+        var refreshRicherCalls = 0;
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                if (Interlocked.Increment(ref localCalls) == 1)
+                {
+                    oldLocalStarted.TrySetResult(true);
+                    oldLocalGate.Task.GetAwaiter().GetResult();
+                }
+
+                return Payload(null);
+            },
+            _ =>
+            {
+                Interlocked.Increment(ref normalRicherCalls);
+                return Payload(null, PricingMode.BestEffort, CostCoverage.Complete);
+            },
+            _ =>
+            {
+                Interlocked.Increment(ref refreshRicherCalls);
+                return Payload(null, PricingMode.BestEffort, CostCoverage.Complete);
+            });
+        coordinator.Completed += completion =>
+        {
+            if (completion.RequestId.Generation > 1)
+            {
+                newerCompletion.TrySetResult(completion);
+            }
+        };
+
+        var old = coordinator.Request(null);
+        await oldLocalStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var newer = coordinator.Request(null, force: true);
+        var result = await newerCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(newer, result.RequestId);
+        Assert.True(result.RicherSucceeded);
+        Assert.Equal(1, refreshRicherCalls);
+
+        oldLocalGate.TrySetResult(true);
+        await Task.Delay(100);
+        Assert.Equal(0, normalRicherCalls);
+        Assert.True(newer.Generation > old.Generation);
+    }
+
+    [Fact]
+    public void CompletionMatchesOnlyExactSuccessfulRicherRequest()
+    {
+        var allTime = new GraphRequestId(GraphQuery.Normalize(null), 7);
+        var otherGeneration = new GraphRequestId(GraphQuery.Normalize(null), 6);
+        var year = new GraphRequestId(GraphQuery.Normalize("2026"), 7);
+
+        Assert.True(new GraphRequestCompletion(allTime, true, true)
+            .IsSuccessfulRicherFor(allTime));
+        Assert.False(new GraphRequestCompletion(allTime, true, false)
+            .IsSuccessfulRicherFor(allTime));
+        Assert.False(new GraphRequestCompletion(allTime, true, true)
+            .IsSuccessfulRicherFor(otherGeneration));
+        Assert.False(new GraphRequestCompletion(year, true, true)
+            .IsSuccessfulRicherFor(allTime));
+    }
+
+    [Fact]
+    public async Task StageFailuresPublishNoSuccessForThatStage()
+    {
+        var localCompleted = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var localPublications = new ConcurrentQueue<GraphPublication>();
+        var richerCalls = 0;
+        var localFailing = new GraphRequestCoordinator(
+            _ => throw new InvalidOperationException("blocked local"),
+            _ =>
+            {
+                Interlocked.Increment(ref richerCalls);
+                return Payload(null, PricingMode.BestEffort, CostCoverage.Complete);
+            });
+        localFailing.Published += localPublications.Enqueue;
+        localFailing.Completed += completion =>
+            localCompleted.TrySetResult(completion);
+        var localId = localFailing.Request(null);
+        var localResult = await localCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(localId, localResult.RequestId);
+        Assert.False(localResult.Succeeded);
+        Assert.Empty(localPublications);
+        Assert.Equal(0, richerCalls);
+
+        var richerCompleted = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var richerPublications = new ConcurrentQueue<GraphPublication>();
+        var richerFailing = new GraphRequestCoordinator(
+            _ => Payload(null),
+            _ => throw new InvalidOperationException("blocked richer"));
+        richerFailing.Published += richerPublications.Enqueue;
+        richerFailing.Completed += completion =>
+            richerCompleted.TrySetResult(completion);
+        var richerId = richerFailing.Request(null);
+        var richerResult = await richerCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(richerId, richerResult.RequestId);
+        Assert.False(richerResult.Succeeded);
+        Assert.Single(richerPublications);
+        Assert.Equal(GraphPublicationStage.LocalFirst,
+            richerPublications.Single().Stage);
+    }
+
+    private static async Task WaitForCompletion(
+        GraphRequestCoordinator coordinator,
+        GraphRequestId requestId)
+    {
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnCompleted(GraphRequestCompletion value)
+        {
+            if (value.RequestId == requestId)
+            {
+                completion.TrySetResult(true);
+            }
+        }
+
+        coordinator.Completed += OnCompleted;
+        try
+        {
+            await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            coordinator.Completed -= OnCompleted;
+        }
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!predicate())
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException("condition was not reached");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+}

--- a/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
+++ b/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
@@ -176,6 +176,60 @@ public class GraphRequestCoordinatorTests
     }
 
     [Fact]
+    public async Task CoalescedRequestReplaysLatestAfterConsumerBegins()
+    {
+        var localPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var richerGate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var local = Payload(null);
+        var coordinator = new GraphRequestCoordinator(
+            _ => local,
+            _ =>
+            {
+                richerGate.Task.GetAwaiter().GetResult();
+                throw new InvalidOperationException("blocked richer");
+            });
+        coordinator.Published += publication =>
+        {
+            if (publication.Stage == GraphPublicationStage.LocalFirst)
+            {
+                localPublished.TrySetResult(true);
+            }
+        };
+        coordinator.Completed += completion => completed.TrySetResult(completion);
+
+        var requestId = coordinator.Request(null);
+        await localPublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var consumer = new GraphConsumerState();
+        GraphPublication? replayed = null;
+        var coalesced = coordinator.Request(
+            null,
+            onBegin: id => Assert.True(consumer.Begin(id)),
+            onReplay: publication =>
+            {
+                replayed = publication;
+                Assert.True(consumer.TryAcceptGraph(
+                    publication.RequestId,
+                    publication.Payload,
+                    publication.Stage));
+            });
+
+        Assert.Equal(requestId, coalesced);
+        Assert.Equal(GraphPublicationStage.LocalFirst, replayed?.Stage);
+        Assert.Same(local, consumer.AcceptedGraph);
+
+        richerGate.TrySetResult(true);
+        var result = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(result.LocalSucceeded);
+        Assert.False(result.RicherSucceeded);
+        Assert.Same(local, consumer.AcceptedGraph);
+    }
+
+    [Fact]
     public async Task AttachAndNonForceRequestCoalesceInFlight()
     {
         var localGate = new TaskCompletionSource<bool>(
@@ -489,6 +543,56 @@ public class GraphRequestCoordinatorTests
     }
 
     [Fact]
+    public async Task GraphStagesRunInsideInjectedBoostScopes()
+    {
+        var completed = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var active = 0;
+        var opened = 0;
+        var closed = 0;
+        var localBoosted = false;
+        var richerBoosted = false;
+        IDisposable Boost()
+        {
+            Interlocked.Increment(ref opened);
+            Interlocked.Increment(ref active);
+            return new CallbackScope(() =>
+            {
+                Interlocked.Decrement(ref active);
+                Interlocked.Increment(ref closed);
+            });
+        }
+
+        var coordinator = new GraphRequestCoordinator(
+            localFirst: _ =>
+            {
+                localBoosted = Volatile.Read(ref active) == 1;
+                return Payload(null);
+            },
+            graph: _ =>
+            {
+                richerBoosted = Volatile.Read(ref active) == 1;
+                return Payload(
+                    null,
+                    PricingMode.BestEffort,
+                    CostCoverage.Complete);
+            },
+            boost: Boost);
+        coordinator.Completed += completion => completed.TrySetResult(completion);
+
+        var requestId = coordinator.Request(null);
+        var result = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(requestId, result.RequestId);
+        Assert.True(result.Succeeded);
+        Assert.True(localBoosted);
+        Assert.True(richerBoosted);
+        Assert.Equal(2, opened);
+        Assert.Equal(2, closed);
+        Assert.Equal(0, active);
+    }
+
+    [Fact]
     public void CompletionMatchesOnlyExactSuccessfulRicherRequest()
     {
         var allTime = new GraphRequestId(GraphQuery.Normalize(null), 7);
@@ -545,6 +649,13 @@ public class GraphRequestCoordinatorTests
         Assert.Single(richerPublications);
         Assert.Equal(GraphPublicationStage.LocalFirst,
             richerPublications.Single().Stage);
+    }
+
+    private sealed class CallbackScope(Action dispose) : IDisposable
+    {
+        private Action? _dispose = dispose;
+
+        public void Dispose() => Interlocked.Exchange(ref _dispose, null)?.Invoke();
     }
 
     private static async Task WaitForCompletion(

--- a/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
+++ b/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
@@ -449,6 +449,46 @@ public class GraphRequestCoordinatorTests
     }
 
     [Fact]
+    public async Task NormalDefaultRicherUsesInjectedRefreshWhenGraphDelegateIsMissing()
+    {
+        var completed = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var publications = new ConcurrentQueue<GraphPublication>();
+        var local = Payload(null);
+        var refreshed = Payload(null, PricingMode.BestEffort, CostCoverage.Complete);
+        var refreshCalls = 0;
+        var coordinator = new GraphRequestCoordinator(
+            localFirst: _ => local,
+            graph: null,
+            refreshGraph: _ =>
+            {
+                Interlocked.Increment(ref refreshCalls);
+                return refreshed;
+            });
+        coordinator.Published += publications.Enqueue;
+        coordinator.Completed += completion => completed.TrySetResult(completion);
+
+        var requestId = coordinator.Request(null);
+        var result = await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(requestId, result.RequestId);
+        Assert.True(result.RicherSucceeded);
+        Assert.Equal(1, refreshCalls);
+        Assert.Collection(
+            publications,
+            publication =>
+            {
+                Assert.Equal(GraphPublicationStage.LocalFirst, publication.Stage);
+                Assert.Same(local, publication.Payload);
+            },
+            publication =>
+            {
+                Assert.Equal(GraphPublicationStage.Richer, publication.Stage);
+                Assert.Same(refreshed, publication.Payload);
+            });
+    }
+
+    [Fact]
     public void CompletionMatchesOnlyExactSuccessfulRicherRequest()
     {
         var allTime = new GraphRequestId(GraphQuery.Normalize(null), 7);

--- a/src/TokenBar.Core.Tests/ModelColorsTests.cs
+++ b/src/TokenBar.Core.Tests/ModelColorsTests.cs
@@ -45,4 +45,17 @@ public class ModelColorsTests
         Assert.NotEqual("#da7756", map.Color("anthropic", "claude-haiku-4-5")); // cheaper = tinted
         Assert.Equal("#06b6d4", map.Color(null, "gemini-3-pro")); // unseen → provider base
     }
+
+    [Fact]
+    public void CheckingRankingUsesLexicalModelOrder()
+    {
+        var map = new ModelColorMap(
+        [
+            ("anthropic", "model-z", 100.0),
+            ("anthropic", "model-a", 1.0),
+        ], costAuthoritative: false);
+
+        Assert.Equal("#da7756", map.Color("anthropic", "model-a"));
+        Assert.NotEqual("#da7756", map.Color("anthropic", "model-z"));
+    }
 }

--- a/src/TokenBar.Core.Tests/RetainedGraphStartupTests.cs
+++ b/src/TokenBar.Core.Tests/RetainedGraphStartupTests.cs
@@ -1,0 +1,71 @@
+using TokenBar.App;
+using TokenBar.Interop;
+
+namespace TokenBar.Core.Tests;
+
+public class RetainedGraphStartupTests
+{
+    private static UsagePayload Payload() =>
+        new(
+            new UsageMeta(
+                "generated",
+                "test",
+                new DateRange("2026-01-01", "2026-12-31"),
+                PricingMode.BestEffort,
+                CostCoverage.Complete),
+            new UsageSummary(1, 2, 1, 1, 2, 2, [], []),
+            [],
+            []);
+
+    [Fact]
+    public async Task TrayFirstDashboardAttachReusesRichPublicationAndModelGate()
+    {
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var localCalls = 0;
+        var richerCalls = 0;
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                Interlocked.Increment(ref localCalls);
+                return Payload();
+            },
+            _ =>
+            {
+                Interlocked.Increment(ref richerCalls);
+                return Payload();
+            });
+        coordinator.Completed += _ => completion.TrySetResult(true);
+
+        var tray = new GraphConsumerState();
+        var trayAttachment = coordinator.Attach(null, id => { tray.Begin(id); });
+        Assert.True(trayAttachment.InFlight);
+        await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, localCalls);
+        Assert.Equal(1, richerCalls);
+
+        var dashboard = new GraphConsumerState();
+        var dashboardAttachment = coordinator.Attach(
+            null, id => { dashboard.Begin(id); });
+        Assert.Equal(trayAttachment.RequestId, dashboardAttachment.RequestId);
+        Assert.False(dashboardAttachment.InFlight);
+        Assert.NotNull(dashboardAttachment.Latest);
+        Assert.True(dashboard.TryAcceptGraph(
+            dashboardAttachment.RequestId,
+            dashboardAttachment.Latest!.Payload,
+            dashboardAttachment.Latest.Stage));
+        Assert.True(dashboard.TryBeginModel(dashboardAttachment.RequestId));
+        Assert.False(dashboard.TryBeginModel(dashboardAttachment.RequestId));
+        Assert.Equal(1, localCalls);
+        Assert.Equal(1, richerCalls);
+
+        var newer = coordinator.Request(
+            null,
+            force: true,
+            onBegin: id => { dashboard.Begin(id); });
+        Assert.False(dashboard.TryAcceptModel(
+            dashboardAttachment.RequestId,
+            new ModelReport([], 0, 0, 0, 0, 0, 0)));
+        Assert.True(newer.Generation > dashboardAttachment.RequestId.Generation);
+    }
+}

--- a/src/TokenBar.Core.Tests/RetainedGraphStartupTests.cs
+++ b/src/TokenBar.Core.Tests/RetainedGraphStartupTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using TokenBar.App;
 using TokenBar.Interop;
 
@@ -67,5 +68,93 @@ public class RetainedGraphStartupTests
             dashboardAttachment.RequestId,
             new ModelReport([], 0, 0, 0, 0, 0, 0)));
         Assert.True(newer.Generation > dashboardAttachment.RequestId.Generation);
+    }
+
+    [Fact]
+    public async Task AttachResumeRefreshesCompletedYearsOnly()
+    {
+        var completions = new ConcurrentQueue<GraphRequestCompletion>();
+        var localCalls = new ConcurrentDictionary<string, int>();
+        var yearStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseYear = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new GraphRequestCoordinator(
+            year =>
+            {
+                var key = year ?? "all";
+                localCalls.AddOrUpdate(key, 1, (_, count) => count + 1);
+                if (year == "2025")
+                {
+                    yearStarted.TrySetResult(true);
+                    releaseYear.Task.GetAwaiter().GetResult();
+                }
+
+                return Payload();
+            },
+            year =>
+            {
+                var key = $"richer:{year ?? "all"}";
+                localCalls.AddOrUpdate(key, 1, (_, count) => count + 1);
+                return Payload();
+            });
+        coordinator.Completed += completions.Enqueue;
+
+        var completedYear = coordinator.Request(" 2026 ");
+        await WaitUntil(() => completions.Any(
+            completion => completion.RequestId == completedYear));
+        var completedAttachment = coordinator.Attach(" 2026 ");
+        Assert.Equal("2026", completedAttachment.RequestId.Query.Year);
+        Assert.False(completedAttachment.InFlight);
+        Assert.NotNull(completedAttachment.Latest);
+        Assert.True(GraphResumePolicy.ShouldRefreshAfterAttach(completedAttachment));
+
+        var resumedYear = coordinator.Request(
+            completedAttachment.RequestId.Query.Year,
+            force: false);
+        Assert.True(resumedYear.Generation > completedYear.Generation);
+        await WaitUntil(() => completions.Any(
+            completion => completion.RequestId == resumedYear));
+        Assert.Equal(2, localCalls["2026"]);
+
+        var inFlightYear = coordinator.Request("2025");
+        await yearStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var inFlightAttachment = coordinator.Attach(" 2025 ");
+        Assert.Equal(inFlightYear, inFlightAttachment.RequestId);
+        Assert.True(inFlightAttachment.InFlight);
+        Assert.False(GraphResumePolicy.ShouldRefreshAfterAttach(inFlightAttachment));
+        if (GraphResumePolicy.ShouldRefreshAfterAttach(inFlightAttachment))
+        {
+            coordinator.Request(inFlightAttachment.RequestId.Query.Year);
+        }
+
+        releaseYear.TrySetResult(true);
+        await WaitUntil(() => completions.Any(
+            completion => completion.RequestId == inFlightYear));
+        Assert.Equal(1, localCalls["2025"]);
+
+        var allTime = coordinator.Request(null);
+        await WaitUntil(() => completions.Any(
+            completion => completion.RequestId == allTime));
+        var allTimeCalls = localCalls["all"];
+        var allTimeAttachment = coordinator.Attach(null);
+        Assert.Equal(allTime, allTimeAttachment.RequestId);
+        Assert.False(allTimeAttachment.InFlight);
+        Assert.False(GraphResumePolicy.ShouldRefreshAfterAttach(allTimeAttachment));
+        Assert.Equal(allTimeCalls, localCalls["all"]);
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!predicate())
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException("condition was not reached");
+            }
+
+            await Task.Delay(10);
+        }
     }
 }

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -25,6 +25,9 @@
     <Compile Include="..\TokenBar.App\ProductIdentity.cs" Link="ProductIdentity.cs" />
     <Compile Include="..\TokenBar.App\TrayForceCreatePolicy.cs" Link="TrayForceCreatePolicy.cs" />
     <Compile Include="..\TokenBar.App\UpdateFlow.cs" Link="UpdateFlow.cs" />
+    <Compile Include="..\TokenBar.App\GraphRequestCoordinator.cs" Link="GraphRequestCoordinator.cs" />
+    <Compile Include="..\TokenBar.App\GraphConsumerState.cs" Link="GraphConsumerState.cs" />
+    <Compile Include="..\TokenBar.App\CostSurfaceProjection.cs" Link="CostSurfaceProjection.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TokenBar.Core/ModelColors.cs
+++ b/src/TokenBar.Core/ModelColors.cs
@@ -5,8 +5,8 @@ namespace TokenBar.Core;
 
 // Provider-based model coloring, port of TokenBarCore/ModelColors.swift
 // (originally src/lib/modelColors.ts, itself ported from tokscale's TUI).
-// Each provider has a base color; models within a provider are cost-ranked
-// and tinted toward white by rank, so the priciest model reads darkest.
+// Each provider has a base color; models within a provider are ranked and
+// tinted toward white by rank. Cost ranking is used only for authoritative data.
 // Colors are hex strings so this stays UI-framework-free.
 
 public static class ModelColors
@@ -102,7 +102,9 @@ public sealed class ModelColorMap
 {
     private readonly Dictionary<string, string> _colorByKeyModel = [];
 
-    public ModelColorMap(IEnumerable<(string Provider, string Model, double Cost)> entries)
+    public ModelColorMap(
+        IEnumerable<(string Provider, string Model, double Cost)> entries,
+        bool costAuthoritative = true)
     {
         // provider key → model → summed cost
         var byProvider = new Dictionary<string, Dictionary<string, double>>();
@@ -123,9 +125,11 @@ public sealed class ModelColorMap
         {
             var baseColor = ModelColors.ProviderBase.GetValueOrDefault(
                 providerKey, ModelColors.ProviderBase["unknown"]);
-            var ranked = models
-                .OrderByDescending(kv => kv.Value)
-                .ThenBy(kv => kv.Key, StringComparer.Ordinal);
+            var ranked = costAuthoritative
+                ? models
+                    .OrderByDescending(kv => kv.Value)
+                    .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+                : models.OrderBy(kv => kv.Key, StringComparer.Ordinal);
             var rank = 0;
             foreach (var (model, _) in ranked)
             {
@@ -135,8 +139,10 @@ public sealed class ModelColorMap
         }
     }
 
-    public ModelColorMap(ModelReport? report)
-        : this((report?.Entries ?? []).Select(e => (e.Provider, e.Model, e.Cost)))
+    public ModelColorMap(ModelReport? report, bool costAuthoritative = true)
+        : this(
+            (report?.Entries ?? []).Select(e => (e.Provider, e.Model, e.Cost)),
+            costAuthoritative)
     {
     }
 


### PR DESCRIPTION
## Summary

- add one process-shared, UI-free `GraphRequestCoordinator` for Dashboard and TrayFeed
- publish `GraphLocalFirst` immediately, then recompute and publish the richer graph when pricing completes
- keep every cost-bearing surface in `Checking` or token fallback until the exact current graph is `BestEffort + Complete`
- defer `ModelReport` until the current generation accepts graph data, with exact query/generation and disposal fences

## Behavior and data flow

```text
App.OnLaunched
  → shared GraphRequestCoordinator
  → GraphLocalFirst
  → LocalFirst publication
  → Dashboard / TrayFeed exact-generation consumers
  → RefreshGraph
  → Richer publication
  → cost authority only for BestEffort + Complete
```

Dashboard and Tray now share retained all-time graph work instead of independently entering the native graph API. Year-filtered Dashboard queries keep their own coordinator state. Non-force same-query requests coalesce; forced requests supersede prior generations.

A generation start immediately revokes prior graph, model, and cost authority. Same-query refreshes retain only the old topology as a visual baseline. Query changes clear the old snapshot. Model, graph, and dispatcher callbacks must all match the exact current request before updating UI state.

## Cost authority

`CostSurfaceProjection` is the single policy for Header, persisted Price chart, Models, Daily, Hourly, Stats/BestDay, Agents, 2D/3D tooltips, tray title, and tray tooltip.

Before exact-current `BestEffort + Complete`:

- cost text displays `Checking`
- the persisted Price selection remains selected but disabled and is not rewritten
- model, contribution, chart segment, and agent ordering/scaling use token fallbacks
- model shades use stable lexical ranking rather than unconfirmed prices

A complete richer publication restores dollar formatting, cost ordering, bars, tooltips, and the Price control together.

## Race fixes

- `Attach()` reacquires the coordinator lock after the consumer handoff and returns the newest exact publication, so Richer cannot be lost if it publishes before `Begin()`
- an accepted same-generation `Richer` publication cannot be replaced by retained `LocalFirst`
- delayed older generations cannot replace a newer generation of the same query, while switching to another query with an older retained numeric generation remains valid
- stale local work cannot start a stale richer request
- forced-refresh cadence advances only after exact-generation richer success

## Codex review fixes

- exact-current completion now settles `_slowInFlight` and `_refreshing` even while the flyout is hidden; stale completion remains fenced and visible query/force mismatch still reruns
- normal and forced production richer stages both use `RefreshGraph`, preventing the cache-isolated LocalFirst payload from being replaced by a graph cached before a new local entry arrived
- reopening a completed year-filtered Dashboard replays the retained graph immediately, then starts a non-force refresh; in-flight years still coalesce and all-time remains Tray-owned
- an exact-current publication whose selected year vanished now uses the normal `SetYear(null)` transition, immediately starting an all-time request even when completion beat the dispatcher callback
- query switches retain the all-time graph so `KnownYears` can continue excluding years whose activity belongs only to hidden clients
- a coalesced Dashboard request begins its consumer, then replays the newest exact retained stage only to that caller; retained LocalFirst survives richer failure without leaving the view blank
- the production coordinator receives `ProcessPower.Boost` from `App` and scopes both blocking graph stages, preserving the pre-B2 Windows Efficiency Mode performance contract
- Dashboard normalizes debug, persisted, and runtime year inputs before storing or comparing `_year`, keeping every consumer guard identical to the coordinator's canonical query
- deterministic completion, publication handoff, retained-year, missing-year, boost-scope, and year-identity tests cover all review scenarios

## Non-goals

- no B3/B4 disk snapshot, cold restore, or freshness persistence
- no Rust, FFI, schema, wire contract, or vendor pin changes
- no DNS/transport timeout rewrite or native cancellation
- no UI restyle

## Verification

- macOS Debug Core.Tests: `430/430`
- macOS Release Core.Tests: `430/430`
- Windows x64 Core.Tests: `430/430`
- Windows x64 App build: passed, PE machine `0x8664`
- Windows ARM64 native/Core.Tests/App cross-build: passed, PE machine `0xAA64`
- original B2 verifier bounded regression: `42/42`
- original B2 verifier complete Release suite: `423/423`
- first Codex review-fix verifier: exact reproductions `2/2`, bounded graph regression `23/23`
- second Codex review-fix verifier: retained-year reproduction `1/1`, bounded graph regression `24/24`
- third Codex review-fix verifier: missing-year reproduction `1/1`, bounded graph regression `25/25`
- fourth Codex review-fix verifier: coalesced replay＋boost scopes `2/2`, bounded graph regression `27/27`
- hard-cap targeted verifier: year identity `1/1`, bounded graph regression `28/28`
- `git diff --check`: passed
- original B2 candidate fingerprint: `D73CB672E5138439BBC505A21A0B2AF2EA1A006587E235B3966023166674F163`
- first Codex review-fix candidate fingerprint: `4D128E9DDCDA0D121C65A61D714D7497408E5DB74D12A27F8300F662E11FA578`
- second Codex review-fix candidate fingerprint: `B22BEFAB157526061DB47DDF9F2471434A323252841FFB9743CEE2B6DFEF7EF6`
- third Codex review-fix candidate fingerprint: `874FAEF1B0744D7CB40676264186926C56A658F0D91083BAA54596FFA07D2917`
- fourth Codex review-fix candidate fingerprint: `B4500960E9FD4FFA74CB41C7E7D4EFCB7A8B2F21D176F888A6AB6EE1C9DC216A`
- hard-cap targeted candidate fingerprint: `D65A927420EBD9E908E87E01AF2861537D613972BD8A82D470BA3848221E1DC9`
- original B2, four Codex review-fix, and hard-cap targeted outcome verifiers: `CONFIRMED`

Existing xUnit analyzer and Rust dead-code warnings remain unchanged.

## Windows human acceptance baseline

- controlled broken-IPv6 old first snapshot: `24,299 ms`
- pre-review candidate broken-IPv6 first snapshot: `940 ms`
- all local-first `Checking` and token-fallback surfaces: passed
- independently probed richer metadata: `BestEffort + Complete`, total cost `$4.957500`
- all authoritative dollar, ordering, chart, tooltip, Price-control, and Tray surfaces: passed

The task-private App, hosts override, listener, scheduled tasks, and settings junction were removed. The real settings tree was restored byte-for-byte with digest `896BD55695CA3D96D3F617C69C3F2F406CD828A4D755E83A5ACE852BEFBF7C00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
