### PR TITLE
feat(dashboard): port the Monthly lens

### DIFF
--- a/docs/proposals/settings-sidebar.md
+++ b/docs/proposals/settings-sidebar.md
@@ -142,7 +142,7 @@ macOS 的預覽欄**不隨分頁變化**，永遠顯示同樣三塊。Windows �
 | **S4** | General / Language 分節 + i18n 基礎建設 | S1 | 全 UI 字串可切換語言 |
 | **S5** | General / Discord 分節 + Rich Presence | S1 | Discord 狀態列顯示用量 |
 | **S6** | Usage attribution 分頁 + 歸因邏輯 | S1 | 側邊欄出現第五頁 |
-| **S7** | Monthly lens 移植（macOS `MonthlyView.swift`，275 行） | — | flyout 分頁列出現 Monthly，且可在 View tabs 中隱藏 |
+| **S7** | Monthly lens 移植（macOS `MonthlyView.swift`，275 行） | — | flyout 分頁列出現 Monthly，且可在 View tabs 中隱藏 |  ✅ |
 | **S8** | flyout OEM 快捷鍵修正 | — | `Ctrl+[`、`Ctrl+]`、`Ctrl+,` 實際可觸發 |
 
 S4 排在 S5 之前，因為 i18n 會碰到每一個字串；先做 Discord 等於保證之後要再改一次 Discord 的所有文案。
@@ -151,7 +151,7 @@ S4 排在 S5 之前，因為 i18n 會碰到每一個字串；先做 Discord 等�
 
 > **S8 的決定與結果：** 「該綁哪一排」經評估後**維持 Windows 現況**——數字鍵與 `[` `]` 都操作 lenses。macOS 把數字鍵給 client tabs 是因為 client 數量可變且最多九個，而 Windows 的 lens 固定六個、client tabs 另有上排可點；把使用者已在使用的綁定換掉，代價高於 parity 的收益。這個差異因此是**刻意的平台差異，不是缺陷**。S8 只修「按不動」：`VirtualKey` 沒有 OEM 成員，硬轉型的值 `KeyboardAccelerator` 永遠不匹配，改用 `KeyDown` 比對原始 Win32 虛擬鍵碼。連帶修好同病的 `Ctrl+,`（`VK_OEM_COMMA`），它同樣一直沒作用。
 
-> **S3 discovery 的發現（lens 數量）：** macOS `AppView` 有**七個** case（`overview, models, monthly, daily, hourly, stats, agents`），Windows 只有六個——`monthly` 從未移植。原本的 parity 盤點誤信了 `DashboardView` 那句「the six lenses from the macOS AppView router」註解，而那句話本身就是錯的。S7 因此獨立登記，不併入 S3；它不相依 S1，只是排在後面。
+> **S3 discovery 的發現（lens 數量）：**〔S7 已補上〕macOS `AppView` 有**七個** case（`overview, models, monthly, daily, hourly, stats, agents`），Windows 當時只有六個——`monthly` 從未移植。原本的 parity 盤點誤信了 `DashboardView` 那句「the six lenses from the macOS AppView router」註解，而那句話本身就是錯的。S7 因此獨立登記，不併入 S3；它不相依 S1，只是排在後面。
 
 ### S1 範圍細節
 

--- a/src/TokenBar.App/AppViews.cs
+++ b/src/TokenBar.App/AppViews.cs
@@ -3,12 +3,12 @@ using TokenBar.Core;
 namespace TokenBar.App;
 
 /// <summary>The flyout's lenses, ported from the macOS AppView router. macOS
