### PR TITLE
feat(settings): show the live session card in the settings preview

### DIFF
--- a/src/TokenBar.App/DashboardView.xaml.cs
+++ b/src/TokenBar.App/DashboardView.xaml.cs
@@ -1017,36 +1017,11 @@ public sealed partial class DashboardView : UserControl
         return panel;
     }
 
-    private FrameworkElement? BuildTrace(DashboardModel.Snapshot snapshot)
-    {
-        // tokenbar.trace.detailed (macOS UsageTraceCard): one row per
-        // agent-and-model bucket instead of one collapsed row per app.
-        // Selection must happen before collapse and Take(5), or a high-rate
-        // hidden client can evict every selected row from the card.
-        var selected = TraceCollapse.FilterByClients(snapshot.Trace, _selectedSet);
-        var detailed = AppSettings.Store.GetBool("tokenbar.trace.detailed", false);
-        var rows = detailed
-            ? selected
-                .Select(b => (b.Client, b.Model, b.TokensPerMin)).Take(5).ToList()
-            : TraceCollapse.CollapseByClient(selected)
-                .Select(r => (r.Client, r.Model, r.TokensPerMin)).Take(5).ToList();
-        if (rows.Count == 0)
-        {
-            return null;
-        }
-
-        var panel = new StackPanel { Spacing = 6 };
-        foreach (var row in rows)
-        {
-            var name = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6 };
-            name.Children.Add(Ui.Disc(ClientRegistry.Style(row.Client).Color));
-            name.Children.Add(Ui.Text($"{ClientRegistry.ShortName(row.Client)} · {row.Model}", 11));
-            panel.Children.Add(Ui.Row(
-                name, Ui.Text($"{Format.CompactTokens((long)row.TokensPerMin)}/min", 11, 0.75)));
-        }
-
-        return panel;
-    }
+    private FrameworkElement? BuildTrace(DashboardModel.Snapshot snapshot) =>
+        Ui.TraceRows(
+            snapshot.Trace,
+            _selectedSet,
+            AppSettings.Store.GetBool("tokenbar.trace.detailed", false));
 
     private FrameworkElement BuildStreaks(DashboardModel.Snapshot snapshot)
     {

--- a/src/TokenBar.App/SettingsWindow.cs
+++ b/src/TokenBar.App/SettingsWindow.cs
@@ -24,6 +24,7 @@ public sealed class SettingsWindow : Window
     private static SettingsWindow? _shared;
     private readonly Func<AgentUsagePayload?> _quota;
     private readonly Func<UsagePayload?> _graph;
+    private readonly Func<IReadOnlyList<TraceBucket>> _trace;
     private readonly ScrollViewer _scroll = new()
     {
         VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
@@ -74,9 +75,10 @@ public sealed class SettingsWindow : Window
     private string _selectedTag = "menubar";
 
     public static void Present(
-        Func<AgentUsagePayload?> quota, Func<UsagePayload?> graph)
+        Func<AgentUsagePayload?> quota, Func<UsagePayload?> graph,
+        Func<IReadOnlyList<TraceBucket>> trace)
     {
-        _shared ??= new SettingsWindow(quota, graph);
+        _shared ??= new SettingsWindow(quota, graph, trace);
         _shared.Rebuild();
         _shared.AppWindow.Show();
         // Activate() alone cannot bring the window forward when the opener
@@ -95,10 +97,12 @@ public sealed class SettingsWindow : Window
     }
 
     private SettingsWindow(
-        Func<AgentUsagePayload?> quota, Func<UsagePayload?> graph)
+        Func<AgentUsagePayload?> quota, Func<UsagePayload?> graph,
+        Func<IReadOnlyList<TraceBucket>> trace)
     {
         _quota = quota;
         _graph = graph;
+        _trace = trace;
         Title = $"{ProductIdentity.Name} Settings";
         SystemBackdrop = new MicaBackdrop();
         var root = new Grid();
@@ -832,6 +836,25 @@ public sealed class SettingsWindow : Window
         }
 
         _preview.Children.Add(card);
+
+        // Live session (macOS UsageTraceCard, the preview column's third
+        // block). Rendered through the same Ui.TraceRows the Overview lens
+        // uses, so the preview cannot drift from the real card. TrayFeed
+        // already polls the live tail and marshals it back, so this reads a
+        // value rather than making an FFI call on the UI thread.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var present = (_graph()?.Summary.Clients ?? [])
+            .Select(ClientRegistry.CanonicalClient)
+            .Where(seen.Add)
+            .ToList();
+        var selected = new HashSet<string>(
+            ClientRegistry.DisplayClients(present, store), StringComparer.Ordinal);
+        var detailed = store.GetBool("tokenbar.trace.detailed", false);
+        if (Ui.TraceRows(_trace(), selected, detailed) is { } rows)
+        {
+            _preview.Children.Add(Ui.Text("LIVE SESSION", 10, 0.55, bold: true));
+            _preview.Children.Add(rows);
+        }
     }
 
     /// <summary>frame-00 of the cat/parrot set, letterboxed like the

