### PR TITLE
feat(graph): restore fresh persisted snapshots

### DIFF
--- a/src/TokenBar.App/App.xaml.cs
+++ b/src/TokenBar.App/App.xaml.cs
@@ -56,7 +56,7 @@ public partial class App : Application
         try
         {
             DevLog.Write("launch: creating graph coordinator");
-            _graphCoordinator = new GraphRequestCoordinator(
+            _graphCoordinator = GraphRequestCoordinator.CreateForApp(
                 boost: ProcessPower.Boost);
             DevLog.Write("launch: creating flyout");
             _flyout = new FlyoutWindow(_graphCoordinator);

--- a/src/TokenBar.App/GraphRequestCoordinator.cs
+++ b/src/TokenBar.App/GraphRequestCoordinator.cs
@@ -1,3 +1,4 @@
+using TokenBar.Core;
 using TokenBar.Interop;
 
 namespace TokenBar.App;
@@ -37,10 +38,30 @@ public readonly record struct GraphAttachment(
     GraphPublication? Latest,
     bool InFlight);
 
+internal sealed class SnapshotAccess
+{
+    public SnapshotAccess(
+        Func<string?, GraphSnapshotReadResult> read,
+        Func<string?, DateTimeOffset, UsagePayload, Action<Action>?, GraphSnapshotWriteStatus> write)
+    {
+        Read = read ?? throw new ArgumentNullException(nameof(read));
+        Write = write ?? throw new ArgumentNullException(nameof(write));
+    }
+
+    public Func<string?, GraphSnapshotReadResult> Read { get; }
+
+    public Func<string?, DateTimeOffset, UsagePayload, Action<Action>?, GraphSnapshotWriteStatus> Write { get; }
+}
+
 /// <summary>Process-shared graph pipeline. Every production graph call enters
 /// here, so local-first publication and request supersession have one owner.</summary>
 public sealed class GraphRequestCoordinator
 {
+    internal const Environment.SpecialFolder SnapshotProfileRoot =
+        Environment.SpecialFolder.LocalApplicationData;
+
+    private static readonly TimeSpan SnapshotMaxAge = TimeSpan.FromMinutes(30);
+
     private sealed class QueryState(GraphQuery query)
     {
         public GraphQuery Query { get; } = query;
@@ -60,11 +81,14 @@ public sealed class GraphRequestCoordinator
     }
 
     private readonly object _gate = new();
+    private readonly object _publicationGate = new();
     private readonly Dictionary<GraphQuery, QueryState> _states = [];
     private readonly Func<string?, UsagePayload> _localFirst;
     private readonly Func<string?, UsagePayload> _graph;
     private readonly Func<string?, UsagePayload> _refreshGraph;
     private readonly Func<IDisposable> _boost;
+    private readonly SnapshotAccess? _snapshot;
+    private readonly Func<DateTimeOffset> _utcNow;
     private long _nextGeneration;
 
     public GraphRequestCoordinator(
@@ -72,16 +96,117 @@ public sealed class GraphRequestCoordinator
         Func<string?, UsagePayload>? graph = null,
         Func<string?, UsagePayload>? refreshGraph = null,
         Func<IDisposable>? boost = null)
+        : this(localFirst, graph, refreshGraph, boost, null, null)
+    {
+    }
+
+    internal GraphRequestCoordinator(
+        Func<string?, UsagePayload>? localFirst,
+        Func<string?, UsagePayload>? graph,
+        Func<string?, UsagePayload>? refreshGraph,
+        Func<IDisposable>? boost,
+        SnapshotAccess? snapshot,
+        Func<DateTimeOffset>? utcNow)
     {
         _localFirst = localFirst ?? TbCore.GraphLocalFirst;
         _graph = graph ?? refreshGraph ?? TbCore.RefreshGraph;
         _refreshGraph = refreshGraph ?? graph ?? TbCore.RefreshGraph;
         _boost = boost ?? (() => NoopScope.Instance);
+        _snapshot = snapshot;
+        _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
     }
+
+    internal GraphRequestCoordinator(
+        Func<string?, UsagePayload>? localFirst,
+        Func<string?, UsagePayload>? graph,
+        SnapshotAccess snapshot,
+        Func<DateTimeOffset>? utcNow = null)
+        : this(localFirst, graph, null, null, snapshot, utcNow)
+    {
+    }
+
+    internal GraphRequestCoordinator(
+        Func<string?, UsagePayload>? localFirst,
+        Func<string?, UsagePayload>? graph,
+        Func<string?, UsagePayload>? refreshGraph,
+        SnapshotAccess snapshot,
+        Func<DateTimeOffset>? utcNow = null)
+        : this(localFirst, graph, refreshGraph, null, snapshot, utcNow)
+    {
+    }
+
+    internal SnapshotAccess? Snapshot => _snapshot;
 
     public event Action<GraphRequestId>? Started;
     public event Action<GraphPublication>? Published;
     public event Action<GraphRequestCompletion>? Completed;
+
+    /// <summary>Build the production graph pipeline and its profile-local
+    /// snapshot. Any profile setup failure leaves the live pipeline usable.</summary>
+    internal static GraphRequestCoordinator CreateForApp(
+        Func<IDisposable>? boost = null,
+        Func<Environment.SpecialFolder, string?>? getFolderPath = null,
+        Func<string>? sourceContextId = null,
+        Action<string>? createDirectory = null,
+        Func<string?, UsagePayload>? localFirst = null,
+        Func<string?, UsagePayload>? graph = null,
+        Func<string?, UsagePayload>? refreshGraph = null,
+        Func<DateTimeOffset>? utcNow = null)
+    {
+        try
+        {
+            var root = getFolderPath is null
+                ? Environment.GetFolderPath(SnapshotProfileRoot)
+                : getFolderPath(SnapshotProfileRoot);
+            if (string.IsNullOrWhiteSpace(root)
+                || !Path.IsPathFullyQualified(root))
+            {
+                throw new InvalidOperationException();
+            }
+
+            var profile = Path.Combine(root, "TokenBar");
+            if (createDirectory is null)
+            {
+                Directory.CreateDirectory(profile);
+            }
+            else
+            {
+                createDirectory(profile);
+            }
+
+            var sourceId = sourceContextId is null
+                ? TbCore.SourceContextId()
+                : sourceContextId();
+            if (string.IsNullOrWhiteSpace(sourceId))
+            {
+                throw new InvalidOperationException();
+            }
+
+            var store = new GraphSnapshotStore(
+                Path.Combine(profile, "graph-snapshot.json"));
+            var snapshot = new SnapshotAccess(
+                year => store.Read(sourceId, year),
+                (year, capturedAt, payload, commitFence) =>
+                    store.Write(sourceId, year, capturedAt, payload, commitFence));
+            return new GraphRequestCoordinator(
+                localFirst,
+                graph,
+                refreshGraph,
+                boost,
+                snapshot,
+                utcNow);
+        }
+        catch
+        {
+            return new GraphRequestCoordinator(
+                localFirst,
+                graph,
+                refreshGraph,
+                boost,
+                snapshot: null,
+                utcNow: utcNow);
+        }
+    }
 
     /// <summary>Attach an observer's exact query. A retained exact publication
     /// is returned synchronously; otherwise one pipeline is started.</summary>
@@ -113,7 +238,6 @@ public sealed class GraphRequestCoordinator
                 requestId = BeginLocked(state);
                 start = true;
             }
-
         }
 
         if (start)
@@ -134,6 +258,7 @@ public sealed class GraphRequestCoordinator
         if (start)
         {
             StartPipeline(state, requestId, force: false);
+            StartRestore(state, requestId);
         }
 
         return new GraphAttachment(requestId, latest, inFlight);
@@ -213,6 +338,7 @@ public sealed class GraphRequestCoordinator
     {
         var requestId = new GraphRequestId(state.Query, ++_nextGeneration);
         state.Current = requestId;
+        state.Latest = null;
         state.InFlight = true;
         state.CurrentSucceeded = false;
         return requestId;
@@ -220,7 +346,29 @@ public sealed class GraphRequestCoordinator
 
     private void StartPipeline(QueryState state, GraphRequestId requestId, bool force)
     {
-        _ = Task.Run(() => RunPipeline(state, requestId, force));
+        try
+        {
+            _ = Task.Run(() => RunPipeline(state, requestId, force));
+        }
+        catch
+        {
+        }
+    }
+
+    private void StartRestore(QueryState state, GraphRequestId requestId)
+    {
+        if (_snapshot is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = Task.Run(() => RestoreSnapshot(state, requestId));
+        }
+        catch
+        {
+        }
     }
 
     private void RunPipeline(QueryState state, GraphRequestId requestId, bool force)
@@ -244,7 +392,9 @@ public sealed class GraphRequestCoordinator
                 return;
             }
 
-            if (!PublishIfCurrent(state, requestId,
+            if (!PublishIfCurrent(
+                    state,
+                    requestId,
                     new GraphPublication(
                         requestId, GraphPublicationStage.LocalFirst, local)))
             {
@@ -260,8 +410,14 @@ public sealed class GraphRequestCoordinator
                 }
 
                 richerSucceeded = true;
-                PublishIfCurrent(state, requestId,
-                    new GraphPublication(requestId, GraphPublicationStage.Richer, richer));
+                if (PublishIfCurrent(
+                        state,
+                        requestId,
+                        new GraphPublication(
+                            requestId, GraphPublicationStage.Richer, richer)))
+                {
+                    StartPersist(state, requestId, richer);
+                }
             }
             catch
             {
@@ -276,7 +432,8 @@ public sealed class GraphRequestCoordinator
                 if (state.Current == requestId)
                 {
                     state.InFlight = false;
-                    state.CurrentSucceeded = localSucceeded;
+                    state.CurrentSucceeded = localSucceeded
+                        || state.Latest?.RequestId == requestId;
                     current = true;
                 }
             }
@@ -289,29 +446,122 @@ public sealed class GraphRequestCoordinator
         }
     }
 
