### PR TITLE
feat(settings): let the user hide individual lenses

### DIFF
--- a/docs/proposals/settings-sidebar.md
+++ b/docs/proposals/settings-sidebar.md
@@ -93,7 +93,7 @@ WinUI 3 的 `NavigationView` 就是這個控制項，`PaneDisplayMode="Left"` �
 | | Quota source | `Quota source` | ✅ 一致 |
 | | Individual items | **非目標** | `ClientTray.settingsRows` |
 | **Dashboard** | Agent limits | `Agent limits` | ✅ 一致 |
-| | View tabs | **缺** | `tokenbar.views.hidden` |
+| | View tabs | S3 | `tokenbar.views.hidden` |
 | | Client tabs (top bar) | `Client tabs` | ✅ 一致 |
 | | Live trace | `Live trace` | ✅ 一致 |
 | | Popover size | `Flyout size` | ✅ 一致（名稱依平台） |
@@ -142,8 +142,11 @@ macOS 的預覽欄**不隨分頁變化**，永遠顯示同樣三塊。Windows �
 | **S4** | General / Language 分節 + i18n 基礎建設 | S1 | 全 UI 字串可切換語言 |
 | **S5** | General / Discord 分節 + Rich Presence | S1 | Discord 狀態列顯示用量 |
 | **S6** | Usage attribution 分頁 + 歸因邏輯 | S1 | 側邊欄出現第五頁 |
+| **S7** | Monthly lens 移植（macOS `MonthlyView.swift`，275 行） | — | flyout 分頁列出現 Monthly，且可在 View tabs 中隱藏 |
 
 S4 排在 S5 之前，因為 i18n 會碰到每一個字串；先做 Discord 等於保證之後要再改一次 Discord 的所有文案。
+
+> **S3 discovery 的發現：** macOS `AppView` 有**七個** case（`overview, models, monthly, daily, hourly, stats, agents`），Windows 只有六個——`monthly` 從未移植。原本的 parity 盤點誤信了 `DashboardView` 那句「the six lenses from the macOS AppView router」註解，而那句話本身就是錯的。S7 因此獨立登記，不併入 S3；它不相依 S1，只是排在後面。
 
 ### S1 範圍細節
 

--- a/docs/proposals/settings-sidebar.md
+++ b/docs/proposals/settings-sidebar.md
@@ -143,10 +143,13 @@ macOS 的預覽欄**不隨分頁變化**，永遠顯示同樣三塊。Windows �
 | **S5** | General / Discord 分節 + Rich Presence | S1 | Discord 狀態列顯示用量 |
 | **S6** | Usage attribution 分頁 + 歸因邏輯 | S1 | 側邊欄出現第五頁 |
 | **S7** | Monthly lens 移植（macOS `MonthlyView.swift`，275 行） | — | flyout 分頁列出現 Monthly，且可在 View tabs 中隱藏 |
+| **S8** | flyout 快捷鍵 parity 修正 | — | `Ctrl+[` / `Ctrl+]` 實際可觸發，且與 `Ctrl+1..9` 一致地操作 macOS 所綁的那一排 |
 
 S4 排在 S5 之前，因為 i18n 會碰到每一個字串；先做 Discord 等於保證之後要再改一次 Discord 的所有文案。
 