--- a/src/TokenBar.App/TrayService.cs
+++ b/src/TokenBar.App/TrayService.cs
@@ -130,7 +130,7 @@ public sealed class TrayService : IDisposable
     public static Action? OpenSettings { get; private set; }
 
     public void ShowSettings() => SettingsWindow.Present(
-        () => _feed.Quota, () => _feed.Graph);
+        () => _feed.Quota, () => _feed.Graph, () => _feed.Trace);
 
     internal bool CanHandoff => !Volatile.Read(ref _disposed);
 

--- a/src/TokenBar.App/Ui.cs
+++ b/src/TokenBar.App/Ui.cs
@@ -2,6 +2,8 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
+using TokenBar.Core;
+using TokenBar.Interop;
 using Windows.UI;
 
 namespace TokenBar.App;
@@ -137,6 +139,37 @@ public static class Ui
             CornerRadius = new CornerRadius(2),
         });
         return track;
+    }
+
+    /// <summary>Live-session rows (macOS UsageTraceCard): one collapsed row per
+    /// app, or one row per agent-and-model bucket when detailed. Returns null
+    /// when nothing is running so the caller can drop the whole card instead of
+    /// showing an empty one. Selection happens before collapse and Take(5), or a
+    /// high-rate hidden client can evict every selected row.</summary>
+    public static FrameworkElement? TraceRows(
+        IReadOnlyList<TraceBucket> trace, IReadOnlySet<string> selected, bool detailed)
+    {
+        var picked = TraceCollapse.FilterByClients(trace, selected);
+        var rows = detailed
+            ? picked.Select(b => (b.Client, b.Model, b.TokensPerMin)).Take(5).ToList()
+            : TraceCollapse.CollapseByClient(picked)
+                .Select(r => (r.Client, r.Model, r.TokensPerMin)).Take(5).ToList();
+        if (rows.Count == 0)
+        {
+            return null;
+        }
+
+        var panel = new StackPanel { Spacing = 6 };
+        foreach (var row in rows)
+        {
+            var name = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 6 };
+            name.Children.Add(Disc(ClientRegistry.Style(row.Client).Color));
+            name.Children.Add(Text($"{ClientRegistry.ShortName(row.Client)} · {row.Model}", 11));
+            panel.Children.Add(Row(
+                name, Text($"{Format.CompactTokens((long)row.TokensPerMin)}/min", 11, 0.75)));
+        }
+
+        return panel;
     }
 
     public static SolidColorBrush BrushFromHex(string hex)


### PR DESCRIPTION
Slice **S2** of `docs/proposals/settings-sidebar.md`. Follows #54.

The settings preview column now carries all three blocks the macOS one does: the two menu-bar mocks, the Agent limits card, and — new here — the live session card.

## Reuse rather than reimplementation

`DashboardView.BuildTrace` already rendered exactly this card for the Overview lens, and its own comment named `UsageTraceCard` as the macOS counterpart. A second renderer would have let the preview drift from the card it is previewing, which defeats the point of a preview.

The body moves to `Ui.TraceRows(trace, selected, detailed)` and both call sites go through it:

| Call site | Supplies |
|---|---|
| `DashboardView.BuildTrace` | the lens's own `_selectedSet` |
| `SettingsWindow.RebuildPreview` | `ClientRegistry.DisplayClients(present, store)` |

`detailed` is a parameter rather than a lookup inside `Ui`, so `Ui.cs` gains no dependency on `AppSettings`. Selection still happens before collapse and `Take(5)` — a high-rate hidden client would otherwise evict every selected row — and a null return still means "no rows", so the caller drops the whole block rather than showing an empty one.

`Ui.cs` already hosted composite elements with some domain shape (`Card`, `ShareBar`), so this needs no new file.

## Data path

No new FFI call, and no live-tail parsing on the UI thread:

```
TrayFeed          background task -> TbCore.UsageTrace(600) -> marshal to UI -> TrayFeed.Trace
TrayService       ShowSettings() already passes _feed.Quota and _feed.Graph; adds () => _feed.Trace
SettingsWindow    one field, one constructor parameter, reads an already-resident value
```

## Deliberately not live-updating

The preview shows the trace as of window open or the next settings-write rebuild, not a continuously updating feed. macOS gets that free from its SwiftUI binding; matching it means subscribing to `TrayFeed.Changed`, which is a bigger change than this slice. "Live preview — settings apply immediately" is about settings taking effect, not about the sample data refreshing.

## Size

```
Ui.cs                   +33   TraceRows, extracted
DashboardView.xaml.cs   -29   BuildTrace becomes a delegation
SettingsWindow.cs       +26   _trace field, Present signature, LIVE SESSION block
TrayService.cs           +1   inject () => _feed.Trace
```

## Verification

Build clean on real x64 Windows hardware, 0 warnings 0 errors.

**Not yet exercised on screen.** Two things need eyes before this is done: the preview block actually appearing (it only renders when something is running, which is intentional), and — the real regression risk, since this slice edits `DashboardView` — the Overview lens's own Live session card still rendering correctly through the extracted method.

## Scope correction carried in #54

That PR's final commit corrected this document's preview-column table, which had claimed Windows renders only one menu-bar mock. It renders both; the original survey found one `_preview.Children.Add(strip)` and missed that it sits inside `foreach (var dark in new[] { true, false })`. S2 is therefore one block, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