-    private bool PublishIfCurrent(
-        QueryState state, GraphRequestId requestId, GraphPublication publication)
+    private void RestoreSnapshot(QueryState state, GraphRequestId requestId)
     {
-        var current = false;
-        lock (_gate)
+        var access = _snapshot;
+        if (access is null)
         {
-            if (state.Current == requestId)
+            return;
+        }
+
+        GraphSnapshotReadResult? result;
+        try
+        {
+            result = access.Read(requestId.Query.Year);
+        }
+        catch
+        {
+            return;
+        }
+
+        if (result is null
+            || result.Status != GraphSnapshotReadStatus.Hit
+            || result.Payload is null
+            || result.CapturedAt is not { } capturedAt)
+        {
+            return;
+        }
+
+        try
+        {
+            var now = _utcNow().ToUniversalTime();
+            var age = now - capturedAt.ToUniversalTime();
+            if (age < TimeSpan.Zero || age > SnapshotMaxAge)
             {
-                state.Latest = publication;
-                state.CurrentSucceeded = true;
-                current = true;
+                return;
             }
         }
-
-        if (!current)
+        catch
         {
-            return false;
+            return;
         }
 
-        InvokePublished(publication);
-        lock (_gate)
+        PublishIfCurrent(
+            state,
+            requestId,
+            new GraphPublication(
+                requestId, GraphPublicationStage.LocalFirst, result.Payload),
+            snapshot: true);
+    }
+
+    private void StartPersist(
+        QueryState state,
+        GraphRequestId requestId,
+        UsagePayload payload)
+    {
+        var access = _snapshot;
+        if (access is null)
         {
-            return state.Current == requestId;
+            return;
+        }
+
+        try
+        {
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var capturedAt = _utcNow();
+                    access.Write(
+                        requestId.Query.Year,
+                        capturedAt,
+                        payload,
+                        commit =>
+                        {
+                            lock (_gate)
+                            {
+                                if (state.Current == requestId)
+                                {
+                                    commit();
+                                }
+                            }
+                        });
+                }
+                catch
+                {
+                }
+            });
+        }
+        catch
+        {
+        }
+    }
+
+    private bool PublishIfCurrent(
+        QueryState state,
+        GraphRequestId requestId,
+        GraphPublication publication,
+        bool snapshot = false)
+    {
+        lock (_publicationGate)
+        {
+            lock (_gate)
+            {
+                if (state.Current != requestId
+                    || snapshot && state.Latest is not null)
+                {
+                    return false;
+                }
+
+                state.Latest = publication;
+                state.CurrentSucceeded = true;
+            }
+
+            InvokePublished(publication);
+            lock (_gate)
+            {
+                return state.Current == requestId;
+            }
         }
     }
 