-> **S3 discovery 的發現：** macOS `AppView` 有**七個** case（`overview, models, monthly, daily, hourly, stats, agents`），Windows 只有六個——`monthly` 從未移植。原本的 parity 盤點誤信了 `DashboardView` 那句「the six lenses from the macOS AppView router」註解，而那句話本身就是錯的。S7 因此獨立登記，不併入 S3；它不相依 S1，只是排在後面。
+> **S3 discovery 的發現（快捷鍵）：** 兩個既有問題，都不是 S3 引入。其一，macOS 的 ⌘1-9 與 ⌘[ ⌘] 操作的是 **client tabs**（`PopoverView.swift:693-702`，`clientTab.wrappedValue = tabs[...]`），Windows 卻綁到 **lenses**——綁錯了那一排。其二，`Ctrl+[` / `Ctrl+]` 實測無反應：`AddAccel` 機制本身正常（`Ctrl+1..6` 用同一條路徑且有效），差別在 `VirtualKey.Number1` 是具名成員，而 `(VirtualKey)0xDB` / `0xDD`（`VK_OEM_4` / `VK_OEM_6`）是硬轉型的未定義值、且佈局相依；macOS 用 `charactersIgnoringModifiers` 比對字元，與佈局無關。修法牽涉「該綁哪一排」的產品決定，故登記為 S8 而非併入 S3。
+
+> **S3 discovery 的發現（lens 數量）：** macOS `AppView` 有**七個** case（`overview, models, monthly, daily, hourly, stats, agents`），Windows 只有六個——`monthly` 從未移植。原本的 parity 盤點誤信了 `DashboardView` 那句「the six lenses from the macOS AppView router」註解，而那句話本身就是錯的。S7 因此獨立登記，不併入 S3；它不相依 S1，只是排在後面。
 
 ### S1 範圍細節
 

--- a/src/TokenBar.App/AppViews.cs
+++ b/src/TokenBar.App/AppViews.cs
@@ -1,0 +1,63 @@
+using TokenBar.Core;
+
+namespace TokenBar.App;
+
+/// <summary>The flyout's lenses, ported from the macOS AppView router. macOS
+/// has seven; Monthly is not ported here, so this enum is deliberately one
+/// short rather than merely out of date.</summary>
+public enum AppView
+{
+    Overview,
+    Models,
+    Daily,
+    Hourly,
+    Stats,
+    Agents,
+}
+
+/// <summary>Hidden-lens policy for the flyout's tab row (macOS AppView's
+/// toggleable/visible/effective trio). Ids are the lowercase enum names, the
+/// same shape macOS persists, and the hidden set reuses
+/// <see cref="ClientRegistry.ParseIdSet"/> — that parser is a generic CSV-id
+/// reader, not client-specific in implementation.</summary>
+public static class AppViews
+{
+    public const string HiddenKey = "tokenbar.views.hidden";
+
+    /// <summary>Lenses the user may hide. Overview is the fallback target for
+    /// every hidden lens (see <see cref="Effective"/>) so it can never be
+    /// hidden itself; Models is the other fixed anchor, matching macOS.</summary>
+    public static readonly IReadOnlyList<AppView> Toggleable =
+        [.. Enum.GetValues<AppView>()
+            .Where(v => v is not (AppView.Overview or AppView.Models))];
+
+    public static string Id(AppView view) => view.ToString().ToLowerInvariant();
+
+    /// <summary>Lenses to show in the tab row. Only <see cref="Toggleable"/>
+    /// lenses can ever be dropped, so even a hand-edited settings file cannot
+    /// remove Overview and leave the fallback target missing.</summary>
+    public static List<AppView> Visible(string hiddenRaw)
+    {
+        var hidden = ClientRegistry.ParseIdSet(hiddenRaw);
+        return [.. Enum.GetValues<AppView>()
+            .Where(v => !Toggleable.Contains(v) || !hidden.Contains(Id(v)))];
+    }
+
+    /// <summary>The lens to actually render. A hidden lens never survives, so
+    /// callers that carry a stale selection — the Ctrl+1..9 accelerators bind
+    /// one fixed lens each at construction — cannot land on a tab that is not
+    /// in the row. Guarded to Toggleable for the same tamper-resistance reason
+    /// as <see cref="Visible"/>.</summary>
+    public static AppView Effective(AppView view, string hiddenRaw) =>
+        !Toggleable.Contains(view)
+            ? view
+            : ClientRegistry.ParseIdSet(hiddenRaw).Contains(Id(view))
+                ? AppView.Overview
+                : view;
+
+    public static List<AppView> Visible(SettingsStore store) =>
+        Visible(store.GetString(HiddenKey) ?? string.Empty);
+
+    public static AppView Effective(AppView view, SettingsStore store) =>
+        Effective(view, store.GetString(HiddenKey) ?? string.Empty);
+}

--- a/src/TokenBar.App/DashboardView.xaml.cs
+++ b/src/TokenBar.App/DashboardView.xaml.cs
@@ -12,19 +12,10 @@ using Grid = Microsoft.UI.Xaml.Controls.Grid;
 
 namespace TokenBar.App;
 