-/// has seven; Monthly is not ported here, so this enum is deliberately one
-/// short rather than merely out of date.</summary>
+/// order matches macOS, so the number-key positions line up with it.</summary>
 public enum AppView
 {
     Overview,
     Models,
+    Monthly,
     Daily,
     Hourly,
     Stats,

--- a/src/TokenBar.App/DashboardView.xaml
+++ b/src/TokenBar.App/DashboardView.xaml
@@ -82,10 +82,21 @@
                     Orientation="Horizontal"
                     Spacing="4" />
             </ScrollViewer>
-            <StackPanel
-                x:Name="TabsPanel"
-                Orientation="Horizontal"
-                Spacing="4" />
+            <!-- Same treatment as the client row above. Seven lenses at 400
+                 DIP already sit close to the available width, and Windows text
+                 scaling widens every button, so the trailing tabs would be
+                 clipped by the window edge and unclickable rather than
+                 reachable. -->
+            <ScrollViewer
+                HorizontalScrollBarVisibility="Auto"
+                HorizontalScrollMode="Enabled"
+                VerticalScrollBarVisibility="Disabled"
+                VerticalScrollMode="Disabled">
+                <StackPanel
+                    x:Name="TabsPanel"
+                    Orientation="Horizontal"
+                    Spacing="4" />
+            </ScrollViewer>
         </StackPanel>
 
         <!-- Lens content -->

--- a/src/TokenBar.App/DashboardView.xaml.cs
+++ b/src/TokenBar.App/DashboardView.xaml.cs
@@ -13,9 +13,8 @@ using Grid = Microsoft.UI.Xaml.Controls.Grid;
 namespace TokenBar.App;
 
 /// <summary>
-/// The dashboard shell: global header, lens switch, and the lenses of the
-/// macOS AppView router, each built in code from the current snapshot. Six of
-/// the seven are ported; Monthly is not (see AppView).
+/// The dashboard shell: global header, lens switch, and the seven lenses of
+/// the macOS AppView router, each built in code from the current snapshot.
 /// </summary>
 public sealed partial class DashboardView : UserControl
 {
@@ -30,6 +29,7 @@ public sealed partial class DashboardView : UserControl
     private string _activeClientTab = ClientRegistry.OverviewTab;
     private string _clientTabsSignature = "";
     private string? _expandedDay; // Daily drill-down state
+    private string? _expandedMonth; // Monthly drill-down state
     private bool _hourlyProfileMode;
     private int _hourlyWindow = 48; // Timeline rows shown; +48 per "Show more"
     // Chart toggles, persisted with the macOS rawValue strings.
@@ -699,6 +699,7 @@ public sealed partial class DashboardView : UserControl
         UIElement content = _view switch
         {
             AppView.Models => BuildModels(_snapshot),
+            AppView.Monthly => BuildMonthly(_snapshot),
             AppView.Daily => BuildDaily(_snapshot),
             AppView.Hourly => BuildHourly(_snapshot),
             AppView.Stats => BuildStats(_snapshot),
@@ -1291,6 +1292,64 @@ public sealed partial class DashboardView : UserControl
 
     // ── Daily lens ───────────────────────────────────────────────────────
 
+    /// <summary>One model stripe inside an expanded Daily or Monthly card:
+    /// provider-tinted disc, model and client name, tokens and cost, with the
+    /// disc and the row outline lighting together on hover so the rich tooltip
+    /// points at an unambiguous row. Shared so the two lenses cannot drift —
+    /// the hover/glow/tooltip wiring is the fiddly part, and a copy of it is
+    /// exactly where a divergence would hide.</summary>
+    private FrameworkElement ModelStripeRow(
+        ContributionClient client, ModelColorMap colors, bool authoritative)
+    {
+        var name = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            Margin = new Thickness(12, 0, 0, 0),
+        };
+        var (subDiscHost, subDiscGlow) =
+            GlowingDisc(colors.Color(client.ProviderId, client.ModelId), 6);
+        name.Children.Add(subDiscHost);
+        name.Children.Add(Ui.Text(
+            $"{client.ModelId} · {ClientRegistry.ShortName(client.Client)}", 10, 0.85));
+        var row = Ui.Row(
+            name,
+            Ui.Text(
+                $"{Format.CompactTokens(client.Tokens.Total)} · "
+                    + CostSurfaceProjection.CostText(client.Cost, authoritative),
+                10,
+                0.7));
+
+        // Highlight the sub-row itself, not the card enclosing it: the tooltip
+        // describes this model, and lighting the whole card points at the
+        // wrong thing.
+        var rowGlow = new Border
+        {
+            BorderBrush = new SolidColorBrush(Colors.Transparent),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(3),
+            IsHitTestVisible = false,
+            Opacity = 0,
+        };
+        var rowHost = new Grid();
+        rowHost.Children.Add(row);
+        rowHost.Children.Add(rowGlow);
+        AttachHoverOutline(rowHost, hovered =>
+        {
+            if (hovered)
+            {
+                var accent = HoverOutlineBrush();
+                subDiscGlow.Stroke = accent;
+                rowGlow.BorderBrush = accent;
+            }
+
+            subDiscGlow.Opacity = hovered ? 1 : 0;
+            rowGlow.Opacity = hovered ? 0.55 : 0;
+        });
+        HoverTip.AttachRich(rowHost, () => ModelTip(client, colors, authoritative));
+        return rowHost;
+    }
+
     private UIElement BuildDaily(DashboardModel.Snapshot snapshot)
     {
         var panel = new StackPanel { Spacing = 6 };
@@ -1330,59 +1389,8 @@ public sealed partial class DashboardView : UserControl
                 foreach (var client in CostSurfaceProjection.OrderContributionClients(
                     selectedDay.Clients, snapshot.CostAuthoritative))
                 {
-                    var name = new StackPanel
-                    {
-                        Orientation = Orientation.Horizontal,
-                        Spacing = 6,
-                        Margin = new Thickness(12, 0, 0, 0),
-                    };
-                    var (subDiscHost, subDiscGlow) =
-                        GlowingDisc(colors.Color(client.ProviderId, client.ModelId), 6);
-                    name.Children.Add(subDiscHost);
-                    name.Children.Add(Ui.Text(
-                        $"{client.ModelId} · {ClientRegistry.ShortName(client.Client)}", 10, 0.85));
-                    var row = Ui.Row(
-                        name,
-                        Ui.Text(
-                            $"{Format.CompactTokens(client.Tokens.Total)} · "
-                                + CostSurfaceProjection.CostText(
-                                    client.Cost, snapshot.CostAuthoritative),
-                            10,
-                            0.7));
-                    var capturedClient = client;
-                    // Same treatment as the Models lens: the disc lights up with
-                    // the card, so the row the card describes is unambiguous.
-                    // Highlight the sub-row itself, not the day card that
-                    // encloses it: the card the tooltip describes is this model,
-                    // and lighting the whole day would point at the wrong thing.
-                    var rowGlow = new Border
-                    {
-                        BorderBrush = new SolidColorBrush(Colors.Transparent),
-                        BorderThickness = new Thickness(1),
-                        CornerRadius = new CornerRadius(3),
-                        IsHitTestVisible = false,
-                        Opacity = 0,
-                    };
-                    var rowHost = new Grid();
-                    rowHost.Children.Add(row);
-                    rowHost.Children.Add(rowGlow);
-                    AttachHoverOutline(rowHost, hovered =>
-                    {
-                        if (hovered)
-                        {
-                            var accent = HoverOutlineBrush();
-                            subDiscGlow.Stroke = accent;
-                            rowGlow.BorderBrush = accent;
-                        }
-
-                        subDiscGlow.Opacity = hovered ? 1 : 0;
-                        rowGlow.Opacity = hovered ? 0.55 : 0;
-                    });
-                    HoverTip.AttachRich(
-                        rowHost,
-                        () => ModelTip(
-                            capturedClient, colors, snapshot.CostAuthoritative));
-                    block.Children.Add(rowHost);
+                    block.Children.Add(ModelStripeRow(
+                        client, colors, snapshot.CostAuthoritative));
                 }
             }
 
@@ -1397,6 +1405,74 @@ public sealed partial class DashboardView : UserControl
             card.Tapped += (_, _) =>
             {
                 _expandedDay = _expandedDay == date ? null : date;
+                RenderContent(animated: false);
+            };
+
+            panel.Children.Add(card);
+        }
+
+        return panel;
+    }
+
+    // ── Monthly lens ─────────────────────────────────────────────────────
+
+    /// <summary>"Monthly" lens: one card per calendar month, most recent
+    /// first, expanding to the model stripes folded across that month's days.
+    /// Structurally a sibling of BuildDaily rather than a generalisation of it
+    /// — macOS keeps DailyView and MonthlyView separate too — but the stripe
+    /// row itself is shared so the drill-downs cannot drift.</summary>
+    private UIElement BuildMonthly(DashboardModel.Snapshot snapshot)
+    {
+        var panel = new StackPanel { Spacing = 6 };
+        var colors = new ModelColorMap(snapshot.Models, snapshot.CostAuthoritative);
+        var months = MonthlyRows.Build(snapshot.Graph, _selectedClients);
+        if (months.Count == 0)
+        {
+            panel.Children.Add(Ui.Dim("No usage in this range."));
+        }
+
+        foreach (var month in months)
+        {
+            var block = new StackPanel { Spacing = 4 };
+            var summary = $"{month.Messages} msgs";
+            if (month.Turns is { } turns)
+            {
+                var scope = month.TurnClients.Count switch
+                {
+                    1 => $"{ClientRegistry.ShortName(month.TurnClients[0])} only",
+                    > 1 => $"{string.Join(" + ", month.TurnClients.Select(ClientRegistry.ShortName))} only",
+                    _ => "selected clients",
+                };
+                summary += $" · {turns} turns · {scope}";
+            }
+
+            summary += $" · {Format.CompactTokens(month.Tokens)} · "
+                + CostSurfaceProjection.CostText(month.Cost, snapshot.CostAuthoritative);
+            block.Children.Add(Ui.Row(
+                Ui.Text(Format.MonthYear(month.Month), 12, bold: true),
+                Ui.Text(summary, 11, 0.8)));
+
+            if (_expandedMonth == month.Month)
+            {
+                foreach (var client in CostSurfaceProjection.OrderContributionClients(
+                    month.Clients, snapshot.CostAuthoritative))
+                {
+                    block.Children.Add(ModelStripeRow(
+                        client, colors, snapshot.CostAuthoritative));
+                }
+            }
+
+            var card = new Border
+            {
+                Background = (Brush)Application.Current.Resources["CardBackgroundFillColorDefaultBrush"],
+                CornerRadius = new CornerRadius(6),
+                Padding = new Thickness(10, 8, 10, 8),
+                Child = block,
+            };
+            var key = month.Month;
+            card.Tapped += (_, _) =>
+            {
+                _expandedMonth = _expandedMonth == key ? null : key;
                 RenderContent(animated: false);
             };
 

--- a/src/TokenBar.Core.Tests/FormatTests.cs
+++ b/src/TokenBar.Core.Tests/FormatTests.cs
@@ -36,6 +36,16 @@ public class FormatTests
     public void MonthDay(string iso, string expected) =>
         Assert.Equal(expected, Format.MonthDay(iso));
 
+    [Theory]
+    [InlineData("2026-06", "Jun 2026")]
+    [InlineData("2026-01", "Jan 2026")]
+    [InlineData("2026-12", "Dec 2026")]
+    [InlineData("2026-13", "2026-13")]
+    [InlineData("2026-06-10", "2026-06-10")]
+    [InlineData("garbage", "garbage")]
+    public void MonthYear(string ym, string expected) =>
+        Assert.Equal(expected, Format.MonthYear(ym));
+
     [Fact]
     public void MmddSplits() => Assert.Equal("06/10", Format.Mmdd("2026-06-10"));
 

--- a/src/TokenBar.Core.Tests/MonthlyRowsTests.cs
+++ b/src/TokenBar.Core.Tests/MonthlyRowsTests.cs
@@ -1,0 +1,118 @@
+using TokenBar.Interop;
+using Xunit;
+
+namespace TokenBar.Core.Tests;
+
+public class MonthlyRowsTests
+{
+    private static ContributionClient Client(
+        string id, string model = "m", long tokens = 0, double cost = 0,
+        int messages = 0) =>
+        new(id, model, "anthropic", new TokenBreakdown(tokens, 0, 0, 0, 0), cost, messages);
+
+    private static Contribution Day(
+        string date,
+        IReadOnlyList<ContributionClient> clients,
+        IReadOnlyDictionary<string, long>? turns = null) =>
+        new(date, new ContributionTotals(0, 0, 0), 0,
+            new TokenBreakdown(0, 0, 0, 0, 0), clients, turns);
+
+    private static UsagePayload Payload(params Contribution[] days) =>
+        new(
+            new UsageMeta("g", "v", new DateRange("2026-05-01", "2026-06-30"),
+                PricingMode.BestEffort, CostCoverage.Complete),
+            new UsageSummary(0, 0, 0, 0, 0, 0, [], []), [], days);
+
+    [Fact]
+    public void DaysFoldIntoMonthsMostRecentFirst()
+    {
+        var rows = MonthlyRows.Build(
+            Payload(
+                Day("2026-05-30", [Client("claude", tokens: 100, cost: 1, messages: 2)]),
+                Day("2026-06-01", [Client("claude", tokens: 10, cost: 0.5, messages: 1)]),
+                Day("2026-06-15", [Client("claude", tokens: 5, cost: 0.25, messages: 3)])),
+            ["claude"]);
+
+        Assert.Equal(["2026-06", "2026-05"], rows.Select(r => r.Month));
+        Assert.Equal(15L, rows[0].Tokens);
+        Assert.Equal(0.75, rows[0].Cost, 6);
+        Assert.Equal(4L, rows[0].Messages);
+        Assert.Equal(100L, rows[1].Tokens);
+    }
+
+    // Daily merges stripes inside one contribution; Monthly has to fold them
+    // across every day in the month, which is the behaviour that has no
+    // equivalent in DailyRows.
+    [Fact]
+    public void ModelStripesMergeAcrossDaysWithinAMonth()
+    {
+        var rows = MonthlyRows.Build(
+            Payload(
+                Day("2026-06-01", [Client("claude", "opus", tokens: 10, cost: 1)]),
+                Day("2026-06-02", [Client("claude", "opus", tokens: 5, cost: 2)]),
+                Day("2026-06-03", [Client("claude", "haiku", tokens: 7, cost: 0.5)])),
+            ["claude"]);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(2, row.Clients.Count);
+        var opus = row.Clients.Single(c => c.ModelId == "opus");
+        Assert.Equal(15L, opus.Tokens.Total);
+        Assert.Equal(3.0, opus.Cost, 6);
+        // Ordered by cost, so the merged stripe outranks the cheaper model.
+        Assert.Equal("opus", row.Clients[0].ModelId);
+    }
+
+    [Fact]
+    public void SameModelFromDifferentClientsStaysSeparate()
+    {
+        var rows = MonthlyRows.Build(
+            Payload(
+                Day("2026-06-01", [Client("claude", "shared", tokens: 10)]),
+                Day("2026-06-02", [Client("codex", "shared", tokens: 4)])),
+            ["claude", "codex"]);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(2, row.Clients.Count);
+        Assert.Equal([10L, 4L], row.Clients.Select(c => c.Tokens.Total).OrderByDescending(t => t));
+    }
+
+    // Turn data is per-client and only some clients report it, so a month with
+    // one turn-bearing day must keep that count rather than being flattened to
+    // zero by the days around it.
+    [Fact]
+    public void TurnsAccumulateOnlyFromDaysThatHaveThem()
+    {
+        var rows = MonthlyRows.Build(
+            Payload(
+                Day("2026-06-01", [Client("claude", messages: 1)],
+                    new Dictionary<string, long> { ["claude"] = 3 }),
+                Day("2026-06-02", [Client("claude", messages: 1)])),
+            ["claude"]);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(3L, row.Turns);
+        Assert.Equal(["claude"], row.TurnClients);
+    }
+
+    [Fact]
+    public void MonthWithNoTurnDataReportsNullRatherThanZero()
+    {
+        var rows = MonthlyRows.Build(
+            Payload(Day("2026-06-01", [Client("opencode", messages: 1)])),
+            ["opencode"]);
+
+        Assert.Null(Assert.Single(rows).Turns);
+    }
+
+    [Fact]
+    public void DatesTooShortToBucketAreDropped()
+    {
+        var rows = MonthlyRows.Build(
+            Payload(
+                Day("2026-6", [Client("claude", messages: 1)]),
+                Day("2026-06-02", [Client("claude", messages: 1)])),
+            ["claude"]);
+
+        Assert.Equal(["2026-06"], rows.Select(r => r.Month));
+    }
+}

--- a/src/TokenBar.Core/Format.cs
+++ b/src/TokenBar.Core/Format.cs
@@ -85,6 +85,23 @@ public static class Format
         return $"{MonthsShort[month - 1]} {day}";
     }
 
+    /// <summary>"2026-06" → "Jun 2026". Same shape as <see cref="MonthDay"/>:
+    /// anything that does not parse as year-month comes back unchanged rather
+    /// than being guessed at.</summary>
+    public static string MonthYear(string ym)
+    {
+        var parts = ym.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 2 ||
+            !int.TryParse(parts[0], NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var year) ||
+            !int.TryParse(parts[1], NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var month) ||
+            month is < 1 or > 12)
+        {
+            return ym;
+        }
+
+        return $"{MonthsShort[month - 1]} {year}";
+    }
+
     /// <summary>"2026-06-10" → "06/10".</summary>
     public static string Mmdd(string iso)
     {

--- a/src/TokenBar.Core/MonthlyRows.cs
+++ b/src/TokenBar.Core/MonthlyRows.cs
@@ -1,0 +1,116 @@
+using TokenBar.Interop;
+
+namespace TokenBar.Core;
+
+/// <summary>UI-free projection for one calendar month. Built by folding
+/// <see cref="DailyRows"/> rather than re-walking the payload, so client
+/// selection, turn scoping and the activity threshold stay defined in exactly
+/// one place.</summary>
+public sealed record MonthlyRow(
+    string Month,
+    long Tokens,
+    double Cost,
+    long Messages,
+    long? Turns,
+    IReadOnlyList<string> TurnClients,
+    IReadOnlyList<ContributionClient> Clients);
+
+public static class MonthlyRows
+{
+    /// <summary>Project selected payload stripes into most-recent-first months.
+    /// Model stripes are merged across every day in the month — Daily merges
+    /// within one contribution, Monthly folds up to 31 of them — keyed by raw
+    /// client id plus model and provider, so two clients reporting the same
+    /// model stay separate rows in the drill-down.</summary>
+    public static IReadOnlyList<MonthlyRow> Build(
+        UsagePayload payload, IReadOnlyList<string> orderedSelectedClients)
+    {
+        var months = new Dictionary<string, Slot>(StringComparer.Ordinal);
+
+        foreach (var day in DailyRows.Build(payload, orderedSelectedClients))
+        {
+            // Contribution.Date is "YYYY-MM-DD"; anything shorter is not a date
+            // this fold can bucket, so it is dropped rather than guessed at.
+            if (day.Date.Length < 7)
+            {
+                continue;
+            }
+
+            var key = day.Date[..7];
+            if (!months.TryGetValue(key, out var slot))
+            {
+                slot = new Slot();
+                months[key] = slot;
+            }
+
+            slot.Tokens = slot.Tokens.SaturatingAdd(day.Tokens);
+            slot.Messages = slot.Messages.SaturatingAdd(day.Messages);
+            slot.Cost += day.Cost;
+
+            // A month has turn data if any of its days did; days without it
+            // contribute nothing rather than forcing the month to zero.
+            if (day.Turns is { } turns)
+            {
+                slot.Turns = (slot.Turns ?? 0).SaturatingAdd(turns);
+            }
+
+            foreach (var id in day.TurnClients)
+            {
+                if (!slot.TurnClients.Contains(id, StringComparer.Ordinal))
+                {
+                    slot.TurnClients.Add(id);
+                }
+            }
+
+            foreach (var client in day.Clients)
+            {
+                var stripe = (client.Client, client.ModelId, client.ProviderId);
+                if (slot.Clients.TryGetValue(stripe, out var merged))
+                {
+                    slot.Clients[stripe] = merged with
+                    {
+                        Tokens = Add(merged.Tokens, client.Tokens),
+                        Cost = merged.Cost + client.Cost,
+                        // ContributionClient.Messages is int, so this cannot
+                        // use the long SaturatingAdd the rest of the fold does.
+                        Messages = (int)Math.Min(
+                            (long)merged.Messages + client.Messages, int.MaxValue),
+                    };
+                }
+                else
+                {
+                    slot.Clients[stripe] = client;
+                }
+            }
+        }
+
+        return [.. months
+            .Select(entry => new MonthlyRow(
+                entry.Key,
+                entry.Value.Tokens,
+                entry.Value.Cost,
+                entry.Value.Messages,
+                entry.Value.Turns,
+                entry.Value.TurnClients,
+                [.. entry.Value.Clients.Values.OrderByDescending(c => c.Cost)]))
+            .OrderByDescending(row => row.Month, StringComparer.Ordinal)];
+    }
+
+    private static TokenBreakdown Add(TokenBreakdown a, TokenBreakdown b) =>
+        new(
+            a.Input.SaturatingAdd(b.Input),
+            a.Output.SaturatingAdd(b.Output),
+            a.CacheRead.SaturatingAdd(b.CacheRead),
+            a.CacheWrite.SaturatingAdd(b.CacheWrite),
+            a.Reasoning.SaturatingAdd(b.Reasoning));
+
+    private sealed class Slot
+    {
+        public long Tokens;
+        public long Messages;
+        public double Cost;
+        public long? Turns;
+        public List<string> TurnClients { get; } = [];
+        public Dictionary<(string, string, string), ContributionClient> Clients { get; } = [];
+    }
+}


### PR DESCRIPTION
Slice **S7** of `docs/proposals/settings-sidebar.md`.

macOS `AppView` has seven cases; Windows had six. `monthly` was never ported — found during S3 by diffing the two enums directly rather than trusting `DashboardView`'s comment, which claimed six lenses and was itself wrong.

## Folding, not re-walking

`MonthlyRows.Build` folds the output of `DailyRows.Build` rather than scanning the payload again, so client selection, canonical id handling, turn scoping and the activity threshold keep exactly one definition.

What Monthly adds is the part Daily has no equivalent for — merging model stripes **across** the month's days, keyed on raw client + model + provider so two clients reporting the same model stay distinct in the drill-down.

Two details the tests pin:

- **Turns accumulate only from days that carry them.** A month with one turn-bearing day keeps that count instead of being flattened by the days around it; a month with none reports `null`, preserving the "no turn data" vs "zero turns" distinction `DailyRow` already makes.
- `ContributionClient.Messages` is `int`, not `long`, so its fold saturates explicitly rather than borrowing the `long` `SaturatingAdd` used everywhere else in the same method.

## Enum position

`Monthly` sits between `Models` and `Daily`, matching macOS. That shifts the `Ctrl+N` accelerators by one from Daily onward — the cost of giving the lens the position the reference implementation gives it. The ordering is coarse-to-fine by time window; appending Monthly after Agents to preserve the numbering would read as an afterthought permanently.

Everything else follows the enum automatically: tab row, View tabs switches, cycle set, and the hidden-lens policy all enumerate it.

## Shared stripe row

`BuildDaily`'s expanded rows and `BuildMonthly`'s are the same element — provider-tinted disc, model and client name, tokens and cost, with disc and row outline lighting together on hover behind a rich tooltip. That is ~60 lines of hover/glow/tooltip wiring, and a copy is exactly where a divergence would hide, so it moved to `ModelStripeRow` and both lenses call it.

The surrounding card structure stays duplicated deliberately: macOS keeps `DailyView` and `MonthlyView` separate, and the two may yet diverge.

`Format.MonthYear` mirrors `Format.MonthDay`, including returning its input unchanged when it does not parse as year-month.

## Verification

| | |
|---|---|
| Build | 0 warnings, 0 errors (x64 Windows) |
| Tests | **497 passed, 0 failed** — 12 more than before |

New coverage: the month fold, cross-day stripe merging, same-model-different-client separation, turn accumulation and its null case, unbucketable dates, and six `Format.MonthYear` cases.

**Observed on hardware**: the Monthly tab appears between Models and Daily, its cards render, and the drill-down expands. The Daily lens was also checked — it was edited to call the extracted row, making it this slice's one regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