--- a/src/TokenBar.App/GraphRequestCoordinator.cs
+++ b/src/TokenBar.App/GraphRequestCoordinator.cs
@@ -520,7 +520,8 @@ public sealed class GraphRequestCoordinator
                         {
                             lock (_gate)
                             {
-                                if (state.Current == requestId)
+                                if (state.Current == requestId
+                                    && requestId.Generation == _nextGeneration)
                                 {
                                     commit();
                                 }

--- a/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
+++ b/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
@@ -882,6 +882,69 @@ public class GraphRequestCoordinatorTests
         }
     }
 
+    [Fact]
+    public async Task OlderQueryCannotCommitAfterNewerQueryStarts()
+    {
+        var firstWriteStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstWrite = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstWriteFinished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondCommitted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var commits = new ConcurrentQueue<string>();
+        var access = new SnapshotAccess(
+            _ => new GraphSnapshotReadResult(GraphSnapshotReadStatus.Missing),
+            (year, _, _, fence) =>
+            {
+                if (year is null)
+                {
+                    firstWriteStarted.TrySetResult(true);
+                    releaseFirstWrite.Task.GetAwaiter().GetResult();
+                }
+
+                var committed = false;
+                fence!(() =>
+                {
+                    committed = true;
+                    commits.Enqueue(year ?? "all");
+                    if (year == "2026")
+                    {
+                        secondCommitted.TrySetResult(true);
+                    }
+                });
+                if (year is null)
+                {
+                    firstWriteFinished.TrySetResult(true);
+                }
+                return committed
+                    ? GraphSnapshotWriteStatus.Written
+                    : GraphSnapshotWriteStatus.Skipped;
+            });
+        var coordinator = new GraphRequestCoordinator(
+            year => Payload(year),
+            year => Payload(year, PricingMode.BestEffort, CostCoverage.Complete),
+            snapshot: access);
+
+        try
+        {
+            coordinator.Request(null);
+            await firstWriteStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            coordinator.Request("2026");
+            await secondCommitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            releaseFirstWrite.TrySetResult(true);
+            await firstWriteFinished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(["2026"], commits);
+        }
+        finally
+        {
+            releaseFirstWrite.TrySetResult(true);
+        }
+    }
+
     private sealed class CallbackScope(Action dispose) : IDisposable
     {
         private Action? _dispose = dispose;

--- a/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
+++ b/src/TokenBar.Core.Tests/GraphRequestCoordinatorTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using TokenBar.App;
+using TokenBar.Core;
 using TokenBar.Interop;
 
 namespace TokenBar.Core.Tests;
@@ -657,6 +658,228 @@ public class GraphRequestCoordinatorTests
         Assert.Single(richerPublications);
         Assert.Equal(GraphPublicationStage.LocalFirst,
             richerPublications.Single().Stage);
+    }
+
+    [Fact]
+    public async Task FreshSnapshotPublishesOnceWithoutSuppressingLiveStages()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var localStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLocal = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var snapshotPublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var completion = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var snapshot = Payload("2026", PricingMode.BestEffort);
+        var local = Payload("2026");
+        var richer = Payload("2026", PricingMode.BestEffort, CostCoverage.Complete);
+        var publications = new ConcurrentQueue<GraphPublication>();
+        var access = new SnapshotAccess(
+            _ => new GraphSnapshotReadResult(
+                GraphSnapshotReadStatus.Hit, snapshot, now.AddMinutes(-5)),
+            (_, _, _, _) => GraphSnapshotWriteStatus.Skipped);
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                localStarted.TrySetResult(true);
+                releaseLocal.Task.GetAwaiter().GetResult();
+                return local;
+            },
+            _ => richer,
+            snapshot: access,
+            utcNow: () => now);
+        coordinator.Published += publication =>
+        {
+            publications.Enqueue(publication);
+            if (ReferenceEquals(publication.Payload, snapshot))
+            {
+                snapshotPublished.TrySetResult(true);
+            }
+        };
+        coordinator.Completed += value => completion.TrySetResult(value);
+
+        var requestId = coordinator.Attach(" 2026 ").RequestId;
+        await localStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await snapshotPublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        releaseLocal.TrySetResult(true);
+        var result = await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(3, publications.Count);
+        Assert.Equal(requestId, publications.First().RequestId);
+        Assert.Same(snapshot, publications.First().Payload);
+        Assert.Contains(publications, value => ReferenceEquals(value.Payload, local));
+        Assert.Contains(publications, value => ReferenceEquals(value.Payload, richer));
+    }
+
+    [Fact]
+    public async Task LivePublicationWinsAndLateSnapshotIsNotEmitted()
+    {
+        var snapshotStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSnapshot = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var livePublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var completion = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var snapshot = Payload("2026", PricingMode.BestEffort);
+        var local = Payload("2026");
+        var richer = Payload("2026", PricingMode.BestEffort, CostCoverage.Complete);
+        var publications = new ConcurrentQueue<GraphPublication>();
+        var access = new SnapshotAccess(
+            _ =>
+            {
+                snapshotStarted.TrySetResult(true);
+                releaseSnapshot.Task.GetAwaiter().GetResult();
+                return new GraphSnapshotReadResult(
+                    GraphSnapshotReadStatus.Hit, snapshot, DateTimeOffset.UtcNow);
+            },
+            (_, _, _, _) => GraphSnapshotWriteStatus.Skipped);
+        var coordinator = new GraphRequestCoordinator(
+            _ => local,
+            _ => richer,
+            snapshot: access);
+        coordinator.Published += publication =>
+        {
+            publications.Enqueue(publication);
+            if (ReferenceEquals(publication.Payload, local))
+            {
+                livePublished.TrySetResult(true);
+            }
+        };
+        coordinator.Completed += value => completion.TrySetResult(value);
+
+        coordinator.Attach("2026");
+        await snapshotStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await livePublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        releaseSnapshot.TrySetResult(true);
+        await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(50);
+
+        Assert.DoesNotContain(publications, value => ReferenceEquals(value.Payload, snapshot));
+        Assert.Equal(2, publications.Count);
+        Assert.Same(richer, publications.Last().Payload);
+    }
+
+    [Fact]
+    public async Task NonHitAndSnapshotFailuresLeaveLivePipelineUnchanged()
+    {
+        var statuses = new[]
+        {
+            GraphSnapshotReadStatus.Missing,
+            GraphSnapshotReadStatus.InvalidData,
+            GraphSnapshotReadStatus.ContextMismatch,
+            GraphSnapshotReadStatus.QueryMismatch,
+            GraphSnapshotReadStatus.IoFailure,
+        };
+
+        foreach (var status in statuses)
+        {
+            var completion = new TaskCompletionSource<GraphRequestCompletion>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var publications = new ConcurrentQueue<GraphPublication>();
+            var coordinator = new GraphRequestCoordinator(
+                _ => Payload("2026"),
+                _ => Payload("2026", PricingMode.BestEffort, CostCoverage.Complete),
+                snapshot: new SnapshotAccess(
+                    _ => new GraphSnapshotReadResult(status),
+                    (_, _, _, _) => GraphSnapshotWriteStatus.Skipped));
+            coordinator.Published += publications.Enqueue;
+            coordinator.Completed += value => completion.TrySetResult(value);
+
+            var requestId = coordinator.Attach("2026").RequestId;
+            var result = await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(requestId, result.RequestId);
+            Assert.True(result.Succeeded);
+            Assert.Equal(2, publications.Count);
+            Assert.Equal(GraphPublicationStage.LocalFirst, publications.First().Stage);
+            Assert.Equal(GraphPublicationStage.Richer, publications.Last().Stage);
+        }
+
+        var thrownCompletion = new TaskCompletionSource<GraphRequestCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var thrownPublications = new ConcurrentQueue<GraphPublication>();
+        var thrown = new GraphRequestCoordinator(
+            _ => Payload("2026"),
+            _ => Payload("2026", PricingMode.BestEffort, CostCoverage.Complete),
+            snapshot: new SnapshotAccess(
+                _ => throw new InvalidOperationException(),
+                (_, _, _, _) => GraphSnapshotWriteStatus.Skipped));
+        thrown.Published += thrownPublications.Enqueue;
+        thrown.Completed += value => thrownCompletion.TrySetResult(value);
+        var thrownId = thrown.Attach("2026").RequestId;
+        Assert.Equal(thrownId,
+            (await thrownCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5))).RequestId);
+        Assert.Equal(2, thrownPublications.Count);
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var capturedAt in new[] { now.AddMinutes(-31), now.AddMinutes(1) })
+        {
+            var completion = new TaskCompletionSource<GraphRequestCompletion>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var publications = new ConcurrentQueue<GraphPublication>();
+            var coordinator = new GraphRequestCoordinator(
+                _ => Payload("2026"),
+                _ => Payload("2026", PricingMode.BestEffort, CostCoverage.Complete),
+                snapshot: new SnapshotAccess(
+                    _ => new GraphSnapshotReadResult(
+                        GraphSnapshotReadStatus.Hit,
+                        Payload("2026", PricingMode.BestEffort),
+                        capturedAt),
+                    (_, _, _, _) => GraphSnapshotWriteStatus.Skipped),
+                utcNow: () => now);
+            coordinator.Published += publications.Enqueue;
+            coordinator.Completed += value => completion.TrySetResult(value);
+
+            coordinator.Attach("2026");
+            await completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(2, publications.Count);
+        }
+    }
+
+    [Fact]
+    public async Task BlockedSnapshotReadDoesNotDelayAttachLiveOrSupersession()
+    {
+        var readStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRead = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var livePublished = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new GraphRequestCoordinator(
+            _ =>
+            {
+                livePublished.TrySetResult(true);
+                return Payload("2026");
+            },
+            _ => Payload("2026", PricingMode.BestEffort, CostCoverage.Complete),
+            snapshot: new SnapshotAccess(
+                _ =>
+                {
+                    readStarted.TrySetResult(true);
+                    releaseRead.Task.GetAwaiter().GetResult();
+                    return new GraphSnapshotReadResult(GraphSnapshotReadStatus.Missing);
+                },
+                (_, _, _, _) => GraphSnapshotWriteStatus.Skipped));
+
+        try
+        {
+            var attach = await Task.Run(() => coordinator.Attach("2026"))
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            await readStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await livePublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var newer = coordinator.Request("2026", force: true);
+            Assert.True(newer.Generation > attach.RequestId.Generation);
+        }
+        finally
+        {
+            releaseRead.TrySetResult(true);
+        }
     }
 
     private sealed class CallbackScope(Action dispose) : IDisposable

