### PR TITLE
fix(flyout): hide the tab rows' horizontal scrollbars

### DIFF
--- a/docs/proposals/settings-sidebar.md
+++ b/docs/proposals/settings-sidebar.md
@@ -234,7 +234,9 @@ S1 動工前必須先更新 checkout：本地 `main` 落後 `origin/main` 一週
 |---|---|
 | flyout 的水平捲軸（兩排分頁列）與垂直捲軸持續顯示，不淡出 | WinUI 的 `ScrollBarVisibility.Auto` 是「需要時顯示」，不是「滑過才顯示」。系統的 `DynamicScrollbars` 是預設值，所以不是協助工具設定造成 |
 
-> macOS 用 `OverlayScroller.swift` **強制 overlay 樣式**——靜止隱形、捲動時半透明藥丸、開啟時閃一下讓使用者知道可捲。它還得 KVO 監看 `scrollerStyle`，因為 AppKit 會在 layout 後約 0.6s 把 legacy 樣式套回來。Windows 這邊要達到同樣效果需要自訂 `ScrollBar` 樣式，尚未實作。
+> macOS 用 `OverlayScroller.swift` **強制 overlay 樣式**——靜止隱形、捲動時半透明藥丸、開啟時閃一下讓使用者知道可捲。它還得 KVO 監看 `scrollerStyle`，因為 AppKit 會在 layout 後約 0.6s 把 legacy 樣式套回來。
+>
+> **兩排分頁列的水平捲軸已改為 `Hidden`**（不是 `Disabled`——滾輪與拖曳仍可捲）。要做出 macOS 那種淡入淡出需要覆寫整個 `ControlTemplate`，這裡沒做。代價是失去「可捲」的視覺提示，macOS 靠「開啟時閃一下」補償，Windows 目前靠分頁列被截斷本身當提示。**內容區的垂直捲軸維持 `Auto`**，未一併處理。
 
 ### 快捷鍵與開啟中的 popup
 

--- a/src/TokenBar.App/DashboardView.xaml
+++ b/src/TokenBar.App/DashboardView.xaml
@@ -74,7 +74,7 @@
         <StackPanel Grid.Row="1" Spacing="6">
             <ScrollViewer
                 x:Name="ClientTabsScroll"
-                HorizontalScrollBarVisibility="Auto"
+                HorizontalScrollBarVisibility="Hidden"
                 HorizontalScrollMode="Enabled"
                 VerticalScrollBarVisibility="Disabled"
                 VerticalScrollMode="Disabled">
@@ -90,7 +90,7 @@
                  reachable. -->
             <ScrollViewer
                 x:Name="TabsScroll"
-                HorizontalScrollBarVisibility="Auto"
+                HorizontalScrollBarVisibility="Hidden"
                 HorizontalScrollMode="Enabled"
                 VerticalScrollBarVisibility="Disabled"
                 VerticalScrollMode="Disabled">


### PR DESCRIPTION
Carries #66's content to `main`. Mechanical follow-up to a mistake in how the stack was landed, not new work.

## What happened

#66 was opened with `base: fix/horizontal-wheel` because it depends on that branch's `x:Name`s and its wheel support. Both PRs then merged within moments of each other, so GitHub never retargeted #66 onto `main` — #65 took `fix/horizontal-wheel` into `main` first, and #66 then merged into that same branch, which by then was already behind.

Net effect: `main` had the wheel change but not the scrollbar change, with `HorizontalScrollBarVisibility` still `Auto`. Caught by checking `main`'s actual content rather than trusting two `state=MERGED` responses.

The fix is to merge `fix/horizontal-wheel` — which now carries #66 — into `main`.

## Contents

```
c00eb9e  Merge pull request #66
a824676  fix(flyout): hide the tab rows' horizontal scrollbars
```

Already reviewed as #66 (Codex CLEAN) and verified on the machine: bars gone, wheel still scrolls both rows. Nothing is re-litigated here; this is the same commit reaching the branch it was meant for.

## For next time

A stacked PR needs its base retargeted to `main` *before* the lower PR merges, or the two merges race. Landing them one at a time, confirming the first is in `main`, then retargeting, avoids it entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