### PR TITLE
fix(cost): treat partial coverage as cost authority

### DIFF
--- a/src/TokenBar.App/CostSurfaceProjection.cs
+++ b/src/TokenBar.App/CostSurfaceProjection.cs
@@ -17,9 +17,17 @@ public static class CostSurfaceProjection
         bool authoritative, ChartMetric requested) =>
         !authoritative && requested == ChartMetric.Cost;
 
+    /// <summary>Partial counts as authoritative. The engine's coverage fold
+    /// reports Partial when at least one message priced and at least one did
+    /// not, so the total is every cost it could resolve with the rest folded in
+    /// at zero — the same number macOS displays, since macOS has no coverage
+    /// gate at all. Only None is withheld: there the total really would be a
+    /// fabricated $0. Treating Partial as unauthoritative made the cost surface
+    /// read "Checking" permanently on any profile holding one unpriced model,
+    /// because Partial is a terminal state, not a loading one.</summary>
     public static bool IsAuthoritative(UsagePayload? graph) =>
         graph?.Meta.PricingMode == PricingMode.BestEffort
-        && graph.Meta.CostCoverage == CostCoverage.Complete;
+        && graph.Meta.CostCoverage != CostCoverage.None;
 
     public static string CostText(double cost, bool authoritative) =>
         authoritative ? Format.Usd(cost) : Checking;

--- a/src/TokenBar.Core.Tests/CostSurfaceProjectionTests.cs
+++ b/src/TokenBar.Core.Tests/CostSurfaceProjectionTests.cs
@@ -43,7 +43,10 @@ public class CostSurfaceProjectionTests
     [InlineData(PricingMode.LocalOnly, CostCoverage.Complete, false)]
     [InlineData(PricingMode.LocalOnly, CostCoverage.Partial, false)]
     [InlineData(PricingMode.LocalOnly, CostCoverage.None, false)]
-    [InlineData(PricingMode.BestEffort, CostCoverage.Partial, false)]
+    // Partial is authoritative: the engine folds unpriced messages in at zero,
+    // so the total is real, just incomplete — and it is a terminal state, not a
+    // loading one, so withholding it showed "Checking" forever.
+    [InlineData(PricingMode.BestEffort, CostCoverage.Partial, true)]
     [InlineData(PricingMode.BestEffort, CostCoverage.None, false)]
     [InlineData(PricingMode.BestEffort, CostCoverage.Complete, true)]
     public void MetadataMatrixIsTheOnlyCostAuthority(

--- a/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
+++ b/src/TokenBar.Core.Tests/GraphConsumerStateTests.cs
@@ -167,7 +167,6 @@ public class GraphConsumerStateTests
     [InlineData(PricingMode.LocalOnly, CostCoverage.Complete)]
     [InlineData(PricingMode.LocalOnly, CostCoverage.Partial)]
     [InlineData(PricingMode.LocalOnly, CostCoverage.None)]
-    [InlineData(PricingMode.BestEffort, CostCoverage.Partial)]
     [InlineData(PricingMode.BestEffort, CostCoverage.None)]
     public void NonAuthoritativeMetadataStaysChecking(
         PricingMode pricing, CostCoverage coverage)
@@ -180,6 +179,25 @@ public class GraphConsumerStateTests
             id, Payload(pricing, coverage), GraphPublicationStage.LocalFirst));
         Assert.True(state.LocalAccepted);
         Assert.False(state.CostAuthoritative);
+    }
+
+    /// <summary>Partial priced at least one message and folded the rest in at
+    /// zero, so the total is real. It is also terminal, not a loading step —
+    /// withholding it left the cost surface reading "Checking" forever on any
+    /// profile holding one unpriced model.</summary>
+    [Fact]
+    public void PartialCoverageIsCostAuthoritative()
+    {
+        var state = new GraphConsumerState();
+        var id = Id(null, 1);
+        state.Begin(id);
+
+        Assert.True(state.TryAcceptGraph(
+            id,
+            Payload(PricingMode.BestEffort, CostCoverage.Partial),
+            GraphPublicationStage.Richer));
+        Assert.True(state.LocalAccepted);
+        Assert.True(state.CostAuthoritative);
     }
 
     [Fact]


### PR DESCRIPTION
The cost surface read **"Checking" permanently** on a profile holding one unpriced model.

Not a stall. `pricingMode` was already `bestEffort`, so the richer publication had landed. The condition withholding the cost was `costCoverage == partial`.

## Why partial is authoritative

The engine's `CostCoverageFold`:

```rust
ProviderReported | Estimated  => known
PartiallyEstimated            => known + unknown
Unknown                       => unknown

!unknown → Complete    known && unknown → Partial    else → None
```

`Partial` means some usage priced and some could not; the unpriced messages fold in at zero. Note `Estimated` counts as *known* — an all-estimated profile is still `Complete`. So `Partial` specifically means "some usage has no price at all", and the total is a real sum of everything resolvable.

**`Partial` is terminal, not a loading step.** It resolves only if those messages later acquire prices. Gating on `Complete` promised a check that would never finish.

`None` still withholds — with nothing priced, the total would be a fabricated $0.

## Parity

`costCoverage` appears **nowhere** in `TokenBar-Native/Sources`. macOS renders whatever total the engine returns; its "Checking…" strings belong to agent-limit quota lookups and are unrelated to cost. `CostSurfaceProjection` has no macOS counterpart at all — this gate was Windows-only divergence.

## This overturns a deliberate choice, not an oversight

`BestEffort + Partial -> false` was an explicit row in `CostSurfaceProjectionTests`, and `NonAuthoritativeMetadataStaysChecking` asserted the same through `GraphConsumerState`. It was specified, not missed.

The original intent — don't show an understated cost before pricing is ready — is correct for `None`, which is genuinely a loading state, and incorrect for `Partial`, which is not.

## Blast radius

`IsAuthoritative` is the single decision point; every other member of `CostSurfaceProjection` takes `bool authoritative`. One predicate change covers the header line, model subtitle, chart metric and best-day text together.

## Verification

Both affected suites were **updated, not deleted** — the new behaviour is pinned at both layers:

| Suite | Change |
|---|---|
| `CostSurfaceProjectionTests` | matrix row now asserts `BestEffort + Partial -> true` |
| `GraphConsumerStateTests` | row removed from the negative theory, replaced by `PartialCoverageIsCostAuthoritative` |

`dotnet test src\TokenBar.Core.Tests -p:Platform=x64` filtered to both suites, on real x64 Windows: **23 passed, 0 failed**.

**Not yet observed on screen**: the dashboard rendering a dollar figure where it previously read "Checking". The machine that reproduces the condition is available and its persisted snapshot carries `bestEffort` + `partial`.

## Trade-off

The displayed total excludes usage that could not be priced. On the profile that surfaced this, that is ~15M tokens of `minimax-m2.7` resolving to $0.045 — the rest of the $1730 is unaffected. macOS has always behaved this way, so this is alignment rather than regression. Marking a partial total in the UI (macOS does not) would be a separate product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