--- a/src/TokenBar.Core.Tests/GraphSnapshotStoreTests.cs
+++ b/src/TokenBar.Core.Tests/GraphSnapshotStoreTests.cs
@@ -483,6 +483,45 @@ public sealed class GraphSnapshotStoreTests : IDisposable
         Assert.False(Directory.Exists(Path.GetDirectoryName(absent)));
     }
 
+    [Fact]
+    public void SkippedFenceKeepsPreviousBytesAndInvokedFenceReplacesAtomically()
+    {
+        var store = new GraphSnapshotStore(StorePath);
+        Assert.Equal(
+            GraphSnapshotWriteStatus.Written,
+            store.Write("ctx", "2026", DateTimeOffset.UnixEpoch, Payload("2026-01-01")));
+        var oldBytes = File.ReadAllBytes(StorePath);
+
+        Assert.Equal(
+            GraphSnapshotWriteStatus.Skipped,
+            store.Write(
+                "ctx",
+                "2026",
+                DateTimeOffset.UnixEpoch.AddDays(1),
+                Payload("2026-02-01"),
+                _ => { }));
+        Assert.Equal(oldBytes, File.ReadAllBytes(StorePath));
+        Assert.Empty(Directory.EnumerateFiles(_dir, ".*.tmp"));
+
+        Assert.Equal(
+            GraphSnapshotWriteStatus.Written,
+            store.Write(
+                "ctx",
+                "2026",
+                DateTimeOffset.UnixEpoch.AddDays(2),
+                Payload("2026-03-01"),
+                commit =>
+                {
+                    commit();
+                    commit();
+                }));
+        Assert.Equal(
+            "2026-03-01",
+            new GraphSnapshotStore(StorePath).Read("ctx", "2026").Payload!
+                .Contributions[0].Date);
+        Assert.Empty(Directory.EnumerateFiles(_dir, ".*.tmp"));
+    }
+
     private static bool HasDate(UsagePayload? payload, string date) =>
         payload is { Contributions.Count: 1 }
         && string.Equals(payload.Contributions[0].Date, date, StringComparison.Ordinal);

