### PR TITLE
feat(clients): register Junie and OpenCodeReview, and record the parity survey

### DIFF
--- a/docs/proposals/macos-parity-v1143.md
+++ b/docs/proposals/macos-parity-v1143.md
@@ -1,0 +1,120 @@
+# macOS parity 落差調查（對照 v1.14.3）
+
+> **這份文件會過期。** 它記錄的是兩個特定 commit 之間的差集，不是「現況」。
+> 使用前先確認下面的對照基準是否仍然成立；若 macOS 已前進，重跑調查而不是相信這裡。
+
+| 項目 | 值 |
+|---|---|
+| macOS 對照基準 | `5b894b63`（`origin/main`，v1.14.3） |
+| Windows 基準 | `240663d`（`main`，S4 i18n 完成後） |
+| 引擎 pin | `6a9de8ca5b35ed96e5c56e219e9b95a98633372d`，`ENGINE.md` 標為對齊 `v1.12.0 → v1.13.1` |
+| 調查日期 | 2026-08-27 |
+
+## 這份調查怎麼做的（以及上一份為什麼作廢）
+
+上一次調查得到的結論是「macOS 最近三個月沒有新功能」。那是錯的：本地
+`~/side-project/TokenBar-Native` 的 clone **落後 153 個 commit、四個小版本**，
+而調查從未 `fetch`。看到的最新提交是 v1.13.3 的 release notes，所以「全是 chore」
+是發版前快照的假象。
+
+這次的做法：
+
+```bash
+cd ~/side-project/TokenBar-Native && git fetch origin
+git archive origin/main Sources | tar -x -C <scratch>/macos-v1143
+```
+
+用 `git archive` 取快照而非 `pull`，不動使用者的工作目錄。五個平行 scout 各自
+分到**互斥**的檔案範圍，brief 裡明文禁止讀那棵過期的 checkout。
+
+> **五份報告有三份含實質錯誤**，由主 session 逐一核對修正：一份宣稱 Windows 已有
+> quota curve 的 FFI binding（C# 端零 binding）；一份宣稱 Windows 完全沒有 quota
+> history（Rust 端早就有——該 brief 只指了 C# 檔案，是 brief 的疏漏）；一份把
+> macOS 的托盤動畫樣式數成 2 種（實際 5 種，與 Windows 同）。委派可以擴大覆蓋面，
+> 不能取代對決策關鍵事實的親自查證。
+
+## 最關鍵的發現：Rust 那側已經有一半
+
+`crates/tb_core_ffi/src/agent_quota_history.rs` 存在且是活的，6690 行。
+`agent_usage.rs` 正在呼叫它：
+
+| 用途 | 呼叫點 |
+|---|---|
+| 記錄觀測並評估 | `agent_usage.rs:3378` `record_observations_and_evaluate` |
+| 舊格式遷移 | `agent_usage.rs:1600` `migrate_codex_v2` |
+| 歷史檔案 | `agent_quota_history::HISTORY_FILE_NAME`、`MAX_SERIES` |
+
+那就是 Windows 現行「歷史配速」模式的資料來源。**缺的是把序列讀回來的出口**：
+`include/ctb.h` 匯出 13 個函式，沒有一個讀 quota 曲線；`tb_agent_usage()` 回傳的是
+評估後的投影（`HistoricalPace`），不是序列本身。
+
+`ENGINE.md` 的 ownership 表寫明 `crates/tb_core_ffi` 屬於 TokenBar for Windows，
+因此**新增匯出不必經過 `tokscale-core` 的審查流程**。
+
+> 這改變了 Quota lens 的成本估算：是「新增 FFI 匯出 → C# binding → UI」，
+> 不是「從零建一套持久化」。
+
+## 落差清單
+
+### v1.14.x 新增（Windows 全缺）
+
+| 能力 | 使用者看到什麼 | macOS |
+|---|---|---|
+| **Quota lens** | 第八個 lens，排在 Overview 之後第二位；可隱藏 | `DashboardModel.swift:8` |
+| 單客戶端歷史卡 | 近 12 個週期，每列額度長條＋模型分段花費長條，可展開 | `Views/QuotaHistoryCard.swift` |
+| 全 agent 條帶卡 | 每個時間窗一條，週期由舊到新；峰值％、「從未耗盡」 | `Views/QuotaHistoryStripCard.swift` |
+| 熱圖卡 | 7×24（星期×小時），依消耗％漸層；下拉選時間窗 | `Views/QuotaHeatmapCard.swift` |
+| Overview 摘要行 | 一句話：哪個訂閱最吃緊＋重置倒數＋今日總計 | `Views/QuotaSummaryLine.swift` |
+| In-window 用量卡 | 額度曲線疊本地用量長條；兩階段載入 | `Views/WindowUsageCard.swift` |
+| 訂閱等價 | 「10% 額度 ≈ N tokens · $X，±Z%」，每次現算 | `TokenBarCore/WindowEquivalence.swift` |
+| 訂閱趨勢卡 | 每日花費依宣告的訂閱堆疊 | `Views/SubscriptionTrendCard.swift` |
+| 趨勢指標 | 每列方向箭頭，取時間窗尾端 25% 算斜率 | `TokenBarCore/QuotaTrend.swift` |
+| 多帳號 | 第二個 Claude 帳號；`accountKey` 進入 window key | `TokenBarCore/AccountIdentity.swift` |
+| 自訂掃描根目錄 | 使用者可加 `CLAUDE_CONFIG_DIR` | `ClaudeExtraRoots.swift` |
+| 可隱藏 Overview 卡 | `tokenbar.overview.hidden`；**與 lens 隱藏是兩套機制** | `TokenBarCore/OverviewCard.swift` |
+| 模型範圍時間窗 | 範圍窗只計該模型 | `TokenBarCore/ModelScope.swift` |
+
+### 既有落差（v1.14 之前就缺）
+
+| 能力 | Windows 現況 |
+|---|---|
+| Discord Rich Presence | 全 repo **0** 個 `discord` 字樣；macOS 1674 行三個檔 |
+| 用量歸因整頁 | 零實作；macOS 是設定的第五頁 |
+| 「立即檢查更新」按鈕 | 設定裡沒有任何更新入口 |
+| Beta 更新通道 | `UpdateFlow.cs:43` 寫死 `prerelease: false` |
+| Individual tray items | **明列非目標**，不計入落差 |
+
+### 客戶端註冊表
+
+macOS 34 筆、Windows 32 筆，差集正好兩筆：
+
+```swift
+"junie": ("Junie", "#6b7280"),
+"opencodereview": ("OpenCodeReview", "#6b7280"),
+```
+
+反向差集為空（Windows 沒有 macOS 缺的客戶端）。
+
+### Windows 獨有
+
+無。先前一度以為 3D 貢獻圖是 Windows 獨有，錯了——macOS 有
+`Charts/ContributionGraph3D.swift`，兩邊都有 2D 熱圖與 3D 兩種呈現。
+
+### 托盤
+
+完全對等：7 種標題模式、3 種儀表樣式（`bars`/`ring`/`popsicle`）、2 組動畫幀
+（cat／parrot）、3 種上色模式。
+
+## 切片順序
+
+| # | 切片 | 理由 |
+|---|---|---|
+| **1** | 兩個新客戶端 | 最小，`ClientRegistry` 加兩筆 |
+| **2** | 更新入口（Check now ＋ Beta 通道） | 小，兩個控制項＋Velopack channel 參數 |
+| **3** | Quota 資料出口：FFI 匯出 ＋ C# binding ＋ Overview 摘要行 | **整條鏈的瓶頸**；打通後每張卡都變純 UI |
+| **4** | Quota lens 三張卡 | 依賴 3 |
+| **5** | 多帳號／自訂掃描根目錄 | 碰認證與路徑，需安全審查流程 |
+| **6** | Discord／用量歸因 | 最大；Discord 對外發布使用者資料，需安全審查流程 |
+
+第 5、6 兩片觸及 pilotfish 的 security 風險門：pre-approval 走唯讀
+`security-reviewer`，實作走 `security-executor`，不用一般 executor。

