### PR TITLE
feat(ffi): bind local scans to immutable source context

### DIFF
--- a/crates/tb_core_ffi/src/agents_report.rs
+++ b/crates/tb_core_ffi/src/agents_report.rs
@@ -54,7 +54,10 @@ pub(crate) fn run(
         .enable_all()
         .build()
         .map_err(|e| format!("build runtime: {}", e))?;
-    let report = runtime.block_on(tokscale_core::get_agents_report(options))?;
+    let report = runtime.block_on(tokscale_core::get_agents_report_with_source_context(
+        context.resolved(),
+        options,
+    ))?;
 
     let data = map_report(report);
     serde_json::to_value(data).map_err(|e| format!("serialize agents report: {}", e))

--- a/crates/tb_core_ffi/src/filter_parity_probe.rs
+++ b/crates/tb_core_ffi/src/filter_parity_probe.rs
@@ -120,7 +120,10 @@ type ReportFn<'a> = dyn FnMut(&LocalSourceContext, Option<&[String]>) -> Result<
 /// Run the production parity probe using one context and a fresh graph.
 pub(crate) fn run(context: &LocalSourceContext) -> Result<FilterParityPayload, String> {
     let mut token = |context: &LocalSourceContext| {
-        tokscale_core::local_source_change_token(&context.parse_options(None, None))
+        tokscale_core::local_source_change_token_with_source_context(
+            context.resolved(),
+            &context.parse_options(None, None),
+        )
     };
     let mut graph = |context: &LocalSourceContext| usage_graph::run(context, "");
     let mut hourly = |context: &LocalSourceContext, clients: Option<&[String]>| {
@@ -350,13 +353,22 @@ mod tests {
     use std::cell::RefCell;
     use std::fs::OpenOptions;
     use std::io::Write;
-    use std::path::PathBuf;
     use std::rc::Rc;
 
     fn context() -> LocalSourceContext {
-        LocalSourceContext {
-            home_dir: Some(PathBuf::from("fixture-home")),
-        }
+        LocalSourceContext::capture(
+            Some(std::env::temp_dir().join(format!(
+                "tokenbar-filter-context-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ))),
+            false,
+            tokscale_core::ScannerSettings::default(),
+        )
+        .unwrap()
     }
 
     fn graph() -> Value {
@@ -623,14 +635,22 @@ mod tests {
         let source = root.join(".codex/sessions/session.jsonl");
         std::fs::create_dir_all(source.parent().unwrap()).unwrap();
         std::fs::write(&source, b"seed\n").unwrap();
+        let context = LocalSourceContext::capture(
+            Some(root.clone()),
+            false,
+            tokscale_core::ScannerSettings::default(),
+        )
+        .unwrap();
         let options = tokscale_core::LocalParseOptions {
-            home_dir: Some(root.to_string_lossy().into_owned()),
-            use_env_roots: false,
             clients: Some(vec!["codex".to_string()]),
             ..Default::default()
         };
-        let mut token =
-            |_context: &LocalSourceContext| tokscale_core::local_source_change_token(&options);
+        let mut token = |context: &LocalSourceContext| {
+            tokscale_core::local_source_change_token_with_source_context(
+                context.resolved(),
+                &options,
+            )
+        };
         let calls = Rc::new(RefCell::new(Vec::new()));
         let graph_calls = Rc::clone(&calls);
         let mut graph_fn = |_context: &LocalSourceContext| {
@@ -658,9 +678,7 @@ mod tests {
         };
 
         let result = run_with(
-            &LocalSourceContext {
-                home_dir: Some(root.clone()),
-            },
+            &context,
             &mut token,
             &mut graph_fn,
             &mut hourly_fn,

--- a/crates/tb_core_ffi/src/hourly_report.rs
+++ b/crates/tb_core_ffi/src/hourly_report.rs
@@ -52,7 +52,10 @@ pub(crate) fn run(
         .enable_all()
         .build()
         .map_err(|e| format!("build runtime: {}", e))?;
-    let report = runtime.block_on(tokscale_core::get_hourly_report(options))?;
+    let report = runtime.block_on(tokscale_core::get_hourly_report_with_source_context(
+        context.resolved(),
+        options,
+    ))?;
 
     let data = map_report(report);
     serde_json::to_value(data).map_err(|e| format!("serialize hourly report: {}", e))
@@ -113,7 +116,13 @@ mod tests {
     /// #766 clamps corrupt Antigravity varints to `i64::MAX` per bucket. Two
     /// such buckets in one hourly entry must saturate the mapped `total`, not
     /// overflow it (a plain `+` panics in debug / wraps in release).
-    fn entry(input: i64, output: i64, cache_read: i64, cache_write: i64, reasoning: i64) -> tokscale_core::HourlyUsage {
+    fn entry(
+        input: i64,
+        output: i64,
+        cache_read: i64,
+        cache_write: i64,
+        reasoning: i64,
+    ) -> tokscale_core::HourlyUsage {
         tokscale_core::HourlyUsage {
             hour: "2026-07-12 00:00".to_string(),
             clients: vec!["antigravity_cli".to_string()],

--- a/crates/tb_core_ffi/src/lib.rs
+++ b/crates/tb_core_ffi/src/lib.rs
@@ -35,7 +35,7 @@ mod usage_tail;
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr, CString};
 use std::path::PathBuf;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use usage_tail::UsageTailer;
@@ -54,19 +54,40 @@ pub(crate) fn user_home_dir() -> Option<PathBuf> {
     )
 }
 
-/// Snapshot the local source roots used by every FFI report and parse path.
-/// Environment roots are process-startup configuration: changing them requires
-/// restarting the FFI process. Cache keys intentionally do not fingerprint roots.
+/// Immutable engine-owned source resolution shared by every production local
+/// source entry point in this process.
 #[derive(Debug, Clone)]
 pub(crate) struct LocalSourceContext {
-    home_dir: Option<PathBuf>,
+    resolved: Arc<tokscale_core::ResolvedLocalSourceContext>,
 }
 
 impl LocalSourceContext {
-    pub(crate) fn current() -> Self {
-        Self {
-            home_dir: user_home_dir(),
-        }
+    #[cfg(test)]
+    pub(crate) fn capture(
+        home_dir: Option<PathBuf>,
+        use_env_roots: bool,
+        scanner_settings: tokscale_core::ScannerSettings,
+    ) -> Result<Self, tokscale_core::SourceContextUnavailable> {
+        tokscale_core::ResolvedLocalSourceContext::capture(
+            home_dir,
+            use_env_roots,
+            scanner_settings,
+        )
+        .map(Arc::new)
+        .map(|resolved| Self { resolved })
+    }
+
+    pub(crate) fn process() -> Result<Self, tokscale_core::SourceContextUnavailable> {
+        PROCESS_SOURCE_CONTEXT
+            .as_ref()
+            .map(|resolved| Self {
+                resolved: Arc::clone(resolved),
+            })
+            .map_err(|error| *error)
+    }
+
+    pub(crate) fn resolved(&self) -> &tokscale_core::ResolvedLocalSourceContext {
+        &self.resolved
     }
 
     pub(crate) fn report_options(
@@ -75,11 +96,6 @@ impl LocalSourceContext {
         clients: Option<Vec<String>>,
     ) -> tokscale_core::ReportOptions {
         tokscale_core::ReportOptions {
-            home_dir: self
-                .home_dir
-                .as_ref()
-                .map(|path| path.to_string_lossy().into_owned()),
-            use_env_roots: true,
             year,
             clients,
             ..Default::default()
@@ -92,17 +108,23 @@ impl LocalSourceContext {
         clients: Option<Vec<String>>,
     ) -> tokscale_core::LocalParseOptions {
         tokscale_core::LocalParseOptions {
-            home_dir: self
-                .home_dir
-                .as_ref()
-                .map(|path| path.to_string_lossy().into_owned()),
-            use_env_roots: true,
             year,
             clients,
             ..Default::default()
         }
     }
 }
+
+static PROCESS_SOURCE_CONTEXT: LazyLock<
+    Result<Arc<tokscale_core::ResolvedLocalSourceContext>, tokscale_core::SourceContextUnavailable>,
+> = LazyLock::new(|| {
+    tokscale_core::ResolvedLocalSourceContext::capture(
+        user_home_dir(),
+        true,
+        tokscale_core::ScannerSettings::default(),
+    )
+    .map(Arc::new)
+});
 
 /// Serve `tb_graph` from cache when the last computation is at most this old;
 /// `tb_refresh_graph` always recomputes. Mirrors the Tauri app's oneshot cache.
@@ -274,7 +296,11 @@ unsafe fn clients_from(clients: *const c_char) -> Result<Option<Vec<String>>, St
     Ok(if list.is_empty() { None } else { Some(list) })
 }
 
-fn graph_cached(year: &str, max_age: Duration) -> Option<serde_json::Value> {
+fn graph_cached(
+    context: &LocalSourceContext,
+    year: &str,
+    max_age: Duration,
+) -> Option<serde_json::Value> {
     // Read the entry and release the lock before any filesystem I/O — never hold
     // GRAPH_CACHE across the source-state probe below (mirrors graph_compute,
     // which probes outside the lock too), so concurrent tb_graph callers don't
@@ -292,9 +318,11 @@ fn graph_cached(year: &str, max_age: Duration) -> Option<serde_json::Value> {
     // briefly to re-stamp so the next calls inside the oneshot window skip the
     // probe entirely. A lost re-stamp (entry evicted/replaced meanwhile) just
     // degrades to the next call re-probing — benign.
-    let context = LocalSourceContext::current();
-    let fresh =
-        tokscale_core::local_source_change_token(&context.parse_options(None, None)).ok()?;
+    let fresh = tokscale_core::local_source_change_token_with_source_context(
+        context.resolved(),
+        &context.parse_options(None, None),
+    )
+    .ok()?;
     if fresh == token {
         let mut cache = GRAPH_CACHE.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(entry) = cache.get_mut(year) {
@@ -305,15 +333,17 @@ fn graph_cached(year: &str, max_age: Duration) -> Option<serde_json::Value> {
     None
 }
 
-fn graph_compute(year: &str) -> Result<serde_json::Value, String> {
+fn graph_compute(context: &LocalSourceContext, year: &str) -> Result<serde_json::Value, String> {
     // Probe before parsing: a source write or topology change that lands
     // mid-compute changes the token, so the next aged-out read recomputes
     // rather than serving a graph that missed it. Keep the same context for
     // both paths so the probe and report scan observe identical source roots.
-    let context = LocalSourceContext::current();
-    let token =
-        tokscale_core::local_source_change_token(&context.parse_options(None, None)).unwrap_or(0);
-    let data = usage_graph::run(&context, year)?;
+    let token = tokscale_core::local_source_change_token_with_source_context(
+        context.resolved(),
+        &context.parse_options(None, None),
+    )
+    .unwrap_or(0);
+    let data = usage_graph::run(context, year)?;
     GRAPH_CACHE
         .lock()
         .unwrap_or_else(|p| p.into_inner())
@@ -346,7 +376,7 @@ impl Drop for TickGuard {
 /// heavy `TAILER.tick()` runs with no lock held; the stamp is taken only after
 /// it completes, so a slow (> `TAIL_TICK_SECS`) parse can't be seen as stale
 /// mid-flight, and a tick panic leaves `last` unstamped to retry next call.
-fn tail_tick_if_stale() {
+fn tail_tick_if_stale(context: &LocalSourceContext) {
     let claimed = {
         let mut st = lock_tick();
         if st.in_flight {
@@ -363,7 +393,7 @@ fn tail_tick_if_stale() {
     };
     if claimed {
         let _guard = TickGuard; // clears in_flight on drop (success or panic)
-        TAILER.tick();
+        TAILER.tick(context);
         lock_tick().last = Some(Instant::now()); // success only — panic skips this
     }
 }
@@ -374,8 +404,15 @@ fn tail_tick_if_stale() {
 #[no_mangle]
 pub extern "C" fn tb_probe() -> *mut c_char {
     guarded("tb_probe", || {
-        let context = LocalSourceContext::current();
-        let json = match tokscale_core::parse_local_clients(context.parse_options(None, None)) {
+        let result = LocalSourceContext::process()
+            .map_err(|error| error.to_string())
+            .and_then(|context| {
+                tokscale_core::parse_local_clients_with_source_context(
+                    context.resolved(),
+                    context.parse_options(None, None),
+                )
+            });
+        let json = match result {
             Ok(pm) => format!(r#"{{"ok":true,"messages":{}}}"#, pm.messages.len()),
             Err(e) => serde_json::json!({"ok": false, "err": e}).to_string(),
         };
@@ -392,12 +429,20 @@ pub extern "C" fn tb_probe() -> *mut c_char {
 #[no_mangle]
 pub unsafe extern "C" fn tb_graph(year: *const c_char) -> *mut c_char {
     guarded("tb_graph", || {
-        envelope(unsafe { year_from(year) }.and_then(|year| {
-            if let Some(data) = graph_cached(&year, Duration::from_secs(ONESHOT_MAX_AGE_SECS)) {
-                return Ok(data);
-            }
-            graph_compute(&year)
-        }))
+        envelope(
+            LocalSourceContext::process()
+                .map_err(|error| error.to_string())
+                .and_then(|context| {
+                    unsafe { year_from(year) }.and_then(|year| {
+                        if let Some(data) =
+                            graph_cached(&context, &year, Duration::from_secs(ONESHOT_MAX_AGE_SECS))
+                        {
+                            return Ok(data);
+                        }
+                        graph_compute(&context, &year)
+                    })
+                }),
+        )
     })
 }
 
@@ -411,10 +456,13 @@ pub unsafe extern "C" fn tb_graph(year: *const c_char) -> *mut c_char {
 #[no_mangle]
 pub unsafe extern "C" fn tb_graph_local_first(year: *const c_char) -> *mut c_char {
     guarded("tb_graph_local_first", || {
-        let context = LocalSourceContext::current();
         envelope(
-            unsafe { year_from(year) }
-                .and_then(|year| usage_graph::run_local_first(&context, &year)),
+            LocalSourceContext::process()
+                .map_err(|error| error.to_string())
+                .and_then(|context| {
+                    unsafe { year_from(year) }
+                        .and_then(|year| usage_graph::run_local_first(&context, &year))
+                }),
         )
     })
 }
@@ -426,7 +474,13 @@ pub unsafe extern "C" fn tb_graph_local_first(year: *const c_char) -> *mut c_cha
 #[no_mangle]
 pub unsafe extern "C" fn tb_refresh_graph(year: *const c_char) -> *mut c_char {
     guarded("tb_refresh_graph", || {
-        envelope(unsafe { year_from(year) }.and_then(|year| graph_compute(&year)))
+        envelope(
+            LocalSourceContext::process()
+                .map_err(|error| error.to_string())
+                .and_then(|context| {
+                    unsafe { year_from(year) }.and_then(|year| graph_compute(&context, &year))
+                }),
+        )
     })
 }
 
@@ -437,8 +491,13 @@ pub unsafe extern "C" fn tb_refresh_graph(year: *const c_char) -> *mut c_char {
 #[no_mangle]
 pub unsafe extern "C" fn tb_model_report(year: *const c_char) -> *mut c_char {
     guarded("tb_model_report", || {
-        let context = LocalSourceContext::current();
-        envelope(unsafe { year_from(year) }.and_then(|year| model_report::run(&context, &year)))
+        envelope(
+            LocalSourceContext::process()
+                .map_err(|error| error.to_string())
+                .and_then(|context| {
+                    unsafe { year_from(year) }.and_then(|year| model_report::run(&context, &year))
+                }),
+        )
     })
 }
 
@@ -455,11 +514,16 @@ pub unsafe extern "C" fn tb_hourly_report(
     clients: *const c_char,
 ) -> *mut c_char {
     guarded("tb_hourly_report", || {
-        let context = LocalSourceContext::current();
-        envelope(unsafe { year_from(year) }.and_then(|year| {
-            let clients = unsafe { clients_from(clients) }?;
-            hourly_report::run(&context, &year, clients)
-        }))
+        envelope(
+            LocalSourceContext::process()
+                .map_err(|error| error.to_string())
+                .and_then(|context| {
+                    unsafe { year_from(year) }.and_then(|year| {
+                        let clients = unsafe { clients_from(clients) }?;
+                        hourly_report::run(&context, &year, clients)
+                    })
+                }),
+        )
     })
 }
 
@@ -477,11 +541,35 @@ pub unsafe extern "C" fn tb_agents_report(
     clients: *const c_char,
 ) -> *mut c_char {
     guarded("tb_agents_report", || {
-        let context = LocalSourceContext::current();
-        envelope(unsafe { year_from(year) }.and_then(|year| {
-            let clients = unsafe { clients_from(clients) }?;
-            agents_report::run(&context, &year, clients)
-        }))
+        envelope(
+            LocalSourceContext::process()
+                .map_err(|error| error.to_string())
+                .and_then(|context| {
+                    unsafe { year_from(year) }.and_then(|year| {
+                        let clients = unsafe { clients_from(clients) }?;
+                        agents_report::run(&context, &year, clients)
+                    })
+                }),
+        )
+    })
+}
+
+fn source_context_id_envelope(
+    identity: impl FnOnce() -> Result<String, tokscale_core::SourceContextUnavailable>,
+) -> *mut c_char {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(identity)) {
+        Ok(Ok(identity)) => envelope(Ok(serde_json::Value::String(identity))),
+        Ok(Err(_)) | Err(_) => envelope(Err("sourceContextUnavailable".to_string())),
+    }
+}
+
+/// Return the process-stable, configuration-only source-context identity.
+/// Failures are fixed and redacted so paths and panic payloads never cross the
+/// ABI. Identity capture and formatting stay wholly inside the unwind boundary.
+#[no_mangle]
+pub extern "C" fn tb_source_context_id() -> *mut c_char {
+    source_context_id_envelope(|| {
+        LocalSourceContext::process().map(|context| context.resolved().identity_string())
     })
 }
 
@@ -496,8 +584,9 @@ pub extern "C" fn tb_filter_parity_probe() -> *mut c_char {
     // contain a private source path, model, or provider value.
     LazyLock::force(&RAYON_INIT);
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let context = LocalSourceContext::current();
-        filter_parity_probe::run(&context)
+        LocalSourceContext::process()
+            .map_err(|error| error.to_string())
+            .and_then(|context| filter_parity_probe::run(&context))
     }));
     match result {
         Ok(Ok(payload)) => envelope(
@@ -514,10 +603,14 @@ pub extern "C" fn tb_filter_parity_probe() -> *mut c_char {
 #[no_mangle]
 pub extern "C" fn tb_usage_trace(window_secs: i64) -> *mut c_char {
     guarded("tb_usage_trace", || {
-        tail_tick_if_stale();
         envelope(
-            serde_json::to_value(TAILER.trace(window_secs))
-                .map_err(|e| format!("serialize usage trace: {}", e)),
+            LocalSourceContext::process()
+                .map_err(|error| error.to_string())
+                .and_then(|context| {
+                    tail_tick_if_stale(&context);
+                    serde_json::to_value(TAILER.trace(window_secs))
+                        .map_err(|error| format!("serialize usage trace: {error}"))
+                }),
         )
     })
 }
@@ -527,10 +620,14 @@ pub extern "C" fn tb_usage_trace(window_secs: i64) -> *mut c_char {
 #[no_mangle]
 pub extern "C" fn tb_tokens_per_min() -> *mut c_char {
     guarded("tb_tokens_per_min", || {
-        tail_tick_if_stale();
-        envelope(Ok(
-            serde_json::json!({"tokensPerMin": TAILER.rate_in_window(600)}),
-        ))
+        envelope(
+            LocalSourceContext::process()
+                .map_err(|error| error.to_string())
+                .map(|context| {
+                    tail_tick_if_stale(&context);
+                    serde_json::json!({"tokensPerMin": TAILER.rate_in_window(600)})
+                }),
+        )
     })
 }
 
@@ -585,36 +682,19 @@ mod tests {
     use usage_tail::UsageTailer;
 
     static GRAPH_CACHE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    const LOCAL_FIRST_CHILD_HOME: &str = "TB_TEST_LOCAL_FIRST_CHILD_HOME";
 
-    struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
-
-    impl EnvGuard {
-        fn set(vars: &[(&'static str, &std::ffi::OsStr)]) -> Self {
-            let guard = Self(
-                vars.iter()
-                    .map(|(key, _)| (*key, std::env::var_os(key)))
-                    .collect(),
-            );
-            unsafe {
-                for (key, value) in vars {
-                    std::env::set_var(key, value);
-                }
-            }
-            guard
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                for (key, previous) in self.0.drain(..) {
-                    match previous {
-                        Some(value) => std::env::set_var(key, value),
-                        None => std::env::remove_var(key),
-                    }
-                }
-            }
-        }
+    fn test_context(label: &str) -> LocalSourceContext {
+        let home = std::env::temp_dir().join(format!(
+            "tokenbar-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        LocalSourceContext::capture(Some(home), false, tokscale_core::ScannerSettings::default())
+            .unwrap()
     }
 
     #[test]
@@ -646,26 +726,19 @@ mod tests {
     }
 
     #[test]
-    fn local_source_context_builders_preserve_home_filters_and_env_roots() {
-        let platform_home = PathBuf::from("platform-home");
-        let context = LocalSourceContext {
-            home_dir: select_user_home(None, Some(platform_home.clone())),
-        };
+    fn local_source_context_builders_preserve_filters() {
+        let context = test_context("source-context-options");
         let year = Some("2026".to_string());
         let clients = Some(vec!["claude".to_string(), "codex".to_string()]);
 
         let report = context.report_options(year.clone(), clients.clone());
         let parse = context.parse_options(year.clone(), clients.clone());
-        let expected_home = Some(platform_home.to_string_lossy().into_owned());
 
-        assert_eq!(report.home_dir, expected_home);
-        assert_eq!(parse.home_dir, expected_home);
-        assert!(report.use_env_roots);
-        assert!(parse.use_env_roots);
         assert_eq!(report.year, year);
         assert_eq!(parse.year, year);
         assert_eq!(report.clients, clients);
         assert_eq!(parse.clients, clients);
+        assert!(!context.resolved().use_env_roots());
     }
 
     /// Read a heap JSON pointer into an owned String and free it — the test-side
@@ -674,6 +747,44 @@ mod tests {
         let s = unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned();
         unsafe { tb_free(p) };
         s
+    }
+
+    #[test]
+    fn source_context_identity_envelope_uses_exact_grammar_from_explicit_context() {
+        let context = test_context("source-context-identity");
+        let expected = context.resolved().identity_string();
+        let json = unsafe {
+            take(source_context_id_envelope(|| {
+                Ok(context.resolved().identity_string())
+            }))
+        };
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let identity = value["data"].as_str().unwrap();
+
+        assert_eq!(value["ok"], true);
+        assert_eq!(identity, expected);
+        assert_eq!(identity.len(), 68);
+        assert!(identity.starts_with("sc1:"));
+        assert!(identity[4..]
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')));
+    }
+
+    #[test]
+    fn source_context_identity_failure_and_panic_are_exactly_redacted() {
+        let failure = unsafe {
+            take(source_context_id_envelope(|| {
+                Err(tokscale_core::SourceContextUnavailable)
+            }))
+        };
+        let panic = unsafe {
+            take(source_context_id_envelope(|| {
+                std::panic::resume_unwind(Box::new("injected source-context panic"))
+            }))
+        };
+
+        assert_eq!(failure, r#"{"err":"sourceContextUnavailable","ok":false}"#);
+        assert_eq!(panic, failure);
     }
 
     #[test]
@@ -912,22 +1023,44 @@ mod tests {
     #[test]
     #[allow(clippy::undocumented_unsafe_blocks)]
     fn local_first_is_cache_isolated_in_both_call_orders_and_validates_abi_year() {
-        let _lock = GRAPH_CACHE_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(root) = std::env::var_os(LOCAL_FIRST_CHILD_HOME) {
+            run_local_first_fixture(std::path::Path::new(&root));
+            return;
+        }
+
         let root = std::env::temp_dir().join(format!(
             "tokenbar-ffi-local-first-{}-{}",
             std::process::id(),
-            Instant::now().elapsed().as_nanos()
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
         ));
-        let data_root = root.join("data");
-        std::fs::create_dir_all(&data_root).unwrap();
-        let _env = EnvGuard::set(&[
-            ("HOME", root.as_os_str()),
-            ("TOKSCALE_CONFIG_DIR", root.as_os_str()),
-            ("XDG_DATA_HOME", data_root.as_os_str()),
-            ("TOKSCALE_PRICING_CACHE_ONLY", std::ffi::OsStr::new("1")),
-        ]);
+        std::fs::create_dir_all(root.join("data")).unwrap();
+        std::fs::create_dir_all(root.join("tmp")).unwrap();
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("tests::local_first_is_cache_isolated_in_both_call_orders_and_validates_abi_year")
+            .arg("--exact")
+            .env_clear()
+            .env(LOCAL_FIRST_CHILD_HOME, &root)
+            .env("HOME", &root)
+            .env("TMPDIR", root.join("tmp"))
+            .env("TOKSCALE_CONFIG_DIR", root.join("tokscale-config"))
+            .env("XDG_CONFIG_HOME", root.join("config"))
+            .env("XDG_DATA_HOME", root.join("data"))
+            .env("TOKSCALE_PRICING_CACHE_ONLY", "1")
+            .status()
+            .unwrap();
+        std::fs::remove_dir_all(&root).unwrap();
+        assert!(status.success(), "isolated local-first fixture failed");
+    }
+
+    #[allow(clippy::undocumented_unsafe_blocks)]
+    fn run_local_first_fixture(root: &std::path::Path) {
+        assert_eq!(std::env::var_os("HOME").as_deref(), Some(root.as_os_str()));
+        let _lock = GRAPH_CACHE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         GRAPH_CACHE
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -988,8 +1121,6 @@ mod tests {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clear();
-        drop(_env);
-        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/crates/tb_core_ffi/src/model_report.rs
+++ b/crates/tb_core_ffi/src/model_report.rs
@@ -49,7 +49,7 @@ struct ModelReportData {
 /// Build the per-model report for `year` (empty string = all time).
 pub(crate) fn run(context: &crate::LocalSourceContext, year: &str) -> Result<Value, String> {
     let year = normalize_year(year)?;
-    let data = load_report(report_options(context, year))?;
+    let data = load_report(context, report_options(context, year))?;
     serde_json::to_value(data).map_err(|e| format!("serialize model report: {}", e))
 }
 
@@ -64,13 +64,19 @@ fn report_options(
     options
 }
 
-fn load_report(options: tokscale_core::ReportOptions) -> Result<ModelReportData, String> {
+fn load_report(
+    context: &crate::LocalSourceContext,
+    options: tokscale_core::ReportOptions,
+) -> Result<ModelReportData, String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|e| format!("build runtime: {}", e))?;
     runtime
-        .block_on(tokscale_core::get_model_report(options))
+        .block_on(tokscale_core::get_model_report_with_source_context(
+            context.resolved(),
+            options,
+        ))
         .map(map_report)
 }
 
@@ -257,18 +263,20 @@ mod tests {
     }
 
     fn run_provider_fixture(home: &std::path::Path) {
-        let context = crate::LocalSourceContext {
-            home_dir: Some(home.to_path_buf()),
-        };
+        let context = crate::LocalSourceContext::capture(
+            Some(home.to_path_buf()),
+            false,
+            tokscale_core::ScannerSettings::default(),
+        )
+        .unwrap();
         let mut options = report_options(&context, None);
-        options.use_env_roots = false;
         options.clients = Some(vec!["mux".to_string()]);
         assert_eq!(
             options.group_by,
             tokscale_core::GroupBy::ClientProviderModel
         );
 
-        let report = load_report(options).unwrap();
+        let report = load_report(&context, options).unwrap();
         assert_eq!(report.entries.len(), 3);
         assert!(report.entries.iter().all(|entry| entry.client == "mux"
             && entry.model == "same-model"

--- a/crates/tb_core_ffi/src/usage_graph.rs
+++ b/crates/tb_core_ffi/src/usage_graph.rs
@@ -130,13 +130,19 @@ fn run_mode(
         .build()
         .map_err(|e| format!("build runtime: {}", e))?;
     let report = if local_only {
-        runtime.block_on(tokscale_core::generate_local_graph_report_local_only(
-            options,
-        ))?
+        runtime.block_on(
+            tokscale_core::generate_local_graph_report_local_only_with_source_context(
+                context.resolved(),
+                options,
+            ),
+        )?
     } else {
-        runtime.block_on(tokscale_core::generate_local_graph_report_with_contract(
-            options,
-        ))?
+        runtime.block_on(
+            tokscale_core::generate_local_graph_report_with_source_context(
+                context.resolved(),
+                options,
+            ),
+        )?
     };
 
     let payload = map_graph(report);
@@ -289,7 +295,15 @@ mod tests {
 
     #[test]
     fn invalid_year_is_rejected_before_engine_scan() {
-        let context = crate::LocalSourceContext { home_dir: None };
+        let context = crate::LocalSourceContext::capture(
+            Some(std::env::temp_dir().join(format!(
+                "tokenbar-usage-graph-invalid-year-{}",
+                std::process::id()
+            ))),
+            false,
+            tokscale_core::ScannerSettings::default(),
+        )
+        .unwrap();
         let error = run_local_first(&context, "26").unwrap_err();
         assert!(error.contains("invalid year filter"));
     }

--- a/crates/tb_core_ffi/src/usage_tail.rs
+++ b/crates/tb_core_ffi/src/usage_tail.rs
@@ -75,7 +75,7 @@ impl UsageTailer {
     /// Re-parse recent local sessions via tokscale-core and replace the event
     /// window. Returns the number of events now in the window (cheap to compute
     /// and only used as a "did anything happen" hint by callers).
-    pub fn tick(&self) -> usize {
+    pub fn tick(&self, context: &crate::LocalSourceContext) -> usize {
         // `since` is date-granular; reach back one day so a sub-hour window that
         // straddles midnight still sees yesterday's tail.
         let since = (Local::now() - Duration::days(1))
@@ -87,19 +87,25 @@ impl UsageTailer {
         // only files active within the window — plus a small margin for write
         // latency and clock skew — are re-parsed each tick.
         let window_reach_ms = (EVENT_WINDOW_SECS + 300) * 1000;
-        let context = crate::LocalSourceContext::current();
         let mut options = context.parse_options(None, None);
         options.since = Some(since);
         options.modified_after = Some((now_ms() - window_reach_ms) as u64);
 
         // No source changed since the last parse → the window is already
         // correct; skip the parse. Probe failure falls through to a parse.
-        let token = tokscale_core::local_source_change_token(&options).ok();
+        let token = tokscale_core::local_source_change_token_with_source_context(
+            context.resolved(),
+            &options,
+        )
+        .ok();
         if token.is_some() && *self.last_source_token.lock() == token {
             return self.events.lock().len();
         }
 
-        let parsed = match tokscale_core::parse_local_clients(options) {
+        let parsed = match tokscale_core::parse_local_clients_with_source_context(
+            context.resolved(),
+            options,
+        ) {
             Ok(parsed) => parsed,
             Err(_) => return self.events.lock().len(),
         };

--- a/include/ctb.h
+++ b/include/ctb.h
@@ -71,6 +71,13 @@ char *tb_hourly_report(const char *year, const char *clients);
 // Per-(sub-)agent report (AgentsReport). `clients` as in tb_hourly_report.
 char *tb_agents_report(const char *year, const char *clients);
 
+// Process-stable source configuration identity. Success uses the standard
+// envelope with `data` equal to exactly `sc1:` plus 64 lowercase hex digits.
+// Failure is the fixed redacted `sourceContextUnavailable`; no path, descriptor,
+// panic payload, or native cause crosses this boundary. The ID is not a secret
+// and must not be written to normal diagnostics, UI, or Smoke output.
+char *tb_source_context_id(void);
+
 // Source-generation-aware hourly/Agents filter parity diagnostic. The graph
 // client list is derived from a fresh graph and all reports are bracketed by
 // one opaque local-source token sequence. The success payload contains only

--- a/src/TokenBar.Core.Tests/DtoDecodeTests.cs
+++ b/src/TokenBar.Core.Tests/DtoDecodeTests.cs
@@ -158,6 +158,31 @@ public class DtoDecodeTests
     }
 
     [Fact]
+    public void SourceContextIdAcceptsOnlyExactVersionedLowercaseSha256Grammar()
+    {
+        var valid = "sc1:" + new string('a', 64);
+        Assert.Equal(valid, TbCore.ValidateSourceContextId(valid));
+
+        foreach (var invalid in new[]
+        {
+            "", "sc1:" + new string('a', 63), "sc1:" + new string('a', 65),
+            "sc2:" + new string('a', 64), "SC1:" + new string('a', 64),
+            "sc1:" + new string('A', 64), "sc1:" + new string('g', 64),
+            "sc1:" + new string('a', 63) + "\n", " " + valid, valid + "suffix",
+        })
+        {
+            Assert.Throws<TbCoreException>(() => TbCore.ValidateSourceContextId(invalid));
+        }
+    }
+
+    [Fact]
+    public void SourceContextIdEnvelopeRejectsMissingAndNonStringPayloads()
+    {
+        Assert.Throws<TbCoreException>(() => TbCore.DecodeEnvelope<string>("""{"ok":true}"""));
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<string>("""{"ok":true,"data":1}"""));
+    }
+
+    [Fact]
     public void FilterParityProbeDecodesStatusesNullableAggregatesAndBoundedSummary()
     {
         var payload = TbCore.DecodeEnvelope<FilterParityProbe>(

--- a/src/TokenBar.Interop/NativeMethods.cs
+++ b/src/TokenBar.Interop/NativeMethods.cs
@@ -37,6 +37,9 @@ internal static partial class NativeMethods
     internal static partial nint tb_agents_report(string? year, string? clients);
 
     [LibraryImport(Lib)]
+    internal static partial nint tb_source_context_id();
+
+    [LibraryImport(Lib)]
     internal static partial nint tb_filter_parity_probe();
 
     [LibraryImport(Lib)]

--- a/src/TokenBar.Interop/TbCore.cs
+++ b/src/TokenBar.Interop/TbCore.cs
@@ -83,6 +83,34 @@ public static class TbCore
     public static AgentsReport AgentsReport(string? year = null, IReadOnlyList<string>? clients = null) =>
         Unwrap<AgentsReport>(NativeMethods.tb_agents_report(year, JoinClients(clients)));
 
+    /// <summary>
+    /// Process-stable source configuration identity. The full value is for
+    /// cache binding only and must not be written to normal diagnostics or UI.
+    /// </summary>
+    public static string SourceContextId() =>
+        ValidateSourceContextId(Unwrap<string>(NativeMethods.tb_source_context_id()));
+
+    public static string ValidateSourceContextId(string value)
+    {
+        if (value is null || value.Length != 68 ||
+            !value.StartsWith("sc1:", StringComparison.Ordinal))
+        {
+            throw new TbCoreException("source context ID has invalid format");
+        }
+
+        for (var index = 4; index < value.Length; index++)
+        {
+            var character = value[index];
+            if (!((character >= '0' && character <= '9') ||
+                  (character >= 'a' && character <= 'f')))
+            {
+                throw new TbCoreException("source context ID has invalid format");
+            }
+        }
+
+        return value;
+    }
+
     /// <summary>Source-generation-aware nil/full parity diagnostic for the
     /// hourly and Agents report filters.</summary>
     public static FilterParityProbe FilterParityProbe() =>

--- a/src/TokenBar.Smoke/Program.cs
+++ b/src/TokenBar.Smoke/Program.cs
@@ -42,6 +42,17 @@ void Step(string name, Func<string> body)
     }
 }
 
+try
+{
+    _ = TbCore.SourceContextId();
+    Console.WriteLine("source-context:v1 valid");
+}
+catch
+{
+    failed++;
+    Console.WriteLine("source-context:v1 FAILED");
+}
+
 long probeMessages = -1;
 Step("tb_probe", () =>
 {

--- a/vendor/ENGINE.md
+++ b/vendor/ENGINE.md
@@ -10,25 +10,24 @@ app consumer advances its reviewed pin.
 |---|---|
 | Path | `vendor/tokscale-core` |
 | Repository | `https://github.com/Nanako0129/tokscale-core.git` |
-| Reviewed pin | `5b5f500d3a8abe66ab5fa44b18f4fc1aaee53947` |
+| Reviewed pin | `95b7f33f25e09b3514384776ad353a2efbf6c2b5` |
 | TokenBar alignment | `v1.12.0` → `v1.13.1` |
-| Engine alignment | `84e0d66413d4e0d87b734f66f7a848b3bc323258` → `5b5f500d3a8abe66ab5fa44b18f4fc1aaee53947` |
+| Engine alignment | `84e0d66413d4e0d87b734f66f7a848b3bc323258` → `95b7f33f25e09b3514384776ad353a2efbf6c2b5` |
 | Native consumer baseline | `704426e8df9acfb8e82fe4bf3b7ed3e5adbc2fea` |
 | Windows pre-migration baseline | `68e2541c5e9adb14a47433f8b25e26b0be84d1fc` |
-| Upstream and local-patch ledger | Immutable [`UPSTREAM.md`](https://github.com/Nanako0129/tokscale-core/blob/5b5f500d3a8abe66ab5fa44b18f4fc1aaee53947/UPSTREAM.md) |
+| Upstream and local-patch ledger | Immutable [`UPSTREAM.md`](https://github.com/Nanako0129/tokscale-core/blob/95b7f33f25e09b3514384776ad353a2efbf6c2b5/UPSTREAM.md) |
 
 > **Warning:** Do not edit shared source on a consumer branch. Engine changes
 > must pass review in `tokscale-core`; this repository then advances only the
 > reviewed gitlink and runs the Windows consumer gates.
 
-## v1.13.1 consumer alignment
+## v1.13 source-context consumer alignment
 
-This slice advances only the shared engine pin and the Windows-owned consumer
-contracts: exact-client daily turns and per-`(client, provider, model)` model
-rows. Cache format 3, Claude rewrite retention, missing-source pruning, and the
-batched parser remain engine-owned and are accepted through the pinned engine's
-behavioral regressions. This slice does not include UI, downstream attribution,
-or performance claims.
+The reviewed pin is the immutable GitHub merge commit for tokscale-core PR #10,
+`feat(source-context): capture immutable local source identity`. The Windows FFI
+captures that engine-owned context once per process and routes graph, report,
+parse, source-token, and live-tail work through the context-aware APIs. This
+slice does not include UI, cache-token redesign, or performance claims.
 
 ## Ownership
 


### PR DESCRIPTION
## Summary

- pin `vendor/tokscale-core` to the reviewed immutable merge commit `95b7f33f25e09b3514384776ad353a2efbf6c2b5`
- capture one engine-owned `ResolvedLocalSourceContext` per FFI process and reuse it across graph, report, parse, source-token, parity, and live-tail paths
- expose the process context identity through the existing C ABI envelope/free contract and validate the exact `sc1:` plus 64 lowercase hexadecimal grammar in C#
- keep Smoke output privacy-safe with fixed validity/failure markers only

## Why

The previous Windows FFI rebuilt local-source options at individual entry points, allowing source roots to drift with live environment or working-directory changes. A single process-sticky context gives every producer the same captured configuration and provides the stable identity needed by later snapshot binding without adding B4 snapshot integration to this slice.

## Security and compatibility

- identity failures and caught unwinds return only `sourceContextUnavailable`
- the identity is never printed by Smoke or routine diagnostics
- C# uses the existing `TakeString` / `tb_free` exactly-once ownership path
- in-process identity tests use explicit temporary contexts; the production singleton graph regression runs only in an environment-cleared isolated child
- legacy test-only token comparisons remain; production paths use context-aware engine APIs

## Validation

- `cargo fmt --package tb_core_ffi -- --check`
- `cargo check --locked -p tb_core_ffi`
- hermetic `cargo test --locked -p tb_core_ffi` — 326/326 plus isolated child regressions
- post-edit hermetic graph call-order regression
- `cargo build --release --locked -p tb_core_ffi`
- release ABI symbol and runtime identity checks
- `git diff --check` and production caller sweep

The local host has .NET SDK `10.0.302`, while `global.json` requires `10.0.301` with roll-forward disabled. Managed build, Core.Tests, Smoke, and Windows execution are therefore intentionally left to this PR's hosted CI.

`cargo fmt --all -- --check` also reports formatting drift only inside the clean immutable engine submodule. The consumer-owned `tb_core_ffi` package formatting gate passes; this PR does not modify upstream engine source.