--- a/src/TokenBar.Core.Tests/RetainedGraphStartupTests.cs
+++ b/src/TokenBar.Core.Tests/RetainedGraphStartupTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using TokenBar.App;
+using TokenBar.Core;
 using TokenBar.Interop;
 
 namespace TokenBar.Core.Tests;
@@ -143,6 +144,225 @@ public class RetainedGraphStartupTests
         Assert.False(GraphResumePolicy.ShouldRefreshAfterAttach(allTimeAttachment));
         Assert.Equal(allTimeCalls, localCalls["all"]);
     }
+
+    [Fact]
+    public async Task SupersededRicherCannotCommitAndNextCoordinatorRestoresIt()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(), "tokenbar-tests", "coordinator-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var path = Path.Combine(root, "graph.json");
+        var store = new GraphSnapshotStore(path);
+        var first = SnapshotPayload("2026-01-01");
+        var second = SnapshotPayload("2026-02-01");
+        var writeCount = 0;
+        var firstFenceStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstFence = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var access = new SnapshotAccess(
+            year => store.Read("ctx", year),
+            (year, capturedAt, payload, commitFence) => store.Write(
+                "ctx",
+                year,
+                capturedAt,
+                payload,
+                commit =>
+                {
+                    if (Interlocked.Increment(ref writeCount) == 1)
+                    {
+                        firstFenceStarted.TrySetResult(true);
+                        releaseFirstFence.Task.GetAwaiter().GetResult();
+                    }
+
+                    commitFence!(commit);
+                }));
+        var localCalls = 0;
+        var firstCompletion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondCompletion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new GraphRequestCoordinator(
+            _ => Interlocked.Increment(ref localCalls) == 1 ? first : second,
+            _ => Interlocked.CompareExchange(ref localCalls, 0, 0) == 1 ? first : second,
+            _ => second,
+            snapshot: access,
+            utcNow: () => DateTimeOffset.UtcNow);
+        coordinator.Completed += completion =>
+        {
+            if (completion.RequestId.Generation == 1)
+            {
+                firstCompletion.TrySetResult(true);
+            }
+            else
+            {
+                secondCompletion.TrySetResult(true);
+            }
+        };
+
+        coordinator.Request("2026");
+        await firstCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await firstFenceStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        coordinator.Request("2026", force: true);
+        await secondCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitUntil(() => Volatile.Read(ref writeCount) >= 2);
+        releaseFirstFence.TrySetResult(true);
+        await Task.Delay(100);
+
+        var stored = store.Read("ctx", "2026");
+        Assert.Equal(GraphSnapshotReadStatus.Hit, stored.Status);
+        Assert.Equal("2026-02-01", stored.Payload!.Contributions[0].Date);
+        Assert.Empty(Directory.EnumerateFiles(root, ".*.tmp"));
+
+        var restored = new TaskCompletionSource<GraphPublication>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var restoredCompletion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLocal = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var next = new GraphRequestCoordinator(
+            _ =>
+            {
+                releaseLocal.Task.GetAwaiter().GetResult();
+                return first;
+            },
+            _ => second,
+            snapshot: new SnapshotAccess(
+                year => store.Read("ctx", year),
+                (_, _, _, _) => GraphSnapshotWriteStatus.Skipped),
+            utcNow: () => DateTimeOffset.UtcNow);
+        next.Published += publication =>
+        {
+            if (publication.Payload.Contributions[0].Date == "2026-02-01")
+            {
+                restored.TrySetResult(publication);
+            }
+        };
+        next.Completed += _ => restoredCompletion.TrySetResult(true);
+
+        var restoredId = next.Attach("2026").RequestId;
+        var restoredPublication = await restored.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(restoredId, restoredPublication.RequestId);
+        Assert.Equal(GraphPublicationStage.LocalFirst, restoredPublication.Stage);
+        releaseLocal.TrySetResult(true);
+        await restoredCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public void CreateForAppUsesLocalApplicationDataAndFallsBackLiveOnly()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(), "tokenbar-tests", "profile-" + Guid.NewGuid().ToString("N"));
+        var requested = (Environment.SpecialFolder?)null;
+        var created = new List<string>();
+        var idCalls = 0;
+        try
+        {
+            var coordinator = GraphRequestCoordinator.CreateForApp(
+                getFolderPath: folder =>
+                {
+                    requested = folder;
+                    return root;
+                },
+                sourceContextId: () =>
+                {
+                    idCalls++;
+                    return "ctx";
+                },
+                createDirectory: path =>
+                {
+                    created.Add(path);
+                    Directory.CreateDirectory(path);
+                },
+                localFirst: _ => Payload(),
+                graph: _ => Payload());
+
+            Assert.Equal(
+                (Environment.SpecialFolder?)GraphRequestCoordinator.SnapshotProfileRoot,
+                requested);
+            Assert.Equal(Path.Combine(root, "TokenBar"), Assert.Single(created));
+            Assert.Equal(1, idCalls);
+            Assert.NotNull(coordinator.Snapshot);
+            Assert.Equal(
+                GraphSnapshotWriteStatus.Written,
+                coordinator.Snapshot!.Write(
+                    "2026",
+                    DateTimeOffset.UtcNow,
+                    SnapshotPayload("2026-01-01"),
+                    null));
+            Assert.True(File.Exists(Path.Combine(
+                root, "TokenBar", "graph-snapshot.json")));
+
+            var blank = GraphRequestCoordinator.CreateForApp(
+                getFolderPath: _ => " ",
+                sourceContextId: () => throw new InvalidOperationException(),
+                localFirst: _ => Payload(),
+                graph: _ => Payload());
+            Assert.Null(blank.Snapshot);
+
+            var relative = GraphRequestCoordinator.CreateForApp(
+                getFolderPath: _ => "relative",
+                sourceContextId: () => throw new InvalidOperationException(),
+                localFirst: _ => Payload(),
+                graph: _ => Payload());
+            Assert.Null(relative.Snapshot);
+
+            var mkdirCalls = 0;
+            var mkdirFailure = GraphRequestCoordinator.CreateForApp(
+                getFolderPath: _ => root,
+                createDirectory: _ =>
+                {
+                    mkdirCalls++;
+                    throw new IOException();
+                },
+                sourceContextId: () => throw new InvalidOperationException(),
+                localFirst: _ => Payload(),
+                graph: _ => Payload());
+            Assert.Null(mkdirFailure.Snapshot);
+            Assert.Equal(1, mkdirCalls);
+
+            var idFailure = GraphRequestCoordinator.CreateForApp(
+                getFolderPath: _ => root,
+                createDirectory: _ => { },
+                sourceContextId: () => throw new InvalidOperationException(),
+                localFirst: _ => Payload(),
+                graph: _ => Payload());
+            Assert.Null(idFailure.Snapshot);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    private static UsagePayload SnapshotPayload(string date) => new(
+        new UsageMeta(
+            "generated",
+            "test",
+            new DateRange(date, date),
+            PricingMode.BestEffort,
+            CostCoverage.Complete),
+        new UsageSummary(1, 1, 1, 1, 1, 1, ["claude"], ["model"]),
+        [new YearMeta("2026", 1, 1, new DateRange(date, date))],
+        [new Contribution(
+            date,
+            new ContributionTotals(1, 1, 1),
+            1,
+            new TokenBreakdown(1, 0, 0, 0, 0),
+            [new ContributionClient(
+                "claude",
+                "model",
+                "provider",
+                new TokenBreakdown(1, 0, 0, 0, 0),
+                1,
+                1)],
+            new Dictionary<string, long> { ["claude"] = 1 })]);
 
     private static async Task WaitUntil(Func<bool> predicate)
     {

--- a/src/TokenBar.Core/GraphSnapshotStore.cs
+++ b/src/TokenBar.Core/GraphSnapshotStore.cs
@@ -23,6 +23,7 @@ public enum GraphSnapshotReadStatus
 public enum GraphSnapshotWriteStatus
 {
     Written,
+    Skipped,
     InvalidInput,
     UnsafePath,
     InvalidData,
@@ -136,7 +137,8 @@ public sealed class GraphSnapshotStore
         string sourceContextId,
         string? year,
         DateTimeOffset capturedAt,
-        UsagePayload payload)
+        UsagePayload payload,
+        Action<Action>? commitFence = null)
     {
         if (payload is null || !TryNormalizeInputs(sourceContextId, year, out var normalizedYear))
         {
@@ -182,6 +184,8 @@ public sealed class GraphSnapshotStore
         }
 
         string? temp = null;
+        var committed = false;
+        var commitAttempted = 0;
         try
         {
             if (InspectTarget(path) == TargetState.Unsafe)
@@ -206,9 +210,30 @@ public sealed class GraphSnapshotStore
             // Same-directory rename is the platform primitive that preserves an
             // old-or-new target during normal execution; power-loss durability
             // is deliberately outside this reconstructible cache's contract.
-            File.Move(temp, path, overwrite: true);
-            temp = null;
-            return GraphSnapshotWriteStatus.Written;
+            void Commit()
+            {
+                if (Interlocked.Exchange(ref commitAttempted, 1) != 0)
+                {
+                    return;
+                }
+
+                File.Move(temp!, path, overwrite: true);
+                committed = true;
+                temp = null;
+            }
+
+            if (commitFence is null)
+            {
+                Commit();
+            }
+            else
+            {
+                commitFence(Commit);
+            }
+
+            return committed
+                ? GraphSnapshotWriteStatus.Written
+                : GraphSnapshotWriteStatus.Skipped;
         }
         catch (Exception ex) when (IsExpectedFileFailure(ex))
         {


### PR DESCRIPTION
## Summary

- compose the process-wide graph coordinator with a machine-local LocalApplicationData snapshot store and one captured source-context identity
- restore only strict exact-query snapshots captured within 30 minutes while the live local-first and richer pipeline continues independently
- persist current richer results with a generation fence around only the final atomic replace
- preserve schema v1 and existing unfenced GraphSnapshotStore callers

## Safety

- setup, read, validation, write, and fence failures are silent and leave the live pipeline available
- snapshot and live publications share one ordering gate, so a late snapshot cannot overwrite live data
- no source identity, profile path, payload, exception, real profile, cache, session, or credentials are logged or used by tests

## Verification

- targeted GraphSnapshotStore, GraphRequestCoordinator, and RetainedGraphStartup tests: 58/58 passed
- full TokenBar.Core.Tests: 476/476 passed
- independent timing stress: 100/100 passed
- fresh outcome verifier: CONFIRMED with no P0-P4 findings
- git diff --check passed
- local managed runs used installed .NET SDK 10.0.302; hosted Windows CI remains authoritative for the repository-pinned 10.0.301 SDK and App build