### PR TITLE
fix(flyout): hide the tab rows' horizontal scrollbars

### DIFF
--- a/docs/proposals/settings-sidebar.md
+++ b/docs/proposals/settings-sidebar.md
@@ -234,7 +234,9 @@ S1 動工前必須先更新 checkout：本地 `main` 落後 `origin/main` 一週
 |---|---|
 | flyout 的水平捲軸（兩排分頁列）與垂直捲軸持續顯示，不淡出 | WinUI 的 `ScrollBarVisibility.Auto` 是「需要時顯示」，不是「滑過才顯示」。系統的 `DynamicScrollbars` 是預設值，所以不是協助工具設定造成 |
 
-> macOS 用 `OverlayScroller.swift` **強制 overlay 樣式**——靜止隱形、捲動時半透明藥丸、開啟時閃一下讓使用者知道可捲。它還得 KVO 監看 `scrollerStyle`，因為 AppKit 會在 layout 後約 0.6s 把 legacy 樣式套回來。Windows 這邊要達到同樣效果需要自訂 `ScrollBar` 樣式，尚未實作。
+> macOS 用 `OverlayScroller.swift` **強制 overlay 樣式**——靜止隱形、捲動時半透明藥丸、開啟時閃一下讓使用者知道可捲。它還得 KVO 監看 `scrollerStyle`，因為 AppKit 會在 layout 後約 0.6s 把 legacy 樣式套回來。
+>
+> **兩排分頁列的水平捲軸已改為 `Hidden`**（不是 `Disabled`——滾輪與拖曳仍可捲）。要做出 macOS 那種淡入淡出需要覆寫整個 `ControlTemplate`，這裡沒做。代價是失去「可捲」的視覺提示，macOS 靠「開啟時閃一下」補償，Windows 目前靠分頁列被截斷本身當提示。**內容區的垂直捲軸維持 `Auto`**，未一併處理。
 
 ### 快捷鍵與開啟中的 popup
 

--- a/src/TokenBar.App/DashboardView.xaml
+++ b/src/TokenBar.App/DashboardView.xaml
@@ -74,7 +74,7 @@
         <StackPanel Grid.Row="1" Spacing="6">
             <ScrollViewer
                 x:Name="ClientTabsScroll"
-                HorizontalScrollBarVisibility="Auto"
+                HorizontalScrollBarVisibility="Hidden"
                 HorizontalScrollMode="Enabled"
                 VerticalScrollBarVisibility="Disabled"
                 VerticalScrollMode="Disabled">
@@ -90,7 +90,7 @@
                  reachable. -->
             <ScrollViewer
                 x:Name="TabsScroll"
-                HorizontalScrollBarVisibility="Auto"
+                HorizontalScrollBarVisibility="Hidden"
                 HorizontalScrollMode="Enabled"
                 VerticalScrollBarVisibility="Disabled"
                 VerticalScrollMode="Disabled">


### PR DESCRIPTION
Stacked on #65 — it needs the `x:Name`s that PR adds, and more importantly it needs that PR's wheel support to be safe.

## Diagnosis first

Both rows rendered a permanent horizontal scrollbar. Confirmed with the owner that it is **present from launch**, not appearing on interaction and sticking — which rules out a stuck pointer state in the focusless popup and leaves the control's own styling.

WinUI's `ScrollBarVisibility.Auto` means *"show while scrollable"*, not *"show while pointed at"*. These rows are always scrollable, so `Auto` is permanent here. The system `DynamicScrollbars` preference is at its default, so this is the control, not the OS.

## `Hidden`, not `Disabled`

`Disabled` would remove the ability to scroll along with the bar. The rows still scroll by wheel and by drag.

The wheel path landed in #65, which is what makes hiding the bar safe rather than trapping content off-screen — before that, dragging was the only way to move these rows, and removing their only visible affordance would have been a regression.

## Not attempted

The fade-in-on-scroll behaviour macOS gets from `OverlayScroller`. That needs a full `ScrollBar` `ControlTemplate` override.

The cost is losing the "this scrolls" affordance. macOS pays for it with a one-shot flash when the popover opens; that is not implemented here, and a row visibly cut off mid-tab is the affordance for now.

## Scope

The content area's **vertical** scrollbar stays on `Auto`. The horizontal one is what was reported, and changing both would be a wider judgement than what was asked for.

## Verification

Build clean on x64 Windows. Verified on the machine: bars gone, wheel still scrolls both rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