-public enum AppView
-{
-    Overview,
-    Models,
-    Daily,
-    Hourly,
-    Stats,
-    Agents,
-}
-
 /// <summary>
-/// The dashboard shell: global header, lens switch, and the six lenses from
-/// the macOS AppView router, each built in code from the current snapshot.
+/// The dashboard shell: global header, lens switch, and the lenses of the
+/// macOS AppView router, each built in code from the current snapshot. Six of
+/// the seven are ported; Monthly is not (see AppView).
 /// </summary>
 public sealed partial class DashboardView : UserControl
 {
@@ -77,6 +68,7 @@ public sealed partial class DashboardView : UserControl
             TabsPanel.Children.Add(button);
         }
 
+        ApplyLensVisibility();
         UpdateTabChrome();
 
         AddHandler(
@@ -102,6 +94,10 @@ public sealed partial class DashboardView : UserControl
             if (key is ClientRegistry.TabHiddenKey or ClientRegistry.TabOrderKey)
             {
                 _ = DispatcherQueue.TryEnqueue(() => RefreshSelection(animated: false));
+            }
+            else if (key == AppViews.HiddenKey)
+            {
+                _ = DispatcherQueue.TryEnqueue(ApplyLensVisibility);
             }
             else if (key.StartsWith("tokenbar.limits.", StringComparison.Ordinal)
                 || key == "tokenbar.trace.detailed")
@@ -291,11 +287,35 @@ public sealed partial class DashboardView : UserControl
         KeyboardAccelerators.Add(accel);
     }
 
+    /// <summary>Push the hidden-lens set into the tab row. Buttons are built
+    /// once in the constructor, so this toggles Visibility rather than
+    /// rebuilding, and then re-runs the current selection through SwitchTo —
+    /// whose Effective() guard moves us off a lens that was just hidden.
+    /// Hiding the lens you are looking at must not leave it on screen with no
+    /// tab to return to.</summary>
+    private void ApplyLensVisibility()
+    {
+        var visible = AppViews.Visible(AppSettings.Store);
+        foreach (var (view, button) in _tabs)
+        {
+            button.Visibility = visible.Contains(view)
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        }
+
+        SwitchTo(_view);
+    }
+
     private void CycleLens(int step)
     {
-        var lenses = Enum.GetValues<AppView>();
-        var index = Array.IndexOf(lenses, _view);
-        SwitchTo(lenses[(index + step + lenses.Length) % lenses.Length]);
+        var lenses = AppViews.Visible(AppSettings.Store);
+        var index = lenses.IndexOf(_view);
+        if (index < 0)
+        {
+            index = 0;
+        }
+
+        SwitchTo(lenses[(index + step + lenses.Count) % lenses.Count]);
     }
 
     /// <summary>One control, two states (macOS refreshButton): the glyph
