### PR TITLE
fix(flyout): let a vertical wheel scroll the tab rows

### DIFF
--- a/docs/proposals/settings-sidebar.md
+++ b/docs/proposals/settings-sidebar.md
@@ -228,6 +228,14 @@ S1 動工前必須先更新 checkout：本地 `main` 落後 `origin/main` 一週
 
 > **注意：** `SettingsWindow.ApplySize()` 上方那段既有註解（「Something in the show path renormalizes the size on a non-96-DPI monitor」）記的是同一族問題的另一個面向。`Activated += ApplySize` 是當時的補救，它處理得了首次顯示，處理不了「app 執行期間系統縮放改變」。
 
+### 捲軸不會自動隱藏
+
+| 行為 | 現況 |
+|---|---|
+| flyout 的水平捲軸（兩排分頁列）與垂直捲軸持續顯示，不淡出 | WinUI 的 `ScrollBarVisibility.Auto` 是「需要時顯示」，不是「滑過才顯示」。系統的 `DynamicScrollbars` 是預設值，所以不是協助工具設定造成 |
+
+> macOS 用 `OverlayScroller.swift` **強制 overlay 樣式**——靜止隱形、捲動時半透明藥丸、開啟時閃一下讓使用者知道可捲。它還得 KVO 監看 `scrollerStyle`，因為 AppKit 會在 layout 後約 0.6s 把 legacy 樣式套回來。Windows 這邊要達到同樣效果需要自訂 `ScrollBar` 樣式，尚未實作。
+
 ### 快捷鍵與開啟中的 popup
 
 | 行為 | 現況 | 判定 |

--- a/src/TokenBar.App/DashboardView.xaml
+++ b/src/TokenBar.App/DashboardView.xaml
@@ -73,6 +73,7 @@
         <!-- Client selection above the independent lens switch. -->
         <StackPanel Grid.Row="1" Spacing="6">
             <ScrollViewer
+                x:Name="ClientTabsScroll"
                 HorizontalScrollBarVisibility="Auto"
                 HorizontalScrollMode="Enabled"
                 VerticalScrollBarVisibility="Disabled"
@@ -88,6 +89,7 @@
                  clipped by the window edge and unclickable rather than
                  reachable. -->
             <ScrollViewer
+                x:Name="TabsScroll"
                 HorizontalScrollBarVisibility="Auto"
                 HorizontalScrollMode="Enabled"
                 VerticalScrollBarVisibility="Disabled"

--- a/src/TokenBar.App/DashboardView.xaml.cs
+++ b/src/TokenBar.App/DashboardView.xaml.cs
@@ -572,10 +572,46 @@ public sealed partial class DashboardView : UserControl
         var rasterScale = XamlRoot?.RasterizationScale ?? 1.0;
         var point = new Windows.Foundation.Point(
             windowPixelX / rasterScale, windowPixelY / rasterScale);
-        if (!TryZoomGraphAt(point, delta))
+        if (!TryZoomGraphAt(point, delta) && !TryScrollTabRowAt(point, delta))
         {
             ScrollBy(-delta);
         }
+    }
+
+    /// <summary>A vertical wheel over either tab row scrolls that row
+    /// horizontally (macOS HorizontalWheelScroll). Returns false when the row
+    /// is already at the end it is being pushed toward, so the wheel falls
+    /// through to the dashboard's vertical scroll instead of dying under the
+    /// cursor.</summary>
+    private bool TryScrollTabRowAt(Windows.Foundation.Point point, int delta)
+    {
+        foreach (var row in new[] { ClientTabsScroll, TabsScroll })
+        {
+            if (row is null || row.Visibility != Visibility.Visible)
+            {
+                continue;
+            }
+
+            var origin = row.TransformToVisual(this)
+                .TransformPoint(new Windows.Foundation.Point(0, 0));
+            if (point.X < origin.X || point.X > origin.X + row.ActualWidth
+                || point.Y < origin.Y || point.Y > origin.Y + row.ActualHeight)
+            {
+                continue;
+            }
+
+            var (offset, moved) = WheelScroll.Clamped(
+                row.HorizontalOffset, delta, row.ScrollableWidth);
+            if (!moved)
+            {
+                return false;
+            }
+
+            row.ChangeView(offset, null, null, disableAnimation: true);
+            return true;
+        }
+
+        return false;
     }
 
     private void OnWheel(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
@@ -589,9 +625,11 @@ public sealed partial class DashboardView : UserControl
         }
 
         var point = e.GetCurrentPoint(this);
-        if (!TryZoomGraphAt(point.Position, point.Properties.MouseWheelDelta))
+        var delta = point.Properties.MouseWheelDelta;
+        if (!TryZoomGraphAt(point.Position, delta)
+            && !TryScrollTabRowAt(point.Position, delta))
         {
-            ScrollBy(-point.Properties.MouseWheelDelta);
+            ScrollBy(-delta);
         }
 
         e.Handled = true;