--- a/docs/proposals/macos-parity-v1143.md
+++ b/docs/proposals/macos-parity-v1143.md
@@ -78,11 +78,26 @@ git archive origin/main Sources | tar -x -C <scratch>/macos-v1143
 
 | 能力 | Windows 現況 |
 |---|---|
-| Discord Rich Presence | 全 repo **0** 個 `discord` 字樣；macOS 1674 行三個檔 |
+| Discord Rich Presence | 原始碼零實作；macOS 1674 行三個檔 |
 | 用量歸因整頁 | 零實作；macOS 是設定的第五頁 |
 | 「立即檢查更新」按鈕 | 設定裡沒有任何更新入口 |
 | Beta 更新通道 | `UpdateFlow.cs:43` 寫死 `prerelease: false` |
 | Individual tray items | **明列非目標**，不計入落差 |
+
+> **落差的查證指令**（範圍要寫清楚，否則讀者重跑得到不同結果）：
+>
+> ```bash
+> # Discord：限定原始碼，不含 docs——docs/proposals/settings-sidebar.md
+> # 本來就有四處提到它（第 7、104、145、150 行），全 repo 搜尋不會是零。
+> grep -rni "discord" src/ --include=*.cs --include=*.xaml   # → 0
+>
+> # 更新入口
+> grep -n "prerelease" src/TokenBar.App/UpdateFlow.cs        # → :43 prerelease: false
+>
+> # 客戶端差集
+> # macOS Sources/TokenBarCore/ClientRegistry.swift 34 筆 vs
+> # src/TokenBar.Core/ClientRegistry.cs 32 筆
+> ```
 
 ### 客戶端註冊表
 

--- a/src/TokenBar.Core.Tests/ClientRegistryTests.cs
+++ b/src/TokenBar.Core.Tests/ClientRegistryTests.cs
@@ -63,6 +63,19 @@ public class ClientRegistryTests : IDisposable
         Assert.Equal(ids.OrderBy(x => x, StringComparer.Ordinal), ids);
     }
 
+    // Both carry the same grey the unregistered fallback uses, so Style()
+    // alone cannot tell a registered "junie" from an unregistered one. The
+    // display name can: the fallback only upper-cases the first letter, so an
+    // unregistered "opencodereview" would render "Opencodereview".
+    [Theory]
+    [InlineData("junie", "Junie")]
+    [InlineData("opencodereview", "OpenCodeReview")]
+    public void NewClientsAreRegisteredWithTheirOwnCasing(string id, string expected)
+    {
+        Assert.Contains(id, ClientRegistry.AllIds);
+        Assert.Equal(expected, ClientRegistry.Style(id).DisplayName);
+    }
+
     [Theory]
     [InlineData("claude-code", "claude")]
     [InlineData("codex-cli", "codex")]

--- a/src/TokenBar.Core/ClientRegistry.cs
+++ b/src/TokenBar.Core/ClientRegistry.cs
@@ -27,6 +27,13 @@ public static class ClientRegistry
         ["hermes"] = ("Hermes", "#a78bfa"),
         ["pi"] = ("Pi", "#f472b6"),
         ["kimi"] = ("Kimi CLI", "#fbbf24"),
+        // Both take the same neutral grey the unregistered fallback uses, so
+        // "junie" already rendered correctly by accident. Registering them is
+        // still not a no-op: AllIds is the canonical universe demo fixtures
+        // draw from, and RegisteredNames guards ShortName from collapsing one
+        // client's name onto another's.
+        ["junie"] = ("Junie", "#6b7280"),
+        ["opencodereview"] = ("OpenCodeReview", "#6b7280"),
         ["qwen"] = ("Qwen CLI", "#7c3aed"),
         ["roocode"] = ("Roo Code", "#ef4444"),
         ["kilocode"] = ("KiloCode", "#f97316"),


### PR DESCRIPTION
Slice 1 — two client registry entries, plus the macOS parity survey the slice order comes from.

## Clients

macOS v1.14.3 registers 34 clients, Windows 32; the difference is exactly `junie` and `opencodereview`, both taking `#6b7280` — **the same neutral grey the unregistered fallback already uses**.

That grey makes the two cases behave differently. `ClientRegistry.Style` falls back to the id with its first letter upper-cased, so an unregistered `junie` already rendered `Junie` in that exact grey — registering it **changes no pixel**. `opencodereview` did not: the fallback produces `Opencodereview`.

Registering is **not** a no-op for either. `AllIds` is the canonical client universe demo fixtures draw from, and `RegisteredNames` is what stops `ShortName` collapsing one client's suffixed name onto another client's full name.

The new test asserts membership in `AllIds` as well as the display name, because **the display-name assertion alone cannot fail for `junie`** — the fallback produces the same string.

**Mutation-checked**: deleting both entries fails both theory cases, and both fail on the `AllIds` assertion rather than the name one.

## Parity survey

`docs/proposals/macos-parity-v1143.md` records the gap against macOS `5b894b63` (v1.14.3), the slice order derived from it, and — deliberately at the top — **the two commits it was measured between**, so a reader can tell whether it has gone stale rather than trusting it.

It exists because the previous survey concluded "macOS has added no features in three months". That was wrong: the local macOS clone was **153 commits and four minor versions behind** and had never been fetched, so the newest thing in view was a release-notes commit. macOS had in fact shipped a whole Quota lens, 24 new source files, and multi-account support.

### What the survey found about cost

The largest gap **looked like** it needed a new persistence layer. It does not.

`crates/tb_core_ffi/src/agent_quota_history.rs` already records quota observations and evaluates them — that is what feeds the Historical pace mode Windows ships today. What is missing is an FFI export to read the series back: `include/ctb.h` exports thirteen functions and none returns a quota curve.

`ENGINE.md` puts `crates/tb_core_ffi` under this repository's ownership, so adding one **does not need a tokscale-core review round**.

### About the delegation

Five parallel scouts produced the survey; **three of the five reports contained a materially wrong claim**, each caught by checking it directly. Those are named in the document, including the one caused by a scope error in the brief I wrote.

Delegation widened the coverage; it did not remove the need to verify the facts a decision rests on.

## Verification

558 tests pass (baseline 556) and `TokenBar.App` builds clean (x64 Release, win-x64) on the Windows host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ
