### PR TITLE
feat(core): add strict graph snapshot storage

### DIFF
--- a/src/TokenBar.Core.Tests/GraphSnapshotStoreTests.cs
+++ b/src/TokenBar.Core.Tests/GraphSnapshotStoreTests.cs
@@ -80,6 +80,36 @@ public sealed class GraphSnapshotStoreTests : IDisposable
     }
 
     [Fact]
+    public void UnsupportedSchemaIsClassifiedBeforeV1PayloadDecode()
+    {
+        WriteGood();
+        var json = File.ReadAllText(StorePath);
+        json = json.Replace("\"schemaVersion\":1", "\"schemaVersion\":2", StringComparison.Ordinal)
+            .Replace("\"payload\":{", "\"futureRoot\":true,\"payload\":{\"futurePayload\":true,", StringComparison.Ordinal);
+        File.WriteAllText(StorePath, json);
+
+        Assert.Equal(GraphSnapshotReadStatus.IncompatibleSchema, ReadGood().Status);
+    }
+
+    [Fact]
+    public void SchemaPreflightKeepsBoundsAndScansTheCompleteRoot()
+    {
+        File.WriteAllText(StorePath,
+            "{\"schemaVersion\":2,\"SchemaVersion\":2}");
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, ReadGood().Status);
+
+        File.WriteAllText(StorePath,
+            "{\"future\":{\"" + new string('x', GraphSnapshotStore.MaxStringBytes + 1)
+            + "\":0},\"schemaVersion\":2}");
+        Assert.Equal(GraphSnapshotReadStatus.TooLarge, ReadGood().Status);
+
+        var values = string.Join(',', Enumerable.Repeat("0", GraphSnapshotStore.MaxTokens + 10));
+        File.WriteAllText(StorePath,
+            "{\"future\":[" + values + "],\"schemaVersion\":2}");
+        Assert.Equal(GraphSnapshotReadStatus.TooLarge, ReadGood().Status);
+    }
+
+    [Fact]
     public void RejectsWrongContextQueryAndSchemaWithoutLeakingInputs()
     {
         var store = new GraphSnapshotStore(StorePath);
@@ -257,6 +287,18 @@ public sealed class GraphSnapshotStoreTests : IDisposable
             valid with { Summary = null! },
             valid with { Years = null! },
             valid with { Contributions = null! },
+            valid with { Meta = valid.Meta with { GeneratedAt = null! } },
+            valid with { Summary = valid.Summary with { Clients = [null!] } },
+            valid with
+            {
+                Contributions =
+                [
+                    valid.Contributions[0] with
+                    {
+                        Clients = [valid.Contributions[0].Clients[0] with { Client = null! }],
+                    },
+                ],
+            },
             valid with { Meta = valid.Meta with { DateRange = null! } },
             valid with { Summary = valid.Summary with { Clients = null! } },
             valid with { Summary = valid.Summary with { Models = null! } },

--- a/src/TokenBar.Core.Tests/GraphSnapshotStoreTests.cs
+++ b/src/TokenBar.Core.Tests/GraphSnapshotStoreTests.cs
@@ -1,0 +1,478 @@
+using System.Text;
+using System.Text.Json;
+using TokenBar.Interop;
+using Xunit;
+
+namespace TokenBar.Core.Tests;
+
+public sealed class GraphSnapshotStoreTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "tokenbar-tests", "graph-snapshot-" + Guid.NewGuid().ToString("N"));
+
+    private string StorePath => Path.Combine(_dir, "graph-v1.json");
+
+    public GraphSnapshotStoreTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+
+    [Fact]
+    public void RoundTripsFrozenGraphSchemaAndNumericEdges()
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        var capturedAt = new DateTimeOffset(2026, 8, 13, 3, 4, 5, TimeSpan.FromHours(8));
+        var payload = Payload(
+            "2025-12-31",
+            "2026-01-01",
+            turns: new Dictionary<string, long> { ["claude"] = long.MinValue },
+            input: long.MaxValue,
+            messages: -7,
+            totalCost: -0.25);
+
+        Assert.Equal(
+            GraphSnapshotWriteStatus.Written,
+            store.Write("opaque-context", null, capturedAt, payload));
+
+        var result = new GraphSnapshotStore(StorePath).Read("opaque-context", "  ");
+        Assert.Equal(GraphSnapshotReadStatus.Hit, result.Status);
+        Assert.Equal(capturedAt.ToUniversalTime(), result.CapturedAt);
+        Assert.Equivalent(payload, result.Payload, strict: true);
+
+        using var doc = JsonDocument.Parse(File.ReadAllBytes(StorePath));
+        Assert.Equal(
+            ["schemaVersion", "sourceContextId", "query", "capturedAt", "payload"],
+            doc.RootElement.EnumerateObject().Select(p => p.Name));
+        Assert.Equal(
+            ["meta", "summary", "years", "contributions"],
+            doc.RootElement.GetProperty("payload").EnumerateObject().Select(p => p.Name));
+        Assert.DoesNotContain("quota", File.ReadAllText(StorePath), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("trace", File.ReadAllText(StorePath), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("report", File.ReadAllText(StorePath), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RoundTripsSpecificYearEmptyAndNullTurns()
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        var empty = EmptyPayload();
+        Assert.Equal(
+            GraphSnapshotWriteStatus.Written,
+            store.Write("ctx", " 0042 ", DateTimeOffset.UnixEpoch, empty));
+        Assert.Equal(GraphSnapshotReadStatus.Hit, store.Read("ctx", "0042").Status);
+        Assert.Equal(GraphSnapshotReadStatus.QueryMismatch, store.Read("ctx", null).Status);
+
+        var oneDay = Payload("2026-01-01", turns: null);
+        Assert.Equal(
+            GraphSnapshotWriteStatus.Written,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, oneDay));
+        var result = store.Read("ctx", "2026");
+        Assert.Equal(GraphSnapshotReadStatus.Hit, result.Status);
+        Assert.Null(result.Payload!.Contributions[0].TurnsByClient);
+    }
+
+    [Fact]
+    public void RejectsWrongContextQueryAndSchemaWithoutLeakingInputs()
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        Assert.Equal(
+            GraphSnapshotWriteStatus.Written,
+            store.Write("context-secret", "2026", DateTimeOffset.UnixEpoch, Payload("2026-01-01")));
+
+        var context = store.Read("other-secret", "2026");
+        var query = store.Read("context-secret", "2025");
+        Assert.Equal(GraphSnapshotReadStatus.ContextMismatch, context.Status);
+        Assert.Equal(GraphSnapshotReadStatus.QueryMismatch, query.Status);
+        Assert.DoesNotContain("secret", context.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        ReplaceOnce("\"schemaVersion\":1", "\"schemaVersion\":2");
+        Assert.Equal(GraphSnapshotReadStatus.IncompatibleSchema, store.Read("context-secret", "2026").Status);
+    }
+
+    [Theory]
+    [InlineData("\"schemaVersion\":1", "\"schemaVersion\":1,\"schemaVersion\":1")]
+    [InlineData("\"schemaVersion\":1", "\"SchemaVersion\":1")]
+    [InlineData("\"query\":{\"year\":\"2026\"}", "\"query\":{\"year\":\"2026\",\"Year\":\"2026\"}")]
+    [InlineData("\"meta\":{", "\"meta\":{\"unknown\":0,")]
+    [InlineData("\"summary\":{", "\"summary\":{\"unknown\":0,")]
+    [InlineData("\"date\":\"2026-01-01\"", "\"date\":\"2026-01-01\",\"Date\":\"2026-01-01\"")]
+    [InlineData("\"client\":\"claude\"", "\"client\":\"claude\",\"unknown\":0")]
+    [InlineData("\"input\":9223372036854775807", "\"input\":9223372036854775807,\"Input\":0")]
+    public void StrictReaderRejectsUnknownDuplicateAndCaseAliases(string oldValue, string newValue)
+    {
+        WriteGood();
+        ReplaceOnce(oldValue, newValue);
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, new GraphSnapshotStore(StorePath).Read("ctx", "2026").Status);
+    }
+
+    [Theory]
+    [InlineData("\"generatedAt\":\"g\",", "")]
+    [InlineData("\"messages\":-7", "\"messages\":\"-7\"")]
+    [InlineData("\"turnsByClient\":{\"claude\":1}", "\"turnsByClient\":[]")]
+    public void RejectsMissingAndWrongTypeMembers(string oldValue, string newValue)
+    {
+        WriteGood();
+        ReplaceOnce(oldValue, newValue);
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, ReadGood().Status);
+    }
+
+    [Fact]
+    public void RejectsUnknownEnumsNonFiniteAndNonCanonicalCapturedAt()
+    {
+        WriteGood();
+        ReplaceOnce("\"bestEffort\"", "\"futureMode\"");
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, ReadGood().Status);
+
+        WriteGood();
+        ReplaceOnce("\"totalCost\":-0.25", "\"totalCost\":1e9999");
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, ReadGood().Status);
+
+        WriteGood();
+        var canonical = DateTimeOffset.UnixEpoch.ToString("O").Replace("+", "\\u002B", StringComparison.Ordinal);
+        ReplaceOnce(canonical, "1970-01-01T00:00:00+00:00");
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, ReadGood().Status);
+    }
+
+    [Theory]
+    [InlineData("date-order")]
+    [InlineData("meta-range")]
+    [InlineData("year-range")]
+    [InlineData("query-year")]
+    [InlineData("empty-shape")]
+    public void RejectsQueryPayloadSemanticContradictions(string scenario)
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        var payload = scenario switch
+        {
+            "date-order" => Payload("2026-01-02", "2026-01-01"),
+            "meta-range" => Payload("2026-01-01") with
+            {
+                Meta = new UsageMeta("g", "v", new DateRange("2026-01-02", "2026-01-02"),
+                    PricingMode.BestEffort, CostCoverage.Complete),
+            },
+            "year-range" => Payload("2026-01-01") with
+            {
+                Years = [new YearMeta("2026", 1, 1, new DateRange("2026-01-02", "2026-01-02"))],
+            },
+            "query-year" => Payload("2025-01-01"),
+            _ => EmptyPayload() with
+            {
+                Meta = new UsageMeta("g", "v", new DateRange("2026-01-01", "2026-01-01"),
+                    PricingMode.BestEffort, CostCoverage.Complete),
+            },
+        };
+
+        Assert.Equal(
+            GraphSnapshotWriteStatus.InvalidData,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, payload));
+        Assert.False(File.Exists(StorePath));
+    }
+
+    [Fact]
+    public void OversizeMalformedAndTruncatedFilesAreReadOnlyMisses()
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        File.WriteAllBytes(StorePath, new byte[GraphSnapshotStore.MaxFileBytes + 1]);
+        Assert.Equal(GraphSnapshotReadStatus.TooLarge, store.Read("ctx", null).Status);
+
+        File.WriteAllText(StorePath, "{not-json");
+        var before = File.ReadAllBytes(StorePath);
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, store.Read("ctx", null).Status);
+        Assert.Equal(before, File.ReadAllBytes(StorePath));
+        Assert.False(File.Exists(StorePath + ".corrupt"));
+
+        File.WriteAllText(StorePath, "{\"schemaVersion\":1");
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, store.Read("ctx", null).Status);
+    }
+
+    [Fact]
+    public void DepthAndStringLimitsStopBeforeAcceptance()
+    {
+        File.WriteAllText(StorePath, new string('[', GraphSnapshotStore.MaxDepth + 2)
+            + "0" + new string(']', GraphSnapshotStore.MaxDepth + 2));
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, new GraphSnapshotStore(StorePath).Read("ctx", null).Status);
+
+        WriteGood();
+        ReplaceOnce("\"generatedAt\":\"g\"", "\"generatedAt\":\"" + new string('x', GraphSnapshotStore.MaxStringBytes + 1) + "\"");
+        Assert.Equal(GraphSnapshotReadStatus.TooLarge, ReadGood().Status);
+
+        var tooLong = Payload("2026-01-01") with
+        {
+            Meta = new UsageMeta(new string('x', GraphSnapshotStore.MaxStringBytes + 1), "v",
+                new DateRange("2026-01-01", "2026-01-01"), PricingMode.BestEffort, CostCoverage.Complete),
+        };
+        Assert.Equal(
+            GraphSnapshotWriteStatus.TooLarge,
+            new GraphSnapshotStore(StorePath).Write("ctx", "2026", DateTimeOffset.UnixEpoch, tooLong));
+    }
+
+    [Fact]
+    public void PerContributionAndAggregateBoundsRejectBeforePublication()
+    {
+        var clients = Enumerable.Range(0, GraphSnapshotStore.MaxItemsPerContribution + 1)
+            .Select(i => Client("c" + i))
+            .ToArray();
+        var payload = Payload("2026-01-01") with
+        {
+            Contributions = [Day("2026-01-01", clients, null)],
+        };
+        Assert.Equal(
+            GraphSnapshotWriteStatus.TooLarge,
+            new GraphSnapshotStore(StorePath).Write("ctx", "2026", DateTimeOffset.UnixEpoch, payload));
+        Assert.False(File.Exists(StorePath));
+
+        WriteGood();
+        var goodBytes = File.ReadAllBytes(StorePath);
+        var tooManySummaryItems = Payload("2026-01-01") with
+        {
+            Summary = new UsageSummary(1, 1, 1, 1, 1, 1,
+                Enumerable.Repeat("c", GraphSnapshotStore.MaxSummaryItems + 1).ToArray(), ["m"]),
+        };
+        Assert.Equal(
+            GraphSnapshotWriteStatus.TooLarge,
+            new GraphSnapshotStore(StorePath).Write("ctx", "2026", DateTimeOffset.UnixEpoch, tooManySummaryItems));
+        Assert.Equal(goodBytes, File.ReadAllBytes(StorePath));
+    }
+
+    [Fact]
+    public void RuntimeNestedNullsReturnInvalidDataAndPreserveLastGood()
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        var valid = Payload("2026-01-01");
+        Assert.Equal(GraphSnapshotWriteStatus.Written,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, valid));
+        var lastGood = File.ReadAllBytes(StorePath);
+
+        UsagePayload[] invalid =
+        [
+            valid with { Meta = null! },
+            valid with { Summary = null! },
+            valid with { Years = null! },
+            valid with { Contributions = null! },
+            valid with { Meta = valid.Meta with { DateRange = null! } },
+            valid with { Summary = valid.Summary with { Clients = null! } },
+            valid with { Summary = valid.Summary with { Models = null! } },
+            valid with { Years = [valid.Years[0] with { Range = null! }] },
+            valid with { Contributions = [valid.Contributions[0] with { Totals = null! }] },
+            valid with { Contributions = [valid.Contributions[0] with { TokenBreakdown = null! }] },
+            valid with { Contributions = [valid.Contributions[0] with { Clients = null! }] },
+            valid with
+            {
+                Contributions =
+                [
+                    valid.Contributions[0] with
+                    {
+                        Clients = [valid.Contributions[0].Clients[0] with { Tokens = null! }],
+                    },
+                ],
+            },
+        ];
+
+        foreach (var payload in invalid)
+        {
+            Assert.Equal(GraphSnapshotWriteStatus.InvalidData,
+                store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, payload));
+            Assert.Equal(lastGood, File.ReadAllBytes(StorePath));
+        }
+    }
+
+    [Fact]
+    public void FailedWritesPreserveLastGoodAndSuccessfulReplacePublishesNew()
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        Assert.Equal(GraphSnapshotWriteStatus.Written,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, Payload("2026-01-01")));
+        var oldBytes = File.ReadAllBytes(StorePath);
+
+        Assert.Equal(GraphSnapshotWriteStatus.InvalidData,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch,
+                Payload("2026-01-01") with
+                {
+                    Summary = new UsageSummary(1, double.NaN, 1, 1, 1, 1, ["claude"], ["m"]),
+                }));
+        Assert.Equal(oldBytes, File.ReadAllBytes(StorePath));
+
+        var newer = Payload("2026-02-01");
+        Assert.Equal(GraphSnapshotWriteStatus.Written,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch.AddDays(1), newer));
+        Assert.Equivalent(newer, new GraphSnapshotStore(StorePath).Read("ctx", "2026").Payload, strict: true);
+        Assert.Empty(Directory.EnumerateFiles(_dir, ".*.tmp"));
+    }
+
+    [Fact]
+    public void ConcurrentReadersOnlyObserveCompleteOldOrNewPayloads()
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        var oldPayload = Payload("2026-01-01");
+        var newPayload = Payload("2026-02-01");
+        Assert.Equal(GraphSnapshotWriteStatus.Written,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, oldPayload));
+
+        var unexpected = new List<GraphSnapshotReadResult>();
+        Parallel.For(0, 200, i =>
+        {
+            if (i % 10 == 0)
+            {
+                store.Write("ctx", "2026", DateTimeOffset.UnixEpoch.AddSeconds(i),
+                    i % 20 == 0 ? newPayload : oldPayload);
+                return;
+            }
+
+            var result = new GraphSnapshotStore(StorePath).Read("ctx", "2026");
+            if (result.Status == GraphSnapshotReadStatus.Hit
+                && !HasDate(result.Payload, "2026-01-01")
+                && !HasDate(result.Payload, "2026-02-01")
+                || result.Status is not (GraphSnapshotReadStatus.Hit or GraphSnapshotReadStatus.IoFailure))
+            {
+                lock (unexpected) unexpected.Add(result);
+            }
+        });
+
+        Assert.Empty(unexpected);
+    }
+
+    [Fact]
+    public void FinalSymbolicLinkIsNeverFollowed()
+    {
+        var external = Path.Combine(_dir, "external.json");
+        File.WriteAllText(external, "external-secret");
+        try
+        {
+            File.CreateSymbolicLink(StorePath, external);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.Fail($"Windows reparse acceptance could not create the test symlink: {ex.GetType().Name}");
+            }
+            return;
+        }
+
+        var store = new GraphSnapshotStore(StorePath);
+        Assert.Equal(GraphSnapshotReadStatus.UnsafePath, store.Read("ctx", null).Status);
+        Assert.Equal(GraphSnapshotWriteStatus.UnsafePath,
+            store.Write("ctx", null, DateTimeOffset.UnixEpoch, EmptyPayload()));
+        Assert.Equal("external-secret", File.ReadAllText(external));
+    }
+
+    [Fact]
+    public void ReadDeniedIsARedactedMissAndDoesNotMutateTarget()
+    {
+        WriteGood();
+        var before = File.ReadAllBytes(StorePath);
+        try
+        {
+            using var held = new FileStream(StorePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            var result = new GraphSnapshotStore(StorePath).Read("ctx", "2026");
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.Equal(GraphSnapshotReadStatus.IoFailure, result.Status);
+            }
+        }
+        finally
+        {
+            Assert.Equal(before, File.ReadAllBytes(StorePath));
+        }
+    }
+
+    [Fact]
+    public void MissingAndAbsentParentDoNotCreateFiles()
+    {
+        Assert.Equal(GraphSnapshotReadStatus.Missing, new GraphSnapshotStore(StorePath).Read("ctx", null).Status);
+        var absent = Path.Combine(_dir, "absent", "graph.json");
+        Assert.Equal(GraphSnapshotWriteStatus.InvalidInput,
+            new GraphSnapshotStore(absent).Write("ctx", null, DateTimeOffset.UnixEpoch, EmptyPayload()));
+        Assert.False(Directory.Exists(Path.GetDirectoryName(absent)));
+    }
+
+    private static bool HasDate(UsagePayload? payload, string date) =>
+        payload is { Contributions.Count: 1 }
+        && string.Equals(payload.Contributions[0].Date, date, StringComparison.Ordinal);
+
+    private void WriteGood() => Assert.Equal(
+        GraphSnapshotWriteStatus.Written,
+        new GraphSnapshotStore(StorePath).Write("ctx", "2026", DateTimeOffset.UnixEpoch, Payload("2026-01-01")));
+
+    private GraphSnapshotReadResult ReadGood() => new GraphSnapshotStore(StorePath).Read("ctx", "2026");
+
+    private void ReplaceOnce(string oldValue, string newValue)
+    {
+        var json = File.ReadAllText(StorePath);
+        Assert.Contains(oldValue, json, StringComparison.Ordinal);
+        File.WriteAllText(StorePath, json.Replace(oldValue, newValue, StringComparison.Ordinal));
+    }
+
+    private static UsagePayload EmptyPayload() => new(
+        new UsageMeta("g", "v", new DateRange("", ""), PricingMode.LocalOnly, CostCoverage.None),
+        new UsageSummary(0, 0, 0, 0, 0, 0, [], []),
+        [],
+        []);
+
+    private static UsagePayload Payload(
+        params string[] dates) => Payload(dates, new Dictionary<string, long> { ["claude"] = 1 });
+
+    private static UsagePayload Payload(
+        string date,
+        IReadOnlyDictionary<string, long>? turns) => Payload([date], turns);
+
+    private static UsagePayload Payload(
+        string first,
+        string second,
+        IReadOnlyDictionary<string, long>? turns,
+        long input,
+        int messages,
+        double totalCost) => Payload([first, second], turns, input, messages, totalCost);
+
+    private static UsagePayload Payload(
+        IReadOnlyList<string> dates,
+        IReadOnlyDictionary<string, long>? turns,
+        long input = long.MaxValue,
+        int messages = -7,
+        double totalCost = -0.25)
+    {
+        var days = dates.Select(date => Day(date, [Client("claude", input, messages, totalCost)], turns)).ToArray();
+        var years = dates
+            .GroupBy(date => date[..4], StringComparer.Ordinal)
+            .OrderBy(group => group.Key, StringComparer.Ordinal)
+            .Select(group => new YearMeta(group.Key, 1, totalCost,
+                new DateRange(group.First(), group.Last())))
+            .ToArray();
+        return new UsagePayload(
+            new UsageMeta("g", "v", new DateRange(dates[0], dates[^1]), PricingMode.BestEffort, CostCoverage.Complete),
+            new UsageSummary(1, totalCost, dates.Count, dates.Count, 1, totalCost, ["claude"], ["m"]),
+            years,
+            days);
+    }
+
+    private static Contribution Day(
+        string date,
+        IReadOnlyList<ContributionClient> clients,
+        IReadOnlyDictionary<string, long>? turns) => new(
+        date,
+        new ContributionTotals(1, clients.Sum(c => c.Cost), clients.Sum(c => c.Messages)),
+        -1,
+        new TokenBreakdown(long.MinValue, 2, -3, 4, -5),
+        clients,
+        turns);
+
+    private static ContributionClient Client(
+        string id,
+        long input = long.MaxValue,
+        int messages = -7,
+        double cost = -0.25) => new(
+        id,
+        "m",
+        "p",
+        new TokenBreakdown(input, long.MinValue, -3, 4, -5),
+        cost,
+        messages);
+}

--- a/src/TokenBar.Core.Tests/GraphSnapshotStoreTests.cs
+++ b/src/TokenBar.Core.Tests/GraphSnapshotStoreTests.cs
@@ -245,6 +245,53 @@ public sealed class GraphSnapshotStoreTests : IDisposable
     }
 
     [Fact]
+    public void EscapedStringsUseDecodedUtf8LengthAsTheContract()
+    {
+        var withinLimit = string.Concat(Enumerable.Repeat("😀", GraphSnapshotStore.MaxStringBytes / 4));
+        var payload = Payload("2026-01-01") with
+        {
+            Summary = new UsageSummary(1, 1, 1, 1, 1, 1, ["claude"], [withinLimit]),
+        };
+        var store = new GraphSnapshotStore(StorePath);
+        Assert.Equal(GraphSnapshotWriteStatus.Written,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, payload));
+        var result = store.Read("ctx", "2026");
+        Assert.Equal(GraphSnapshotReadStatus.Hit, result.Status);
+        Assert.Equal(withinLimit, result.Payload!.Summary.Models[0]);
+
+        var overLimit = withinLimit + "😀";
+        Assert.Equal(GraphSnapshotWriteStatus.TooLarge,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, payload with
+            {
+                Summary = payload.Summary with { Models = [overLimit] },
+            }));
+    }
+
+    [Theory]
+    [InlineData("value-high", "\\uD83D")]
+    [InlineData("value-low", "\\uDE00")]
+    [InlineData("map-key", "\\uD83D")]
+    [InlineData("future-value", "\\uDE00")]
+    public void MalformedSurrogatesAreInvalidData(string location, string surrogate)
+    {
+        WriteGood();
+        var json = File.ReadAllText(StorePath);
+        json = location switch
+        {
+            "value-high" or "value-low" => json.Replace("\"generatedAt\":\"g\"",
+                "\"generatedAt\":\"" + surrogate + "\"", StringComparison.Ordinal),
+            "map-key" => json.Replace("\"turnsByClient\":{\"claude\":1}",
+                "\"turnsByClient\":{\"" + surrogate + "\":1}", StringComparison.Ordinal),
+            _ => json.Replace("\"schemaVersion\":1",
+                "\"future\":{\"value\":\"" + surrogate + "\"},\"schemaVersion\":2",
+                StringComparison.Ordinal),
+        };
+        File.WriteAllText(StorePath, json);
+
+        Assert.Equal(GraphSnapshotReadStatus.InvalidData, ReadGood().Status);
+    }
+
+    [Fact]
     public void PerContributionAndAggregateBoundsRejectBeforePublication()
     {
         var clients = Enumerable.Range(0, GraphSnapshotStore.MaxItemsPerContribution + 1)

--- a/src/TokenBar.Core/GraphSnapshotStore.cs
+++ b/src/TokenBar.Core/GraphSnapshotStore.cs
@@ -88,6 +88,10 @@ public sealed class GraphSnapshotStore
             }
 
             var bytes = ReadBounded(path);
+            if (SnapshotCodec.ReadSchemaVersion(bytes) != SchemaVersion)
+            {
+                return new(GraphSnapshotReadStatus.IncompatibleSchema);
+            }
             var envelope = SnapshotCodec.Read(bytes);
             if (envelope.SchemaVersion != SchemaVersion)
             {
@@ -524,7 +528,11 @@ public sealed class GraphSnapshotStore
 
         private static void ValidateString(string value)
         {
-            if (value is null || Utf8Length(value) > MaxStringBytes)
+            if (value is null)
+            {
+                throw new SnapshotFormatException();
+            }
+            if (Utf8Length(value) > MaxStringBytes)
             {
                 throw new SnapshotTooLargeException();
             }
@@ -587,6 +595,50 @@ public sealed class GraphSnapshotStore
 
     private static class SnapshotCodec
     {
+        public static int ReadSchemaVersion(ReadOnlySpan<byte> bytes)
+        {
+            var reader = new Utf8JsonReader(bytes, new JsonReaderOptions
+            {
+                AllowTrailingCommas = false,
+                CommentHandling = JsonCommentHandling.Disallow,
+                MaxDepth = MaxDepth,
+            });
+            var tokens = 0;
+            if (!ReadNext(ref reader, ref tokens) || reader.TokenType != JsonTokenType.StartObject)
+                throw new SnapshotFormatException();
+
+            var rootNames = NewNames();
+            int? schemaVersion = null;
+            string? rootProperty = null;
+            while (ReadNext(ref reader, ref tokens))
+            {
+                if (reader.TokenType is JsonTokenType.PropertyName or JsonTokenType.String)
+                    _ = ReadBoundedString(ref reader);
+
+                if (reader.CurrentDepth == 1 && reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    rootProperty = reader.GetString() ?? throw new SnapshotFormatException();
+                    if (!rootNames.Add(rootProperty)) throw new SnapshotFormatException();
+                    continue;
+                }
+
+                if (rootProperty == "schemaVersion" && reader.CurrentDepth == 1)
+                {
+                    if (reader.TokenType != JsonTokenType.Number || !reader.TryGetInt32(out var version))
+                        throw new SnapshotFormatException();
+                    schemaVersion = version;
+                    rootProperty = null;
+                }
+
+                if (reader.CurrentDepth == 0 && reader.TokenType == JsonTokenType.EndObject)
+                    break;
+            }
+
+            if (reader.TokenType != JsonTokenType.EndObject || reader.Read())
+                throw new SnapshotFormatException();
+            return schemaVersion ?? throw new SnapshotFormatException();
+        }
+
         public static SnapshotEnvelope Read(ReadOnlySpan<byte> bytes)
         {
             var reader = new StrictReader(bytes);
@@ -1088,6 +1140,23 @@ public sealed class GraphSnapshotStore
             writer.WriteString("start", range.Start);
             writer.WriteString("end", range.End);
             writer.WriteEndObject();
+        }
+
+        private static bool ReadNext(ref Utf8JsonReader reader, ref int tokens)
+        {
+            if (!reader.Read()) return false;
+            tokens++;
+            if (tokens > MaxTokens) throw new SnapshotTooLargeException();
+            return true;
+        }
+
+        private static string ReadBoundedString(ref Utf8JsonReader reader)
+        {
+            var rawLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+            if (rawLength > MaxStringBytes) throw new SnapshotTooLargeException();
+            var value = reader.GetString() ?? throw new SnapshotFormatException();
+            if (Utf8Length(value) > MaxStringBytes) throw new SnapshotTooLargeException();
+            return value;
         }
 
         private static HashSet<string> NewNames() => new(StringComparer.OrdinalIgnoreCase);

--- a/src/TokenBar.Core/GraphSnapshotStore.cs
+++ b/src/TokenBar.Core/GraphSnapshotStore.cs
@@ -47,6 +47,7 @@ public sealed class GraphSnapshotStore
     public const int MaxDepth = 16;
     public const int MaxTokens = 1_000_000;
     public const int MaxStringBytes = 8 * 1024;
+    private const int MaxEscapedStringBytes = MaxStringBytes * 6;
     public const int MaxSourceContextBytes = 4 * 1024;
     public const int MaxYears = 256;
     public const int MaxContributions = 100_000;
@@ -1153,8 +1154,17 @@ public sealed class GraphSnapshotStore
         private static string ReadBoundedString(ref Utf8JsonReader reader)
         {
             var rawLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
-            if (rawLength > MaxStringBytes) throw new SnapshotTooLargeException();
-            var value = reader.GetString() ?? throw new SnapshotFormatException();
+            var rawLimit = reader.ValueIsEscaped ? MaxEscapedStringBytes : MaxStringBytes;
+            if (rawLength > rawLimit) throw new SnapshotTooLargeException();
+            string value;
+            try
+            {
+                value = reader.GetString() ?? throw new SnapshotFormatException();
+            }
+            catch (InvalidOperationException)
+            {
+                throw new SnapshotFormatException();
+            }
             if (Utf8Length(value) > MaxStringBytes) throw new SnapshotTooLargeException();
             return value;
         }
@@ -1268,8 +1278,17 @@ public sealed class GraphSnapshotStore
         private string ReadCurrentString()
         {
             var rawLength = _reader.HasValueSequence ? _reader.ValueSequence.Length : _reader.ValueSpan.Length;
-            if (rawLength > MaxStringBytes) throw new SnapshotTooLargeException();
-            var value = _reader.GetString() ?? throw new SnapshotFormatException();
+            var rawLimit = _reader.ValueIsEscaped ? MaxEscapedStringBytes : MaxStringBytes;
+            if (rawLength > rawLimit) throw new SnapshotTooLargeException();
+            string value;
+            try
+            {
+                value = _reader.GetString() ?? throw new SnapshotFormatException();
+            }
+            catch (InvalidOperationException)
+            {
+                throw new SnapshotFormatException();
+            }
             if (Utf8Length(value) > MaxStringBytes) throw new SnapshotTooLargeException();
             return value;
         }

--- a/src/TokenBar.Core/GraphSnapshotStore.cs
+++ b/src/TokenBar.Core/GraphSnapshotStore.cs
@@ -1,0 +1,1241 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using TokenBar.Interop;
+
+namespace TokenBar.Core;
+
+public enum GraphSnapshotReadStatus
+{
+    Hit,
+    Missing,
+    InvalidInput,
+    UnsafePath,
+    InvalidData,
+    IncompatibleSchema,
+    ContextMismatch,
+    QueryMismatch,
+    TooLarge,
+    IoFailure,
+}
+
+public enum GraphSnapshotWriteStatus
+{
+    Written,
+    InvalidInput,
+    UnsafePath,
+    InvalidData,
+    TooLarge,
+    IoFailure,
+}
+
+public sealed record GraphSnapshotReadResult(
+    GraphSnapshotReadStatus Status,
+    UsagePayload? Payload = null,
+    DateTimeOffset? CapturedAt = null);
+
+/// <summary>
+/// Strict graph-only cache. The path and opaque source identity come from the
+/// caller; this type neither derives source roots nor chooses a profile path.
+/// Expected cache and I/O failures are returned as closed, redacted statuses.
+/// </summary>
+public sealed class GraphSnapshotStore
+{
+    public const int SchemaVersion = 1;
+    public const int MaxFileBytes = 16 * 1024 * 1024;
+    public const int MaxDepth = 16;
+    public const int MaxTokens = 1_000_000;
+    public const int MaxStringBytes = 8 * 1024;
+    public const int MaxSourceContextBytes = 4 * 1024;
+    public const int MaxYears = 256;
+    public const int MaxContributions = 100_000;
+    public const int MaxSummaryItems = 16_384;
+    public const int MaxItemsPerContribution = 16_384;
+    public const int MaxNestedItems = 500_000;
+
+    private readonly string _path;
+
+    public GraphSnapshotStore(string path) => _path = path;
+
+    public GraphSnapshotReadResult Read(string sourceContextId, string? year)
+    {
+        if (!TryNormalizeInputs(sourceContextId, year, out var normalizedYear))
+        {
+            return new(GraphSnapshotReadStatus.InvalidInput);
+        }
+
+        if (!TryResolvePath(out var path, out var directory))
+        {
+            return new(GraphSnapshotReadStatus.InvalidInput);
+        }
+
+        if (!Directory.Exists(directory))
+        {
+            return new(GraphSnapshotReadStatus.Missing);
+        }
+
+        try
+        {
+            var target = InspectTarget(path);
+            if (target == TargetState.Missing)
+            {
+                return new(GraphSnapshotReadStatus.Missing);
+            }
+            if (target == TargetState.Unsafe)
+            {
+                return new(GraphSnapshotReadStatus.UnsafePath);
+            }
+
+            var bytes = ReadBounded(path);
+            var envelope = SnapshotCodec.Read(bytes);
+            if (envelope.SchemaVersion != SchemaVersion)
+            {
+                return new(GraphSnapshotReadStatus.IncompatibleSchema);
+            }
+            if (!string.Equals(envelope.SourceContextId, sourceContextId, StringComparison.Ordinal))
+            {
+                return new(GraphSnapshotReadStatus.ContextMismatch);
+            }
+            if (!string.Equals(envelope.Year, normalizedYear, StringComparison.Ordinal))
+            {
+                return new(GraphSnapshotReadStatus.QueryMismatch);
+            }
+
+            SnapshotValidator.Validate(normalizedYear, envelope.CapturedAt, envelope.Payload);
+            return new(GraphSnapshotReadStatus.Hit, envelope.Payload, envelope.CapturedAt);
+        }
+        catch (SnapshotTooLargeException)
+        {
+            return new(GraphSnapshotReadStatus.TooLarge);
+        }
+        catch (SnapshotSchemaException)
+        {
+            return new(GraphSnapshotReadStatus.IncompatibleSchema);
+        }
+        catch (SnapshotFormatException)
+        {
+            return new(GraphSnapshotReadStatus.InvalidData);
+        }
+        catch (JsonException)
+        {
+            return new(GraphSnapshotReadStatus.InvalidData);
+        }
+        catch (Exception ex) when (IsExpectedFileFailure(ex))
+        {
+            return new(GraphSnapshotReadStatus.IoFailure);
+        }
+    }
+
+    public GraphSnapshotWriteStatus Write(
+        string sourceContextId,
+        string? year,
+        DateTimeOffset capturedAt,
+        UsagePayload payload)
+    {
+        if (payload is null || !TryNormalizeInputs(sourceContextId, year, out var normalizedYear))
+        {
+            return GraphSnapshotWriteStatus.InvalidInput;
+        }
+
+        if (!TryResolvePath(out var path, out var directory) || !Directory.Exists(directory))
+        {
+            return GraphSnapshotWriteStatus.InvalidInput;
+        }
+
+        byte[] encoded;
+        try
+        {
+            SnapshotValidator.Validate(normalizedYear, capturedAt, payload);
+            encoded = SnapshotCodec.Write(new SnapshotEnvelope(
+                SchemaVersion,
+                sourceContextId,
+                normalizedYear,
+                capturedAt.ToUniversalTime(),
+                payload));
+            // Exercise the same token/depth/string/count decoder before the
+            // filesystem is touched, so writer and reader accept one contract.
+            _ = SnapshotCodec.Read(encoded);
+        }
+        catch (SnapshotTooLargeException)
+        {
+            return GraphSnapshotWriteStatus.TooLarge;
+        }
+        catch (SnapshotFormatException)
+        {
+            return GraphSnapshotWriteStatus.InvalidData;
+        }
+        catch (Exception ex) when (ex is
+            ArgumentException or
+            EncoderFallbackException or
+            NullReferenceException)
+        {
+            // Nullable annotations are not a runtime trust boundary. A caller
+            // can still construct an invalid graph with a required nested
+            // object/list set to null; reject it before any filesystem access.
+            return GraphSnapshotWriteStatus.InvalidData;
+        }
+
+        string? temp = null;
+        try
+        {
+            if (InspectTarget(path) == TargetState.Unsafe)
+            {
+                return GraphSnapshotWriteStatus.UnsafePath;
+            }
+
+            var fileName = Path.GetFileName(path);
+            temp = Path.Combine(directory, $".{fileName}.{Guid.NewGuid():N}.tmp");
+            using (var stream = new FileStream(
+                temp,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                64 * 1024,
+                FileOptions.SequentialScan))
+            {
+                stream.Write(encoded);
+                stream.Flush(flushToDisk: true);
+            }
+
+            // Same-directory rename is the platform primitive that preserves an
+            // old-or-new target during normal execution; power-loss durability
+            // is deliberately outside this reconstructible cache's contract.
+            File.Move(temp, path, overwrite: true);
+            temp = null;
+            return GraphSnapshotWriteStatus.Written;
+        }
+        catch (Exception ex) when (IsExpectedFileFailure(ex))
+        {
+            return GraphSnapshotWriteStatus.IoFailure;
+        }
+        finally
+        {
+            if (temp is not null)
+            {
+                try
+                {
+                    File.Delete(temp);
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+
+    private static bool TryNormalizeInputs(
+        string sourceContextId,
+        string? year,
+        out string? normalizedYear)
+    {
+        normalizedYear = null;
+        if (string.IsNullOrWhiteSpace(sourceContextId)
+            || sourceContextId.IndexOf('\0') >= 0
+            || Utf8Length(sourceContextId) > MaxSourceContextBytes)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(year))
+        {
+            return true;
+        }
+
+        var trimmed = year.Trim();
+        if (trimmed.Length != 4 || trimmed.Any(c => c is < '0' or > '9'))
+        {
+            return false;
+        }
+
+        normalizedYear = trimmed;
+        return true;
+    }
+
+    private bool TryResolvePath(out string path, out string directory)
+    {
+        path = string.Empty;
+        directory = string.Empty;
+        if (string.IsNullOrWhiteSpace(_path) || _path.IndexOf('\0') >= 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            path = Path.GetFullPath(_path);
+            directory = Path.GetDirectoryName(path) ?? string.Empty;
+            return directory.Length > 0 && Path.GetFileName(path).Length > 0;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+
+    private static TargetState InspectTarget(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            return (attributes & (FileAttributes.ReparsePoint | FileAttributes.Directory)) != 0
+                ? TargetState.Unsafe
+                : TargetState.Regular;
+        }
+        catch (FileNotFoundException)
+        {
+            return TargetState.Missing;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return TargetState.Missing;
+        }
+    }
+
+    private static byte[] ReadBounded(string path)
+    {
+        using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete,
+            64 * 1024,
+            FileOptions.SequentialScan);
+        if (stream.Length > MaxFileBytes)
+        {
+            throw new SnapshotTooLargeException();
+        }
+
+        using var buffer = new MemoryStream((int)Math.Min(stream.Length, MaxFileBytes));
+        var chunk = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
+        {
+            var total = 0;
+            while (true)
+            {
+                var remaining = MaxFileBytes + 1 - total;
+                if (remaining <= 0)
+                {
+                    throw new SnapshotTooLargeException();
+                }
+
+                var read = stream.Read(chunk, 0, Math.Min(chunk.Length, remaining));
+                if (read == 0)
+                {
+                    break;
+                }
+
+                total += read;
+                if (total > MaxFileBytes)
+                {
+                    throw new SnapshotTooLargeException();
+                }
+                buffer.Write(chunk, 0, read);
+            }
+
+            return buffer.ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(chunk);
+        }
+    }
+
+    private static bool IsExpectedFileFailure(Exception ex) => ex is
+        IOException or
+        UnauthorizedAccessException or
+        System.Security.SecurityException or
+        NotSupportedException or
+        ArgumentException;
+
+    private static int Utf8Length(string value)
+    {
+        try
+        {
+            return Encoding.UTF8.GetByteCount(value);
+        }
+        catch (EncoderFallbackException)
+        {
+            return int.MaxValue;
+        }
+    }
+
+    private enum TargetState
+    {
+        Missing,
+        Regular,
+        Unsafe,
+    }
+
+    private sealed record SnapshotEnvelope(
+        int SchemaVersion,
+        string SourceContextId,
+        string? Year,
+        DateTimeOffset CapturedAt,
+        UsagePayload Payload);
+
+    private static class SnapshotValidator
+    {
+        public static void Validate(string? year, DateTimeOffset capturedAt, UsagePayload payload)
+        {
+            var canonicalCapturedAt = capturedAt.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+            if (!TryReadCapturedAt(canonicalCapturedAt, out _))
+            {
+                throw new SnapshotFormatException();
+            }
+
+            ValidatePayloadBounds(payload);
+
+            if (payload.Contributions.Count == 0)
+            {
+                if (payload.Years.Count != 0
+                    || payload.Meta.DateRange.Start.Length != 0
+                    || payload.Meta.DateRange.End.Length != 0)
+                {
+                    throw new SnapshotFormatException();
+                }
+                return;
+            }
+
+            var ranges = new Dictionary<string, (string First, string Last)>(StringComparer.Ordinal);
+            string? previous = null;
+            foreach (var contribution in payload.Contributions)
+            {
+                var date = ParseDate(contribution.Date);
+                var canonical = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                if (!string.Equals(canonical, contribution.Date, StringComparison.Ordinal)
+                    || previous is not null && string.CompareOrdinal(previous, canonical) >= 0)
+                {
+                    throw new SnapshotFormatException();
+                }
+
+                var contributionYear = canonical[..4];
+                if (year is not null && !string.Equals(year, contributionYear, StringComparison.Ordinal))
+                {
+                    throw new SnapshotFormatException();
+                }
+
+                ranges[contributionYear] = ranges.TryGetValue(contributionYear, out var range)
+                    ? (range.First, canonical)
+                    : (canonical, canonical);
+                previous = canonical;
+            }
+
+            if (!string.Equals(payload.Meta.DateRange.Start, payload.Contributions[0].Date, StringComparison.Ordinal)
+                || !string.Equals(payload.Meta.DateRange.End, payload.Contributions[^1].Date, StringComparison.Ordinal))
+            {
+                throw new SnapshotFormatException();
+            }
+            ParseRange(payload.Meta.DateRange);
+
+            if (payload.Years.Count != ranges.Count)
+            {
+                throw new SnapshotFormatException();
+            }
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var item in payload.Years)
+            {
+                if (!IsYear(item.Year) || !seen.Add(item.Year)
+                    || year is not null && !string.Equals(year, item.Year, StringComparison.Ordinal)
+                    || !ranges.TryGetValue(item.Year, out var expected)
+                    || !string.Equals(item.Range.Start, expected.First, StringComparison.Ordinal)
+                    || !string.Equals(item.Range.End, expected.Last, StringComparison.Ordinal))
+                {
+                    throw new SnapshotFormatException();
+                }
+                ParseRange(item.Range);
+            }
+        }
+
+        private static void ValidatePayloadBounds(UsagePayload payload)
+        {
+            if (payload.Years.Count > MaxYears
+                || payload.Contributions.Count > MaxContributions
+                || payload.Summary.Clients.Count > MaxSummaryItems
+                || payload.Summary.Models.Count > MaxSummaryItems)
+            {
+                throw new SnapshotTooLargeException();
+            }
+
+            ValidateString(payload.Meta.GeneratedAt);
+            ValidateString(payload.Meta.Version);
+            ValidateString(payload.Meta.DateRange.Start);
+            ValidateString(payload.Meta.DateRange.End);
+            ValidateFinite(payload.Summary.TotalCost);
+            ValidateFinite(payload.Summary.AveragePerDay);
+            ValidateFinite(payload.Summary.MaxCostInSingleDay);
+            foreach (var value in payload.Summary.Clients)
+            {
+                ValidateString(value);
+            }
+            foreach (var value in payload.Summary.Models)
+            {
+                ValidateString(value);
+            }
+
+            long nested = 0;
+            foreach (var item in payload.Years)
+            {
+                ValidateString(item.Year);
+                ValidateString(item.Range.Start);
+                ValidateString(item.Range.End);
+                ValidateFinite(item.TotalCost);
+            }
+
+            foreach (var contribution in payload.Contributions)
+            {
+                if (contribution.Clients.Count > MaxItemsPerContribution
+                    || contribution.TurnsByClient is { Count: > MaxItemsPerContribution })
+                {
+                    throw new SnapshotTooLargeException();
+                }
+
+                nested += contribution.Clients.Count + (contribution.TurnsByClient?.Count ?? 0);
+                if (nested > MaxNestedItems)
+                {
+                    throw new SnapshotTooLargeException();
+                }
+
+                ValidateString(contribution.Date);
+                ValidateFinite(contribution.Totals.Cost);
+                foreach (var client in contribution.Clients)
+                {
+                    ValidateString(client.Client);
+                    ValidateString(client.ModelId);
+                    ValidateString(client.ProviderId);
+                    ValidateFinite(client.Cost);
+                }
+
+                if (contribution.TurnsByClient is not null)
+                {
+                    var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var pair in contribution.TurnsByClient)
+                    {
+                        ValidateString(pair.Key);
+                        if (!keys.Add(pair.Key))
+                        {
+                            throw new SnapshotFormatException();
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void ValidateString(string value)
+        {
+            if (value is null || Utf8Length(value) > MaxStringBytes)
+            {
+                throw new SnapshotTooLargeException();
+            }
+        }
+
+        private static void ValidateFinite(double value)
+        {
+            if (!double.IsFinite(value))
+            {
+                throw new SnapshotFormatException();
+            }
+        }
+
+        private static DateOnly ParseDate(string value)
+        {
+            if (!DateOnly.TryParseExact(
+                    value,
+                    "yyyy-MM-dd",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var date))
+            {
+                throw new SnapshotFormatException();
+            }
+            return date;
+        }
+
+        private static void ParseRange(DateRange range)
+        {
+            var start = ParseDate(range.Start);
+            var end = ParseDate(range.End);
+            if (start > end)
+            {
+                throw new SnapshotFormatException();
+            }
+        }
+
+        private static bool IsYear(string value) =>
+            value.Length == 4 && value.All(c => c is >= '0' and <= '9');
+    }
+
+    private static bool TryReadCapturedAt(string value, out DateTimeOffset capturedAt)
+    {
+        if (!DateTimeOffset.TryParseExact(
+                value,
+                "O",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out capturedAt)
+            || capturedAt.Offset != TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        return string.Equals(
+            capturedAt.ToString("O", CultureInfo.InvariantCulture),
+            value,
+            StringComparison.Ordinal);
+    }
+
+    private static class SnapshotCodec
+    {
+        public static SnapshotEnvelope Read(ReadOnlySpan<byte> bytes)
+        {
+            var reader = new StrictReader(bytes);
+            reader.Begin();
+            reader.StartObject();
+            var seen = NewNames();
+            int? schema = null;
+            string? context = null;
+            QueryValue? query = null;
+            DateTimeOffset? capturedAt = null;
+            UsagePayload? payload = null;
+
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "schemaVersion": schema = reader.Int32(); break;
+                    case "sourceContextId": context = reader.String(); break;
+                    case "query": query = ReadQuery(ref reader); break;
+                    case "capturedAt":
+                        var raw = reader.String();
+                        if (!TryReadCapturedAt(raw, out var parsed))
+                        {
+                            throw new SnapshotFormatException();
+                        }
+                        capturedAt = parsed;
+                        break;
+                    case "payload": payload = ReadPayload(ref reader); break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            reader.Finish();
+
+            if (schema is null || context is null || query is null || capturedAt is null || payload is null)
+            {
+                throw new SnapshotFormatException();
+            }
+            if (schema != SchemaVersion)
+            {
+                throw new SnapshotSchemaException();
+            }
+            if (!TryNormalizeInputs(context, query.Value.Year, out var storedYear)
+                || !string.Equals(storedYear, query.Value.Year, StringComparison.Ordinal))
+            {
+                throw new SnapshotFormatException();
+            }
+            return new(schema.Value, context, query.Value.Year, capturedAt.Value, payload);
+        }
+
+        public static byte[] Write(SnapshotEnvelope envelope)
+        {
+            using var output = new MemoryStream();
+            using var bounded = new BoundedWriteStream(output, MaxFileBytes);
+            using (var writer = new Utf8JsonWriter(bounded))
+            {
+                writer.WriteStartObject();
+                writer.WriteNumber("schemaVersion", envelope.SchemaVersion);
+                writer.WriteString("sourceContextId", envelope.SourceContextId);
+                writer.WriteStartObject("query");
+                if (envelope.Year is null) writer.WriteNull("year");
+                else writer.WriteString("year", envelope.Year);
+                writer.WriteEndObject();
+                writer.WriteString("capturedAt", envelope.CapturedAt.ToString("O", CultureInfo.InvariantCulture));
+                writer.WritePropertyName("payload");
+                WritePayload(writer, envelope.Payload);
+                writer.WriteEndObject();
+                writer.Flush();
+            }
+            return output.ToArray();
+        }
+
+        private static QueryValue ReadQuery(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            var present = false;
+            string? year = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                if (name != "year") throw new SnapshotFormatException();
+                year = reader.NullableString();
+                present = true;
+            }
+            if (!present || year is not null && !IsYear(year)) throw new SnapshotFormatException();
+            return new(year);
+        }
+
+        private static UsagePayload ReadPayload(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            UsageMeta? meta = null;
+            UsageSummary? summary = null;
+            IReadOnlyList<YearMeta>? years = null;
+            IReadOnlyList<Contribution>? contributions = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "meta": meta = ReadMeta(ref reader); break;
+                    case "summary": summary = ReadSummary(ref reader); break;
+                    case "years": years = ReadYears(ref reader); break;
+                    case "contributions": contributions = ReadContributions(ref reader); break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (meta is null || summary is null || years is null || contributions is null)
+                throw new SnapshotFormatException();
+            return new(meta, summary, years, contributions);
+        }
+
+        private static UsageMeta ReadMeta(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            string? generatedAt = null;
+            string? version = null;
+            DateRange? range = null;
+            PricingMode? pricing = null;
+            CostCoverage? coverage = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "generatedAt": generatedAt = reader.String(); break;
+                    case "version": version = reader.String(); break;
+                    case "dateRange": range = ReadRange(ref reader); break;
+                    case "pricingMode": pricing = reader.String() switch
+                    {
+                        "localOnly" => PricingMode.LocalOnly,
+                        "bestEffort" => PricingMode.BestEffort,
+                        _ => throw new SnapshotFormatException(),
+                    }; break;
+                    case "costCoverage": coverage = reader.String() switch
+                    {
+                        "complete" => CostCoverage.Complete,
+                        "partial" => CostCoverage.Partial,
+                        "none" => CostCoverage.None,
+                        _ => throw new SnapshotFormatException(),
+                    }; break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (generatedAt is null || version is null || range is null || pricing is null || coverage is null)
+                throw new SnapshotFormatException();
+            return new(generatedAt, version, range, pricing.Value, coverage.Value);
+        }
+
+        private static UsageSummary ReadSummary(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            long? totalTokens = null;
+            double? totalCost = null, average = null, maxCost = null;
+            int? totalDays = null, activeDays = null;
+            IReadOnlyList<string>? clients = null, models = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "totalTokens": totalTokens = reader.Int64(); break;
+                    case "totalCost": totalCost = reader.Double(); break;
+                    case "totalDays": totalDays = reader.Int32(); break;
+                    case "activeDays": activeDays = reader.Int32(); break;
+                    case "averagePerDay": average = reader.Double(); break;
+                    case "maxCostInSingleDay": maxCost = reader.Double(); break;
+                    case "clients": clients = ReadStrings(ref reader, MaxSummaryItems); break;
+                    case "models": models = ReadStrings(ref reader, MaxSummaryItems); break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (totalTokens is null || totalCost is null || totalDays is null || activeDays is null
+                || average is null || maxCost is null || clients is null || models is null)
+                throw new SnapshotFormatException();
+            return new(totalTokens.Value, totalCost.Value, totalDays.Value, activeDays.Value,
+                average.Value, maxCost.Value, clients, models);
+        }
+
+        private static IReadOnlyList<YearMeta> ReadYears(ref StrictReader reader)
+        {
+            reader.StartArray();
+            var result = new List<YearMeta>();
+            while (reader.NextArrayItem())
+            {
+                if (result.Count >= MaxYears) throw new SnapshotTooLargeException();
+                result.Add(ReadYear(ref reader));
+            }
+            return result;
+        }
+
+        private static YearMeta ReadYear(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            string? year = null;
+            long? tokens = null;
+            double? cost = null;
+            DateRange? range = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "year": year = reader.String(); break;
+                    case "totalTokens": tokens = reader.Int64(); break;
+                    case "totalCost": cost = reader.Double(); break;
+                    case "range": range = ReadRange(ref reader); break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (year is null || tokens is null || cost is null || range is null)
+                throw new SnapshotFormatException();
+            return new(year, tokens.Value, cost.Value, range);
+        }
+
+        private static IReadOnlyList<Contribution> ReadContributions(ref StrictReader reader)
+        {
+            reader.StartArray();
+            var result = new List<Contribution>();
+            while (reader.NextArrayItem())
+            {
+                if (result.Count >= MaxContributions) throw new SnapshotTooLargeException();
+                result.Add(ReadContribution(ref reader));
+            }
+            return result;
+        }
+
+        private static Contribution ReadContribution(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            string? date = null;
+            ContributionTotals? totals = null;
+            int? intensity = null;
+            TokenBreakdown? breakdown = null;
+            IReadOnlyList<ContributionClient>? clients = null;
+            IReadOnlyDictionary<string, long>? turns = null;
+            var turnsPresent = false;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "date": date = reader.String(); break;
+                    case "totals": totals = ReadTotals(ref reader); break;
+                    case "intensity": intensity = reader.Int32(); break;
+                    case "tokenBreakdown": breakdown = ReadBreakdown(ref reader); break;
+                    case "clients": clients = ReadClients(ref reader); break;
+                    case "turnsByClient":
+                        turnsPresent = true;
+                        turns = reader.IsNull() ? null : ReadTurns(ref reader);
+                        break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (date is null || totals is null || intensity is null || breakdown is null
+                || clients is null || !turnsPresent)
+                throw new SnapshotFormatException();
+            return new(date, totals, intensity.Value, breakdown, clients, turns);
+        }
+
+        private static ContributionTotals ReadTotals(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            long? tokens = null;
+            double? cost = null;
+            int? messages = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "tokens": tokens = reader.Int64(); break;
+                    case "cost": cost = reader.Double(); break;
+                    case "messages": messages = reader.Int32(); break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (tokens is null || cost is null || messages is null) throw new SnapshotFormatException();
+            return new(tokens.Value, cost.Value, messages.Value);
+        }
+
+        private static TokenBreakdown ReadBreakdown(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            long? input = null, output = null, cacheRead = null, cacheWrite = null, reasoning = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "input": input = reader.Int64(); break;
+                    case "output": output = reader.Int64(); break;
+                    case "cacheRead": cacheRead = reader.Int64(); break;
+                    case "cacheWrite": cacheWrite = reader.Int64(); break;
+                    case "reasoning": reasoning = reader.Int64(); break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (input is null || output is null || cacheRead is null || cacheWrite is null || reasoning is null)
+                throw new SnapshotFormatException();
+            return new(input.Value, output.Value, cacheRead.Value, cacheWrite.Value, reasoning.Value);
+        }
+
+        private static IReadOnlyList<ContributionClient> ReadClients(ref StrictReader reader)
+        {
+            reader.StartArray();
+            var result = new List<ContributionClient>();
+            while (reader.NextArrayItem())
+            {
+                if (result.Count >= MaxItemsPerContribution) throw new SnapshotTooLargeException();
+                reader.AddNestedItem();
+                result.Add(ReadClient(ref reader));
+            }
+            return result;
+        }
+
+        private static ContributionClient ReadClient(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            string? client = null, model = null, provider = null;
+            TokenBreakdown? tokens = null;
+            double? cost = null;
+            int? messages = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "client": client = reader.String(); break;
+                    case "modelId": model = reader.String(); break;
+                    case "providerId": provider = reader.String(); break;
+                    case "tokens": tokens = ReadBreakdown(ref reader); break;
+                    case "cost": cost = reader.Double(); break;
+                    case "messages": messages = reader.Int32(); break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (client is null || model is null || provider is null || tokens is null || cost is null || messages is null)
+                throw new SnapshotFormatException();
+            return new(client, model, provider, tokens, cost.Value, messages.Value);
+        }
+
+        private static IReadOnlyDictionary<string, long> ReadTurns(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var names = NewNames();
+            var result = new Dictionary<string, long>(StringComparer.Ordinal);
+            while (reader.NextProperty(names, out var name))
+            {
+                if (result.Count >= MaxItemsPerContribution) throw new SnapshotTooLargeException();
+                reader.AddNestedItem();
+                result.Add(name, reader.Int64());
+            }
+            return result;
+        }
+
+        private static DateRange ReadRange(ref StrictReader reader)
+        {
+            reader.StartObject();
+            var seen = NewNames();
+            string? start = null, end = null;
+            while (reader.NextProperty(seen, out var name))
+            {
+                switch (name)
+                {
+                    case "start": start = reader.String(); break;
+                    case "end": end = reader.String(); break;
+                    default: throw new SnapshotFormatException();
+                }
+            }
+            if (start is null || end is null) throw new SnapshotFormatException();
+            return new(start, end);
+        }
+
+        private static IReadOnlyList<string> ReadStrings(ref StrictReader reader, int max)
+        {
+            reader.StartArray();
+            var result = new List<string>();
+            while (reader.NextArrayItem())
+            {
+                if (result.Count >= max) throw new SnapshotTooLargeException();
+                result.Add(reader.String());
+            }
+            return result;
+        }
+
+        private static void WritePayload(Utf8JsonWriter writer, UsagePayload payload)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("meta"); WriteMeta(writer, payload.Meta);
+            writer.WritePropertyName("summary"); WriteSummary(writer, payload.Summary);
+            writer.WriteStartArray("years");
+            foreach (var item in payload.Years) WriteYear(writer, item);
+            writer.WriteEndArray();
+            writer.WriteStartArray("contributions");
+            foreach (var item in payload.Contributions) WriteContribution(writer, item);
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private static void WriteMeta(Utf8JsonWriter writer, UsageMeta meta)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("generatedAt", meta.GeneratedAt);
+            writer.WriteString("version", meta.Version);
+            writer.WritePropertyName("dateRange"); WriteRange(writer, meta.DateRange);
+            writer.WriteString("pricingMode", meta.PricingMode switch
+            {
+                PricingMode.LocalOnly => "localOnly",
+                PricingMode.BestEffort => "bestEffort",
+                _ => throw new SnapshotFormatException(),
+            });
+            writer.WriteString("costCoverage", meta.CostCoverage switch
+            {
+                CostCoverage.Complete => "complete",
+                CostCoverage.Partial => "partial",
+                CostCoverage.None => "none",
+                _ => throw new SnapshotFormatException(),
+            });
+            writer.WriteEndObject();
+        }
+
+        private static void WriteSummary(Utf8JsonWriter writer, UsageSummary summary)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("totalTokens", summary.TotalTokens);
+            writer.WriteNumber("totalCost", summary.TotalCost);
+            writer.WriteNumber("totalDays", summary.TotalDays);
+            writer.WriteNumber("activeDays", summary.ActiveDays);
+            writer.WriteNumber("averagePerDay", summary.AveragePerDay);
+            writer.WriteNumber("maxCostInSingleDay", summary.MaxCostInSingleDay);
+            writer.WriteStartArray("clients"); foreach (var item in summary.Clients) writer.WriteStringValue(item); writer.WriteEndArray();
+            writer.WriteStartArray("models"); foreach (var item in summary.Models) writer.WriteStringValue(item); writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private static void WriteYear(Utf8JsonWriter writer, YearMeta item)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("year", item.Year);
+            writer.WriteNumber("totalTokens", item.TotalTokens);
+            writer.WriteNumber("totalCost", item.TotalCost);
+            writer.WritePropertyName("range"); WriteRange(writer, item.Range);
+            writer.WriteEndObject();
+        }
+
+        private static void WriteContribution(Utf8JsonWriter writer, Contribution item)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("date", item.Date);
+            writer.WriteStartObject("totals");
+            writer.WriteNumber("tokens", item.Totals.Tokens);
+            writer.WriteNumber("cost", item.Totals.Cost);
+            writer.WriteNumber("messages", item.Totals.Messages);
+            writer.WriteEndObject();
+            writer.WriteNumber("intensity", item.Intensity);
+            writer.WritePropertyName("tokenBreakdown"); WriteBreakdown(writer, item.TokenBreakdown);
+            writer.WriteStartArray("clients");
+            foreach (var client in item.Clients)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("client", client.Client);
+                writer.WriteString("modelId", client.ModelId);
+                writer.WriteString("providerId", client.ProviderId);
+                writer.WritePropertyName("tokens"); WriteBreakdown(writer, client.Tokens);
+                writer.WriteNumber("cost", client.Cost);
+                writer.WriteNumber("messages", client.Messages);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WritePropertyName("turnsByClient");
+            if (item.TurnsByClient is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStartObject();
+                foreach (var pair in item.TurnsByClient.OrderBy(p => p.Key, StringComparer.Ordinal))
+                    writer.WriteNumber(pair.Key, pair.Value);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndObject();
+        }
+
+        private static void WriteBreakdown(Utf8JsonWriter writer, TokenBreakdown value)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("input", value.Input);
+            writer.WriteNumber("output", value.Output);
+            writer.WriteNumber("cacheRead", value.CacheRead);
+            writer.WriteNumber("cacheWrite", value.CacheWrite);
+            writer.WriteNumber("reasoning", value.Reasoning);
+            writer.WriteEndObject();
+        }
+
+        private static void WriteRange(Utf8JsonWriter writer, DateRange range)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("start", range.Start);
+            writer.WriteString("end", range.End);
+            writer.WriteEndObject();
+        }
+
+        private static HashSet<string> NewNames() => new(StringComparer.OrdinalIgnoreCase);
+        private static bool IsYear(string value) => value.Length == 4 && value.All(c => c is >= '0' and <= '9');
+        private readonly record struct QueryValue(string? Year);
+    }
+
+    private ref struct StrictReader
+    {
+        private Utf8JsonReader _reader;
+        private int _tokens;
+        private int _nestedItems;
+
+        public StrictReader(ReadOnlySpan<byte> bytes)
+        {
+            _reader = new Utf8JsonReader(bytes, new JsonReaderOptions
+            {
+                AllowTrailingCommas = false,
+                CommentHandling = JsonCommentHandling.Disallow,
+                MaxDepth = MaxDepth,
+            });
+            _tokens = 0;
+            _nestedItems = 0;
+        }
+
+        public void Begin() => Move();
+        public void StartObject() => Require(JsonTokenType.StartObject);
+        public void StartArray() => Require(JsonTokenType.StartArray);
+
+        public bool NextProperty(HashSet<string> names, out string name)
+        {
+            Move();
+            if (_reader.TokenType == JsonTokenType.EndObject)
+            {
+                name = string.Empty;
+                return false;
+            }
+            if (_reader.TokenType != JsonTokenType.PropertyName) throw new SnapshotFormatException();
+            name = ReadCurrentString();
+            if (!names.Add(name)) throw new SnapshotFormatException();
+            Move();
+            return true;
+        }
+
+        public bool NextArrayItem()
+        {
+            Move();
+            return _reader.TokenType != JsonTokenType.EndArray;
+        }
+
+        public string String()
+        {
+            if (_reader.TokenType != JsonTokenType.String) throw new SnapshotFormatException();
+            return ReadCurrentString();
+        }
+
+        public string? NullableString()
+        {
+            if (_reader.TokenType == JsonTokenType.Null) return null;
+            return String();
+        }
+
+        public bool IsNull() => _reader.TokenType == JsonTokenType.Null;
+
+        public long Int64()
+        {
+            if (_reader.TokenType != JsonTokenType.Number || !_reader.TryGetInt64(out var value))
+                throw new SnapshotFormatException();
+            return value;
+        }
+
+        public int Int32()
+        {
+            if (_reader.TokenType != JsonTokenType.Number || !_reader.TryGetInt32(out var value))
+                throw new SnapshotFormatException();
+            return value;
+        }
+
+        public double Double()
+        {
+            if (_reader.TokenType != JsonTokenType.Number || !_reader.TryGetDouble(out var value) || !double.IsFinite(value))
+                throw new SnapshotFormatException();
+            return value;
+        }
+
+        public void AddNestedItem()
+        {
+            _nestedItems++;
+            if (_nestedItems > MaxNestedItems) throw new SnapshotTooLargeException();
+        }
+
+        public void Finish()
+        {
+            if (_reader.Read()) throw new SnapshotFormatException();
+        }
+
+        private void Require(JsonTokenType type)
+        {
+            if (_reader.TokenType != type) throw new SnapshotFormatException();
+        }
+
+        private void Move()
+        {
+            if (!_reader.Read()) throw new SnapshotFormatException();
+            _tokens++;
+            if (_tokens > MaxTokens) throw new SnapshotTooLargeException();
+        }
+
+        private string ReadCurrentString()
+        {
+            var rawLength = _reader.HasValueSequence ? _reader.ValueSequence.Length : _reader.ValueSpan.Length;
+            if (rawLength > MaxStringBytes) throw new SnapshotTooLargeException();
+            var value = _reader.GetString() ?? throw new SnapshotFormatException();
+            if (Utf8Length(value) > MaxStringBytes) throw new SnapshotTooLargeException();
+            return value;
+        }
+    }
+
+    private sealed class BoundedWriteStream(Stream inner, long limit) : Stream
+    {
+        private long _written;
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => _written;
+        public override long Position { get => _written; set => throw new NotSupportedException(); }
+        public override void Flush() => inner.Flush();
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            Ensure(count);
+            inner.Write(buffer, offset, count);
+        }
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            Ensure(buffer.Length);
+            inner.Write(buffer);
+        }
+        private void Ensure(int count)
+        {
+            if (_written + count > limit) throw new SnapshotTooLargeException();
+            _written += count;
+        }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+    private class SnapshotFormatException : Exception;
+    private sealed class SnapshotSchemaException : SnapshotFormatException;
+    private sealed class SnapshotTooLargeException : SnapshotFormatException;
+}


### PR DESCRIPTION
## Summary

- add a dedicated graph-only `GraphSnapshotStore` with a frozen manual schema-v1 codec
- enforce opaque source-context and year/all-time query isolation plus bounded, strict, redacted cache misses
- preserve last-good bytes through validation and publication failures using same-directory old-or-new replacement
- add adversarial cross-platform coverage for schema drift, malformed input, resource limits, reparse targets, runtime nested nulls, and concurrent readers

## Scope

This is `ALIGN-V13-B3-E1` only. It does not select the cache path, derive `sourceContextId`, connect startup restore/background writes, or change Dashboard freshness/UI; those remain in B4.

## Verification

- macOS Debug focused: 29 passed
- macOS Release focused: 29 passed
- macOS managed Core regression: 459 passed, excluding the pre-existing native `ProbeTests` dylib dependency
- Windows x64 Release focused: 29 passed, including final reparse and read-denied behavior
- fresh outcome verifier: `CONFIRMED` after independently reproducing and rechecking the runtime nested-null recovery

Windows verification used an exact `9cff3b4` task-private clone with the committed files hash-matched before testing. The temporary remote directory was deleted afterward.

No App, Rust, FFI, vendor, settings, or wire-schema files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