--- a/src/TokenBar.Core.Tests/WheelScrollTests.cs
+++ b/src/TokenBar.Core.Tests/WheelScrollTests.cs
@@ -1,0 +1,52 @@
+using Xunit;
+
+namespace TokenBar.Core.Tests;
+
+public class WheelScrollTests
+{
+    // A wheel notch is positive scrolling up; the row should move left, so the
+    // offset decreases by the delta.
+    [Theory]
+    [InlineData(100, 20, 500, 80, true)]
+    [InlineData(100, -20, 500, 120, true)]
+    public void StepsWithinRangeMove(
+        double offset, double step, double max, double expected, bool moved)
+    {
+        var r = WheelScroll.Clamped(offset, step, max);
+        Assert.Equal(expected, r.Offset);
+        Assert.Equal(moved, r.Moved);
+    }
+
+    // The half that matters: at an edge the clamp is a no-op, and reporting it
+    // as consumed would swallow the dashboard's vertical scroll.
+    [Theory]
+    [InlineData(0, 20, 500)]      // already left, pushed further left
+    [InlineData(500, -20, 500)]   // already right, pushed further right
+    public void EdgesReportNotMoved(double offset, double step, double max)
+    {
+        var r = WheelScroll.Clamped(offset, step, max);
+        Assert.Equal(offset, r.Offset);
+        Assert.False(r.Moved);
+    }
+
+    [Fact]
+    public void OvershootClampsAndStillCountsAsMoved()
+    {
+        var a = WheelScroll.Clamped(10, 200, 500);
+        Assert.Equal(0, a.Offset);
+        Assert.True(a.Moved);
+
+        var b = WheelScroll.Clamped(490, -200, 500);
+        Assert.Equal(500, b.Offset);
+        Assert.True(b.Moved);
+    }
+
+    // A row narrower than its viewport reports a negative ScrollableWidth in
+    // WinUI; nothing should scroll and nothing should be consumed.
+    [Fact]
+    public void UnscrollableRowNeverMoves()
+    {
+        Assert.False(WheelScroll.Clamped(0, 20, -1).Moved);
+        Assert.False(WheelScroll.Clamped(0, -20, 0).Moved);
+    }
+}

--- a/src/TokenBar.Core/WheelScroll.cs
+++ b/src/TokenBar.Core/WheelScroll.cs
@@ -1,0 +1,24 @@
+namespace TokenBar.Core;
+
+/// <summary>Vertical-wheel-to-horizontal-scroll policy for the flyout's tab
+/// rows (macOS HorizontalWheelScroll). A mouse without a horizontal wheel only
+/// emits vertical deltas, so without this the rows can only be scrolled by
+/// dragging.</summary>
+public static class WheelScroll
+{
+    /// <summary>The clamped horizontal offset after stepping, and whether it
+    /// actually moved.
+    ///
+    /// The `moved` half is the whole point. At either edge the clamped value
+    /// equals the current one, and reporting the event as consumed there would
+    /// swallow the dashboard's vertical scroll for anyone whose cursor happens
+    /// to rest over a row already parked at its end. macOS hit exactly that and
+    /// fixed it the same way; the caller must fall through when this is
+    /// false.</summary>
+    public static (double Offset, bool Moved) Clamped(
+        double offset, double step, double maxOffset)
+    {
+        var next = Math.Min(Math.Max(0, offset - step), Math.Max(0, maxOffset));
+        return (next, next != offset);
+    }
+}


### PR DESCRIPTION
Both tab rows scroll horizontally, but a mouse without a horizontal wheel only emits vertical deltas — so the rows could only be moved by dragging. macOS solved this with `HorizontalWheelScroll`; this is the same policy.

## Which wheel path, and why it matters

The flyout is a **focusless popup**, so its wheel events arrive through the `WH_MOUSE_LL` hook and land in `RouteGlobalWheel` — not through XAML's routed `PointerWheelChanged`.

Wiring only `OnWheel` would have changed nothing the user could feel. Both are wired so the two paths cannot diverge.

## Falling through at the edges

`WheelScroll.Clamped` returns whether the offset actually changed, and the caller consumes the event **only when it did**.

At either end the clamped value equals the current one, and reporting that as handled would swallow the dashboard's vertical scroll for anyone whose cursor happens to rest over a row already parked at its end. macOS hit exactly that and fixed it the same way.

A row narrower than its viewport reports a *negative* `ScrollableWidth` in WinUI, which the same clamp turns into "did not move" rather than a bogus scroll.

The predicate is a pure function in Core so it can be tested; the hit-test and the `ChangeView` call stay in the view, where they cannot be.

## Verification

| | |
|---|---|
| Build | 0 warnings (x64 Windows) |
| Tests | **524 passed, 0 failed** — six new cases |

New coverage: in-range steps both directions, both edges reporting not-moved, overshoot clamping while still counting as moved, and an unscrollable row.

**Exercised on the machine**: the lens row scrolls under a vertical wheel, and continuing past its end hands the wheel to the dashboard's vertical scroll rather than dying under the cursor. That second half is the part unit tests cannot reach.

## Recorded, not fixed

Reported during the same check: the horizontal scrollbars **do not auto-hide**. WinUI's `ScrollBarVisibility.Auto` means "show when needed", not "show while pointed at", and the system `DynamicScrollbars` preference is at its default — so it is the control, not the OS. macOS forces overlay scrollers explicitly (`OverlayScroller.swift`, which also has to KVO-watch `scrollerStyle` because AppKit re-asserts the legacy style ~0.6s after layout). Added to the proposal's existing-defects section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