@@ -324,6 +344,10 @@ public sealed partial class DashboardView : UserControl
 
     public void SwitchTo(AppView view)
     {
+        // One guard for every caller: the Ctrl+1..9 accelerators each bind a
+        // fixed lens at construction, so a hidden lens would otherwise stay
+        // reachable by shortcut even though its tab is gone.
+        view = AppViews.Effective(view, AppSettings.Store);
         if (_view == view)
         {
             return;

--- a/src/TokenBar.App/SettingsWindow.cs
+++ b/src/TokenBar.App/SettingsWindow.cs
@@ -372,6 +372,9 @@ public sealed class SettingsWindow : Window
 
         panel.Children.Add(Section("Agent limits", limits));
 
+        // ── View tabs ──────────────────────────────────────────────────
+        panel.Children.Add(Section("View tabs", BuildViewTabs(store)));
+
         // ── Client tabs ────────────────────────────────────────────────
         panel.Children.Add(Section("Client tabs", BuildClientTabs(store)));
 
@@ -549,6 +552,49 @@ public sealed class SettingsWindow : Window
             link.Foreground = secondary;
         };
         return link;
+    }
+
+    /// <summary>One switch per hideable lens (macOS SettingsPanel's
+    /// "View tabs"). Overview and Models are absent by construction — Overview
+    /// is the fallback every hidden lens returns to, so offering to hide it
+    /// would let the user remove the only guaranteed destination.</summary>
+    private static StackPanel BuildViewTabs(SettingsStore store)
+    {
+        var panel = new StackPanel { Spacing = 2 };
+        foreach (var view in AppViews.Toggleable)
+        {
+            var hidden = ClientRegistry.ParseIdSet(
+                store.GetString(AppViews.HiddenKey) ?? string.Empty);
+            var toggle = new ToggleSwitch
+            {
+                IsOn = !hidden.Contains(AppViews.Id(view)),
+                OnContent = null,
+                OffContent = null,
+            };
+            var id = AppViews.Id(view);
+            toggle.Toggled += (_, _) =>
+            {
+                var next = new SortedSet<string>(ClientRegistry.ParseIdSet(
+                    store.GetString(AppViews.HiddenKey) ?? string.Empty),
+                    StringComparer.Ordinal);
+                if (toggle.IsOn)
+                {
+                    next.Remove(id);
+                }
+                else
+                {
+                    next.Add(id);
+                }
+
+                store.SetString(AppViews.HiddenKey, string.Join(',', next));
+            };
+            panel.Children.Add(ToggleRow(view.ToString(), toggle));
+        }
+
+        panel.Children.Add(Hint(
+            "Off removes a tab from the flyout's tab row. "
+            + "Cost and token data are unaffected."));
+        return panel;
     }
 
     private StackPanel BuildClientTabs(SettingsStore store)

--- a/src/TokenBar.Core.Tests/AppViewsTests.cs
+++ b/src/TokenBar.Core.Tests/AppViewsTests.cs
@@ -1,0 +1,62 @@
+using TokenBar.App;
+using TokenBar.Core;
+using TokenBar.Interop;
+
+namespace TokenBar.Core.Tests;
+
+public class AppViewsTests
+{
+    [Fact]
+    public void OverviewAndModelsAreNotToggleable()
+    {
+        Assert.DoesNotContain(AppView.Overview, AppViews.Toggleable);
+        Assert.DoesNotContain(AppView.Models, AppViews.Toggleable);
+        Assert.Contains(AppView.Daily, AppViews.Toggleable);
+        Assert.Contains(AppView.Agents, AppViews.Toggleable);
+    }
+
+    [Fact]
+    public void HiddenLensLeavesTheRow()
+    {
+        var visible = AppViews.Visible("daily,agents");
+        Assert.DoesNotContain(AppView.Daily, visible);
+        Assert.DoesNotContain(AppView.Agents, visible);
+        Assert.Contains(AppView.Hourly, visible);
+        Assert.Contains(AppView.Overview, visible);
+    }
+
+    // A hand-edited settings file must not be able to remove the fallback
+    // target: Effective() sends every hidden lens to Overview, so an Overview
+    // that could itself be hidden would leave nowhere to land.
+    [Fact]
+    public void TamperedRawCannotHideTheFallbackTargets()
+    {
+        var visible = AppViews.Visible("overview,models,daily");
+        Assert.Contains(AppView.Overview, visible);
+        Assert.Contains(AppView.Models, visible);
+        Assert.DoesNotContain(AppView.Daily, visible);
+
+        Assert.Equal(AppView.Overview, AppViews.Effective(AppView.Overview, "overview"));
+        Assert.Equal(AppView.Models, AppViews.Effective(AppView.Models, "models"));
+    }
+
+    [Theory]
+    [InlineData("stats", AppView.Stats, AppView.Overview)]
+    [InlineData("daily,stats", AppView.Stats, AppView.Overview)]
+    [InlineData("daily", AppView.Stats, AppView.Stats)]
+    [InlineData("", AppView.Agents, AppView.Agents)]
+    public void EffectiveFallsBackOnlyWhenHidden(
+        string hiddenRaw, AppView requested, AppView expected)
+    {
+        Assert.Equal(expected, AppViews.Effective(requested, hiddenRaw));
+    }
+
+    // Ids are what get persisted; macOS writes the lowercase enum names into
+    // the same key, so a divergence here would silently split the format.
+    [Fact]
+    public void IdsAreLowercaseEnumNames()
+    {
+        Assert.Equal("hourly", AppViews.Id(AppView.Hourly));
+        Assert.Equal("agents", AppViews.Id(AppView.Agents));
+    }
+}

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\TokenBar.App\GraphRequestCoordinator.cs" Link="GraphRequestCoordinator.cs" />
     <Compile Include="..\TokenBar.App\GraphConsumerState.cs" Link="GraphConsumerState.cs" />
     <Compile Include="..\TokenBar.App\CostSurfaceProjection.cs" Link="CostSurfaceProjection.cs" />
+    <Compile Include="..\TokenBar.App\AppViews.cs" Link="AppViews.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Slice **S3** of `docs/proposals/settings-sidebar.md`. Follows #55.

Settings gains a **View tabs** section; lenses switched off there leave the flyout's tab row and cannot be reached by their numeric accelerator.

## One guard, not four

`SwitchTo` runs its argument through `Effective` rather than each caller checking. That is the point, not a style preference: the `Ctrl+1..9` accelerators each capture **one fixed lens at construction time**, so without a guard at the shared entry point a lens with no tab stays reachable by shortcut. Tab clicks, cycling and programmatic switches all inherit the same correction.

## Why Overview cannot be hidden

It is the fallback target every hidden lens returns to. `Visible` and `Effective` both restrict themselves to `Toggleable`, so a hand-edited settings file listing `overview` cannot strand the router — the same tamper-resistance macOS documents. `AppViewsTests.TamperedRawCannotHideTheFallbackTargets` pins it.

Ids are the lowercase enum names, matching what macOS persists into the same `tokenbar.views.hidden` key.

## AppView had to move

`TokenBar.Core.Tests` cannot reference `TokenBar.App` — that project is WinUI, the test project is plain `net10.0`. It pulls in individual non-WinUI sources through `Compile Include`. The enum had to leave `DashboardView.xaml.cs` to be testable at all, and now sits beside its own policy, which is also the shape macOS uses. No namespace change, so no call site moved.

## Verification

| | |
|---|---|
| Build | 0 warnings, 0 errors (x64 Windows) |
| Tests | **485 passed, 0 failed** — full suite, incl. 6 new `AppViewsTests` |

**Observed on x64 Windows**: switching a lens off in View tabs removes it from the flyout's tab row.

That observation also covers the settings subscription. The flyout is a singleton that hides rather than closes, and it dismisses itself on deactivation (`FlyoutWindow.xaml.cs:114`), so the settings window and the flyout are never open together without `--keep-open`. Nothing else updates those buttons' `Visibility`, so a lens disappearing after a settings write and a reopen is exactly the `ApplyLensVisibility` path firing.

**Cannot be observed at all right now**: "cycle skips hidden lenses". `Ctrl+[` / `Ctrl+]` do not fire on this build — see S8 below. The `CycleLens` change here is still correct, it just has no way to be exercised until that lands.

## Two pre-existing gaps found while verifying, both registered rather than fixed here

**S7 — Monthly was never ported.** macOS `AppView` has seven cases; this enum has six. The earlier parity survey missed it by trusting `DashboardView`'s comment "the six lenses from the macOS AppView router", which was itself wrong. That comment is corrected in this PR and the enum now documents the gap.

**S8 — flyout shortcuts.** Two separate defects. macOS binds ⌘1-9 and ⌘[ ⌘] to the **client tabs** (`PopoverView.swift:693-702`); Windows binds them to the **lenses** — wrong row. And `Ctrl+[` / `Ctrl+]` never fire: the plumbing is fine (`Ctrl+1..6` uses the identical `AddAccel` and works), but `VirtualKey.Number1` is a defined member while `(VirtualKey)0xDB` / `0xDD` are hand-cast undefined values, and OEM key codes are layout-dependent. macOS compares `charactersIgnoringModifiers`, which is not.

Neither is folded in here: which row the shortcuts should drive is a product decision, and making an incorrectly bound shortcut start firing would be worse than leaving it inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ

