### PR TITLE
feat(install): add the install wizard shell (INSTALL-1a)

### DIFF
--- a/docs/proposals/install-1-wizard.md
+++ b/docs/proposals/install-1-wizard.md
@@ -131,6 +131,35 @@ this plan relies on; the window either appears or it does not.
 ARM64 is not a minority case: `win-arm64` and `win-arm64-lite` are 2 of the 4
 published channels and 8 of the 16 release assets.
 
+**Result, 2026-08-28: all three observed, INSTALL-1a accepted.**
+
+A1 and A3 were confirmed by the user at the machines. A2's evidence, from
+`%LocalAppData%\Temp\tokenbar-app.log` after installing to `C:\SyrtisTest\Syrtis`:
+
+```
+14:26:26.423 update-download: verified v0.2.2
+14:26:27.331 update-handoff: start v0.2.2        (+908 ms dwell, as designed)
+14:26:27.491 update-handoff: started v0.2.2
+14:27:30.434 <new process, PID 18764>
+14:27:30.682 launch: tray up
+14:27:31.900 update-check: none
+C:\SyrtisTest\Syrtis -> 0.2.2.0
+```
+
+**`--installto` does not break the updater.** The app installed outside
+`%LocalAppData%` resolved its GitHub feed, downloaded, applied and restarted
+into 0.2.2. The Browse button stays; the risk row below is closed as refuted.
+
+**One finding this produced, outside this slice's scope.** The gap between
+hand-off and restart was **63 seconds** here against 4.5 seconds for the same
+0.2.1-to-0.2.2 update at the default location — 13x, with nothing on screen for
+all of it, because our process is gone by then. The user reasonably read it as
+a hang and reported it as one. #76's PR body describes that window as "several
+seconds"; that is now known to be wrong for at least one real install path. The
+likely cause is Defender scanning a directory outside the usual application
+path, unconfirmed. Tracked separately: it belongs to the update flow, not to
+the wizard, and no change here would fix it.
+
 ### INSTALL-1b — embed and package
 
 `package-velopack.ps1` builds the wizard, embeds Setup.exe as a resource, and
@@ -156,7 +185,7 @@ not close until a packed `win-arm64` wrapped Setup has installed on
 
 | Risk | Handling |
 |---|---|
-| `--installto` breaks the updater | Proven or refuted by A2, before any packaging work exists. If refuted: Browse and the editable path are dropped, the wizard offers only the default location, and the rest of the plan is unaffected. |
+| ~~`--installto` breaks the updater~~ | **Closed 2026-08-28, refuted by A2.** An install at `C:\SyrtisTest\Syrtis` found the feed, updated and restarted into 0.2.2. Browse stays. |
 | .NET Framework 4.8 absent | Windows 10 1903+ and all Windows 11 ship it. The wizard fails to start with a Windows-supplied message. Documented in 1c, not handled. |
 | ARM64 | Split across both slices so neither can skip it: A3 in 1a is launch-and-render; 1b does not close without a real ARM64 install. |
 | A broken wizard blocks every install | `--silent` passthrough keeps scripted installs working; the raw Velopack Setup is still buildable locally. |

--- a/docs/proposals/install-1-wizard.md
+++ b/docs/proposals/install-1-wizard.md
@@ -54,8 +54,17 @@ about download size and the install chain.
 **A was chosen.** The wizard is published under the existing filename
 `Nyanako.Syrtis-<ch>-Setup.exe`, so no documentation link or release asset
 name changes. Its cost is that the wizard becomes a mandatory link in every
-install; `--silent` passes straight through to keep scripted installs working,
-and Velopack's raw Setup remains buildable locally from the same pack.
+install. `-s` / `--silent` is honoured so scripted installs keep working, and
+Velopack's raw Setup remains buildable locally from the same pack.
+
+An earlier draft said `--silent` "passes straight through", which was never
+true and would have been dangerous once 1b puts this under Setup's filename:
+1a understands only the silent switch and the setup path, and it now **refuses**
+anything else rather than ignoring it. A script carrying `--installto` gets a
+non-zero exit and a message instead of a silent install into the default
+directory. Forwarding the rest of Setup's command line — `-v`, `-l`,
+`-t/--installto` — is 1b's decision, since 1b is where the substitution
+actually happens.
 
 ## 4. Design
 

--- a/docs/proposals/install-1-wizard.md
+++ b/docs/proposals/install-1-wizard.md
@@ -1,0 +1,191 @@
+# INSTALL-1 — GUI install wizard (per-user)
+
+Status: approved 2026-08-28. Owner: main session.
+Reviewed by four independent fresh plan reviews; five defects were caught
+before any code existed, three of them factual errors in earlier drafts of
+this document. The revision history at the end records them, because two were
+the same mistake made twice.
+
+## 1. Problem
+
+What a user double-clicks today is Velopack's own `Setup.exe`. It shows a bare
+progress splash: no welcome, no choice of location, no Back/Next/Cancel, no
+statement of what is about to happen or where. It installs to
+`%LocalAppData%\Nyanako.Syrtis` and there is no way to say otherwise.
+
+Every other Windows application the user installs asks. This one should too.
+
+## 2. Facts established before planning
+
+These were checked against the running system or the repository, not assumed.
+
+| Fact | Evidence |
+|---|---|
+| `Setup.exe -t, --installto <DIR>` exists | `Setup.exe --help`, Velopack 1.2.0, on 192.168.123.188 |
+| Setup's only other options are `-s/--silent`, `-v`, `-l`, `-h` | same |
+| `Update.exe` takes `--rootDir` to override the **default** locator root | `Update.exe --help`, same host |
+| Install layout is `%LocalAppData%\Nyanako.Syrtis\{current, packages, Syrtis.App.exe, Update.exe}` | directory listing, same host |
+| The app builds its `UpdateManager` with a null locator — the default, exe-relative one | `src/TokenBar.App/UpdateFlow.cs:93-107` |
+| The app is `SelfContained` + `WindowsAppSDKSelfContained`; Setup.exe is ~83 MB | `src/TokenBar.App/TokenBar.App.csproj`; packaging output |
+| A release publishes 16 assets, enumerated explicitly | `.github/workflows/release.yml:220-232` |
+| CI asserts exactly 4 files per channel | `.github/workflows/release.yml:133-144` |
+| `write-package-evidence.ps1` throws unless there is exactly one Setup.exe | `scripts/write-package-evidence.ps1:108` |
+| The Setup/nupkg size budget is stated **twice** — `package-velopack.ps1:443-452` and an independent map at `write-package-evidence.ps1:113-125`, enforced at `:136-140` from `ci.yml:434` | both files |
+| Everything shipped is unsigned; SmartScreen warns on first run | `docs/release-velopack.md:126` |
+| packId is frozen and determines the install directory | `docs/release-velopack.md:119-121` |
+| 192.168.123.188 has the .NET Framework 4.8.1 runtime but **no targeting packs** | registry + reference-assembly check |
+
+## 3. Options considered
+
+The wizard must run on a machine with no runtime installed, because it is the
+thing that installs the runtime-bearing app. That eliminates a
+framework-dependent .NET 10 build and makes the choice a product decision
+about download size and the install chain.
+
+| | A. Setup embedded | B. Setup beside it | C. .NET 10 self-contained |
+|---|---|---|---|
+| Wizard size | ~150 KB + embedded 83 MB | ~150 KB | ~70 MB + 83 MB |
+| Files the user downloads | one | two | two |
+| SmartScreen prompts | one | two | two |
+| Runtime prerequisite | .NET Framework 4.8 (in Win10 1903+/11) | same | none |
+| Release asset count | unchanged | +4, breaks two CI assertions | +4 |
+| ARM64 | emulated | emulated | native |
+
+**A was chosen.** The wizard is published under the existing filename
+`Nyanako.Syrtis-<ch>-Setup.exe`, so no documentation link or release asset
+name changes. Its cost is that the wizard becomes a mandatory link in every
+install; `--silent` passes straight through to keep scripted installs working,
+and Velopack's raw Setup remains buildable locally from the same pack.
+
+## 4. Design
+
+Four pages in one fixed-size form, `< Back` / `Next >` / `Cancel` right-aligned
+along the bottom.
+
+| Page | Content | Buttons |
+|---|---|---|
+| Welcome | icon, heading, what will be installed and its version | Back disabled |
+| Location | path box defaulting to `%LocalAppData%\Nyanako.Syrtis`, `Browse…`, a line stating current-user-only and no administrator rights | Next disabled while the path is invalid, validated as typed |
+| Installing | heading, status line, **indeterminate** bar | all disabled, Cancel included |
+| Done | success: `Launch Syrtis` checkbox. failure: exit code and log path | single `Finish` |
+
+Setup is invoked as `--installto "<dir>" --silent --log "<temp>\syrtis-install.log"`.
+
+The progress bar is indeterminate because `Setup.exe --silent` reports no
+progress. Faking a percentage was rejected: the update dialog in #76 spent four
+rounds learning that invented feedback is worse than honest absence.
+
+**Bilingual, with its own string table.** The wizard cannot reference the app's
+i18n — `TokenBar.Core` is net10 and this is net48 — so it carries one static
+class holding every user-visible string in English and Traditional Chinese,
+selected from `CultureInfo.CurrentUICulture`. An English installer for a
+localised app would be a visible inconsistency; a twenty-entry table is
+cheaper than that.
+
+## 5. Slices
+
+### INSTALL-1a — the wizard, standalone
+
+A `src/Syrtis.Installer/` net48 WinForms project referencing
+`Microsoft.NETFramework.ReferenceAssemblies`. It takes the path to a Velopack
+Setup.exe as an argument, so it is runnable and observable before any
+packaging work exists.
+
+`src/Syrtis.Installer/` **stays out of `src/TokenBar.slnx`**, for the same
+reason `TokenBar.App` does (`TokenBar.App.csproj:3-5`): the slnx is the macOS
+inner loop, `scripts/check.sh:19-21` restores it `--locked-mode` and builds it,
+and net48 WinForms cannot build there. Keeping it out is also what makes this
+slice's rollback — delete the directory — true.
+
+The build policy that reaches it is the repo-root `Directory.Build.props:9-21`;
+there is no `src/Directory.Build.props`. It applies product and version
+identity to every project in the tree, plus `RestorePackagesWithLockFile`. Two
+consequences, both accepted: the wizard assembly is stamped with the repo
+version, and it produces a committed `packages.lock.json`. Nothing globs
+`src/**/packages.lock.json` — `build-app-artifact.ps1:274-277` is an explicit
+four-entry list — so a lock file outside the slnx has no further consequence.
+`src/Directory.Build.targets` does not apply: every target in it is gated on
+the opt-in `TbNativePackagingEnabled`.
+
+**Acceptance — three observations. A1 and A3 are the user's.**
+
+*A1 (user, at 192.168.123.188).* The four pages render, Back/Next/Cancel
+behave, Browse picks a directory, and the wizard installs to a **non-default**
+directory outside `%LocalAppData%`. Nobody else can judge the dialog: this
+slice is blocked, not in progress, until the user has looked at it.
+
+*A2 (main session, from logs) — the decisive one.* The app launched from that
+non-default directory must produce `update-available: v0.2.2` in
+`%LocalAppData%\Temp\tokenbar-app.log`, and after Install Update,
+`update-handoff: started v0.2.2` then a fresh `launch: tray up`, with
+`<non-default dir>\current\Syrtis.App.exe` reporting FileVersion `0.2.2.0`.
+Prerequisite: a locally packed Setup.exe at **0.2.1**, so the published v0.2.2
+is a real available update.
+
+*A3 (user, at 192.168.54.128, the ARM VM).* The same AnyCPU executable
+launches and renders its four pages. No install at this stage — a cheap early
+signal taken before 1b builds any embedding machinery on the assumption that
+it works. Whether ARM64 Windows runs it natively or emulated is not something
+this plan relies on; the window either appears or it does not.
+
+ARM64 is not a minority case: `win-arm64` and `win-arm64-lite` are 2 of the 4
+published channels and 8 of the 16 release assets.
+
+### INSTALL-1b — embed and package
+
+`package-velopack.ps1` builds the wizard, embeds Setup.exe as a resource, and
+emits the result under the existing Setup filename. **Both** statements of the
+size budget are updated with measured values. The exactly-one-Setup rule at
+`write-package-evidence.ps1:108` is re-read before anything near it is touched.
+
+Acceptance: a local pack installs correctly; `--silent` installs headlessly
+with no window; the CI evidence step (`ci.yml:434`) is run against the packed
+output, because that is the path the second budget map is enforced on.
+
+**ARM64 gate.** 1b commits the shipping form for all four channels, so it does
+not close until a packed `win-arm64` wrapped Setup has installed on
+192.168.54.128 and the app has started, observed by the user.
+
+### INSTALL-1c — CI and docs
+
+`.github/workflows/release.yml`, `docs/release-velopack.md`,
+`docs/lite-distribution.md`. Acceptance: a release dry run publishes the same
+16 asset names and the four-file assertion still holds.
+
+## 6. Risks
+
+| Risk | Handling |
+|---|---|
+| `--installto` breaks the updater | Proven or refuted by A2, before any packaging work exists. If refuted: Browse and the editable path are dropped, the wizard offers only the default location, and the rest of the plan is unaffected. |
+| .NET Framework 4.8 absent | Windows 10 1903+ and all Windows 11 ship it. The wizard fails to start with a Windows-supplied message. Documented in 1c, not handled. |
+| ARM64 | Split across both slices so neither can skip it: A3 in 1a is launch-and-render; 1b does not close without a real ARM64 install. |
+| A broken wizard blocks every install | `--silent` passthrough keeps scripted installs working; the raw Velopack Setup is still buildable locally. |
+| A new project collides with repo-wide build policy | Enumerated above from `Directory.Build.props:9-21`; both consequences stated and accepted. |
+
+## 7. Non-goals
+
+Machine-wide installation. Elevation. An uninstall wizard. Signing. Changing
+packId or the install layout. A progress percentage. Any change to how the app
+updates.
+
+## 8. Revision history
+
+Four fresh reviews, five blockers, before any code:
+
+1. INSTALL-1a's acceptance named a machine but no human actor and no build
+   host, so the slice could have been closed with nobody having seen the
+   dialog it exists to produce.
+2. The Setup size budget is stated in two files; the first draft owned one.
+   The repository's own rule — a contract stated in N places is reconciled
+   only after reading all N — was written after an identical failure.
+3. "Finds its update feed" had no observable. Replaced with named log strings.
+4. A repo-wide collision with `Directory.Build.targets` was asserted by
+   generalising from a single error message, without checking that every
+   target in that file is gated on an opt-in property. The named work did not
+   exist.
+5. The correction to (4) cited `src/Directory.Build.props:20`, copied from a
+   reviewer without opening the file. That file does not exist; the real one
+   is at the repo root and carries six properties, not one.
+
+(4) and (5) are the same failure twice in one hour: asserting a fact about a
+file without opening it.

--- a/docs/proposals/install-1-wizard.md
+++ b/docs/proposals/install-1-wizard.md
@@ -162,6 +162,18 @@ the wizard, and no change here would fix it.
 
 ### INSTALL-1b — embed and package
 
+**Carried in from 1a.** The wizard is a WinExe, so it does not attach the
+parent's console: `--silent`'s diagnostic text reaches a caller that redirects
+(a pipe or file is inherited) but not a person typing in a real console window.
+The exit-code contract holds everywhere — 1 never reached Setup, -1 could not
+start it, anything else is Setup's own — and the text is the part that is
+conditional. Two reviews disagreed about this and the one calling it harmless
+was wrong: both had "measured" it through redirected pipes, which is precisely
+the case that works. It is deferred rather than fixed because the fix
+(`AttachConsole(ATTACH_PARENT_PROCESS)`) cannot be verified from a remote
+session for the same reason the defect cannot be reproduced there, and 1b
+already needs a person at a real console for its ARM64 gate.
+
 `package-velopack.ps1` builds the wizard, embeds Setup.exe as a resource, and
 emits the result under the existing Setup filename. **Both** statements of the
 size budget are updated with measured values. The exactly-one-Setup rule at

--- a/docs/proposals/install-1-wizard.md
+++ b/docs/proposals/install-1-wizard.md
@@ -103,8 +103,18 @@ packaging work exists.
 `src/Syrtis.Installer/` **stays out of `src/TokenBar.slnx`**, for the same
 reason `TokenBar.App` does (`TokenBar.App.csproj:3-5`): the slnx is the macOS
 inner loop, `scripts/check.sh:19-21` restores it `--locked-mode` and builds it,
-and net48 WinForms cannot build there. Keeping it out is also what makes this
-slice's rollback — delete the directory — true.
+and net48 WinForms cannot build there.
+
+**This sentence used to continue "keeping it out is also what makes this
+slice's rollback — delete the directory — true", and INSTALL-1a2 made that
+false.** `TokenBar.Core.Tests` now compiles several installer sources through
+`<Compile Include>`, and a stale include path is a hard build error in a
+project that both the macOS inner loop and CI build. Backing the wizard out
+means removing those include items and the test file in the same change. The
+coupling is accepted deliberately: it is the price of the sources being
+reachable by a test at all. The project itself still stays out of the slnx —
+that part is unchanged, and it is what keeps net48 WinForms off the macOS
+inner loop.
 
 The build policy that reaches it is the repo-root `Directory.Build.props:9-21`;
 there is no `src/Directory.Build.props`. It applies product and version
@@ -168,6 +178,44 @@ seconds"; that is now known to be wrong for at least one real install path. The
 likely cause is Defender scanning a directory outside the usual application
 path, unconfirmed. Tracked separately: it belongs to the update flow, not to
 the wizard, and no change here would fix it.
+
+### INSTALL-1a2 — make the boundary logic testable
+
+Added 2026-08-31, after eight consecutive external review rounds on #77 each
+found a real defect and **five of them were introduced or left incomplete by
+the previous round's fix**. That is not a converging series, and the reason it
+was not converging is structural rather than careless.
+
+**Seven of the eight findings sit at the boundary with Win32** — command-line
+parsing, path parsing, process launch, the filesystem, the console subsystem.
+Only one was wizard flow, and it was the mildest. This project is a thin shim
+over hostile platform semantics, and that shim had no automated coverage at
+all: no test project compiled `src/Syrtis.Installer/`. Every fix was verified
+by a throwaway probe that reflected into the built binary, proved one thing,
+and was deleted — so each round began again from nothing.
+
+**The two surfaces also re-derived shared decisions independently.** Program
+parsed arguments, SetupLocator parsed them again, WizardForm chose the
+directory, SetupRunner formatted the command line, and the Done page re-derived
+whether the log was usable. Findings 4 and 7 were one defect on two surfaces;
+finding 5 was one rule in two files; the whole-directory review found five more
+duplicated rules. The plan for this slice reproduced the disease while
+describing the cure: its own `--self-check` switch would have been swallowed by
+its own round-8 argument fix and reported as a missing setup file. That is the
+strongest available evidence that the fault is the missing single answer to
+"what is this run", not insufficient care.
+
+So: one `InstallRequest` produced by one `Parse`, consumed by all five call
+sites; the pure logic moved where a test can reach it; the nine probes already
+run by hand become tests.
+
+**What cannot be tested there, stated because a silent omission would read as
+coverage.** Windows path semantics stay out of `TokenBar.Core.Tests`: that
+suite also runs on the macOS inner loop, where `Path.IsPathRooted("C:\")` is
+false, and net10 does not throw where net48 does — which is finding 1 itself.
+Those assertions live in a `--self-check` switch that runs them in-process on
+the framework that actually ships, and it is required to fail when an assertion
+is deliberately broken.
 
 ### INSTALL-1b — embed and package
 

--- a/src/Syrtis.Installer/App.config
+++ b/src/Syrtis.Installer/App.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+  </startup>
+
+  <!-- Paired with app.manifest's dpiAwareness: this is the piece that
+       actually turns PerMonitorV2 on for a WinForms net48 app; the manifest
+       alone opts the process into the DPI story but leaves WinForms itself
+       unaware. Required for crisp rendering at 150% scaling. -->
+  <System.Windows.Forms.ApplicationConfigurationSection>
+    <add key="DpiAwareness" value="PerMonitorV2" />
+  </System.Windows.Forms.ApplicationConfigurationSection>
+</configuration>

--- a/src/Syrtis.Installer/ExitCodes.cs
+++ b/src/Syrtis.Installer/ExitCodes.cs
@@ -1,0 +1,23 @@
+namespace Syrtis.Installer;
+
+/// <summary>Every exit code this process returns, named at one place instead
+/// of scattered as magic numbers across Program and WizardForm. Moved here
+/// from <c>Program.LaunchFailedExitCode</c> so WizardForm no longer needs a
+/// reference to Program just to report a launch failure.</summary>
+internal static class ExitCodes
+{
+    /// <summary>Ran to completion — Setup's own exit code (RunSilent, or
+    /// --self-check with every assertion passing) or a wizard closed
+    /// normally.</summary>
+    internal const int Ok = 0;
+
+    /// <summary>The arguments were rejected before anything ran: no setup
+    /// path, the setup file was not found, an unexpected extra argument, or
+    /// --self-check found a broken assertion.</summary>
+    internal const int BadArguments = 1;
+
+    /// <summary>Setup.exe could not be started at all, as opposed to starting
+    /// and failing. Kept away from 1 (bad or missing argument) and from
+    /// Setup's own small positive codes.</summary>
+    internal const int LaunchFailed = -1;
+}

--- a/src/Syrtis.Installer/InstallPath.cs
+++ b/src/Syrtis.Installer/InstallPath.cs
@@ -1,0 +1,74 @@
+namespace Syrtis.Installer;
+
+/// <summary>Validation for a per-user install directory typed on the Location
+/// page. Moved out of WizardForm unchanged so it can be exercised by
+/// --self-check on the framework that actually ships (net48's Path APIs throw
+/// on invalid characters where .NET Core's do not — see the comment inside
+/// IsValidInstallPath). Not part of TokenBar.Core.Tests: that suite is net10
+/// and also runs on macOS, where this method's Windows path semantics do not
+/// hold and would be green for the wrong reason or red in the inner loop.</summary>
+internal static class InstallPath
+{
+    /// <summary>A "usable absolute directory path": rooted, and syntactically
+    /// well-formed (Path.GetFullPath does not throw). Whether it can actually
+    /// be created is left to Setup.exe, which reports failure through its
+    /// exit code on the Done page — this is user-typing feedback, not a
+    /// filesystem permission check.</summary>
+    internal static bool IsValidInstallPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        // EVERY System.IO.Path call belongs inside this try. On .NET Framework
+        // — measured, not assumed, on 4.8.9337.0 — IsPathRooted and GetPathRoot
+        // both call CheckInvalidPathChars and throw ArgumentException, so a
+        // single quote in C:\bad" throws from all three of these. This runs
+        // from TextChanged on the UI thread, so one outside the guard is an
+        // unhandled exception on a keystroke rather than the invalid-path hint.
+        // .NET Core stopped throwing from these; that is not the target here.
+        try
+        {
+            if (!Path.IsPathRooted(path))
+            {
+                return false;
+            }
+
+            // Rooted is not the same as fully qualified, and there is more than
+            // one way to be rooted without naming a volume. .NET Framework has
+            // no Path.IsPathFullyQualified (that arrived in .NET Core 2.1), so
+            // the test is on the root, and it is a whitelist: the root must
+            // identify a volume. An earlier revision listed the bad shapes
+            // instead and shipped with the second one still open.
+            //
+            // Measured on 4.8.9337.0, process directory C:\Users\Nanako:
+            //
+            //   "C:\ok"          root "C:\"          -> qualified
+            //   "\\srv\share\x"  root "\\srv\share"  -> qualified
+            //   "C:"             root "C:"           -> C:\Users\Nanako
+            //   "\Syrtis"        root "\"            -> C:\Syrtis
+            //   "/Syrtis"        root "\"            -> C:\Syrtis
+            //
+            // The last three are the trap: every one of them passes
+            // IsPathRooted and resolves silently against the process's current
+            // drive or directory, so the user reads an absolute path and Setup
+            // installs somewhere they never named. GetPathRoot normalises "//"
+            // to "\\", so the UNC test needs only the one form.
+            var root = Path.GetPathRoot(path);
+            var namesAVolume =
+                (root.Length >= 3 && root[1] == ':')
+                || root.StartsWith(@"\\", StringComparison.Ordinal);
+            if (!namesAVolume)
+            {
+                return false;
+            }
+
+            Path.GetFullPath(path);
+            return true;
+        }
+        catch (ArgumentException) { return false; }
+        catch (NotSupportedException) { return false; }
+        catch (PathTooLongException) { return false; }
+    }
+}

--- a/src/Syrtis.Installer/InstallRequest.cs
+++ b/src/Syrtis.Installer/InstallRequest.cs
@@ -24,6 +24,19 @@ internal enum RefusalReason
     /// <summary>An argument was present that this parser does not recognise:
     /// a second non-switch argument, or anything alongside --self-check.</summary>
     UnexpectedArgument,
+
+    /// <summary>A switch this wrapper does not support — anything beginning
+    /// with '-' that is not -s, --silent or --self-check.
+    ///
+    /// <para>Separate from UnexpectedArgument because the refusal path exists
+    /// to protect exactly the case where slice 1b puts this under Setup.exe's
+    /// own filename and an existing script arrives carrying Setup's options.
+    /// Without this, "--installto D:\X" refused while naming "D:\X" — both
+    /// tokens are non-switches to a parser that only knows -s, so the second
+    /// one looked like the surplus — and a lone "-v" was reported as a missing
+    /// setup file. The right token was refused for the wrong stated reason,
+    /// which is the least useful place to be precise.</para></summary>
+    UnsupportedSwitch,
 }
 
 /// <summary>The single parsed shape of the process's command line, produced
@@ -68,7 +81,8 @@ internal readonly struct InstallRequest
     internal RefusalReason Reason { get; }
 
     /// <summary>The offending argument, when Reason names one
-    /// (SetupNotFound, UnexpectedArgument). Null for NoSetupPath.</summary>
+    /// (SetupNotFound, UnexpectedArgument, UnsupportedSwitch). Null for
+    /// NoSetupPath.</summary>
     internal string? Token { get; }
 
     /// <summary>Whether -s / --silent / -S was present anywhere in the
@@ -94,6 +108,21 @@ internal readonly struct InstallRequest
             var otherToken = args.FirstOrDefault(a => !a.Equals(SelfCheckSwitch, StringComparison.OrdinalIgnoreCase))
                 ?? SelfCheckSwitch;
             return Refuse(RefusalReason.UnexpectedArgument, otherToken, silentRequested);
+        }
+
+        // Before anything positional. A Windows path never begins with '-',
+        // so this is unambiguous, and it is the only test that can tell
+        // "--installto D:\X" (an unsupported switch and its value) from
+        // "setup.exe extra.exe" (two paths). Only '-' is treated as a switch
+        // marker: '/x' is a valid rooted Windows path, and Velopack's own
+        // options are all '-' or '--'.
+        var unsupportedSwitch = args.FirstOrDefault(a =>
+            a.StartsWith("-", StringComparison.Ordinal)
+            && !SetupLocator.IsSilentSwitch(a)
+            && !a.Equals(SelfCheckSwitch, StringComparison.OrdinalIgnoreCase));
+        if (unsupportedSwitch != null)
+        {
+            return Refuse(RefusalReason.UnsupportedSwitch, unsupportedSwitch, silentRequested);
         }
 
         var nonSwitchArgs = args.Where(a => !SetupLocator.IsSilentSwitch(a)).ToArray();

--- a/src/Syrtis.Installer/InstallRequest.cs
+++ b/src/Syrtis.Installer/InstallRequest.cs
@@ -1,0 +1,123 @@
+namespace Syrtis.Installer;
+
+/// <summary>Which of the four things this process was asked to do.</summary>
+internal enum InstallRequestKind
+{
+    RunWizard,
+    RunSilent,
+    SelfCheck,
+    Refuse,
+}
+
+/// <summary>Why a Refuse request was refused. An enum plus the offending
+/// token, never a rendered sentence — see InstallRequest's own remarks for
+/// why. The message is rendered at the call site (Program.RenderRefusal),
+/// from this pair.</summary>
+internal enum RefusalReason
+{
+    /// <summary>No non-switch argument was given at all.</summary>
+    NoSetupPath,
+
+    /// <summary>A candidate setup path was given but does not exist on disk.</summary>
+    SetupNotFound,
+
+    /// <summary>An argument was present that this parser does not recognise:
+    /// a second non-switch argument, or anything alongside --self-check.</summary>
+    UnexpectedArgument,
+}
+
+/// <summary>The single parsed shape of the process's command line, produced
+/// once by <see cref="Parse"/> and read by every consumer (Main, RunSilent,
+/// RunGui, MissingSetupMessage, Fail) instead of each re-deriving its own
+/// answer from <c>args</c>. That re-derivation is exactly how finding round 8
+/// happened: Program took the first non-switch argument as the setup path,
+/// SetupLocator parsed the same array again, and Fail re-ran
+/// <c>args.Any(IsSilentSwitch)</c> a fourth time to choose its surface.
+///
+/// <para><b>--self-check is a mode, not a path.</b> Without this being its own
+/// case, the parser above would take it as the first non-switch argument and
+/// report "Setup file not found: --self-check" — the exact collision this
+/// slice's own new switch would otherwise create with this slice's own
+/// refusal logic.</para>
+///
+/// <para><b>A refusal carries a reason, not a rendered sentence.</b> If it
+/// carried only a string, no test could tell NoSetupPath, SetupNotFound and
+/// UnexpectedArgument apart without reading a culture-dependent
+/// <see cref="Strings"/> member — which the project's own testing constraint
+/// forbids. The three are exactly what findings 4, 5 and 7 turned on.</para></summary>
+internal readonly struct InstallRequest
+{
+    private const string SelfCheckSwitch = "--self-check";
+
+    private InstallRequest(InstallRequestKind kind, string? setupPath, RefusalReason reason, string? token, bool silentRequested)
+    {
+        Kind = kind;
+        SetupPath = setupPath;
+        Reason = reason;
+        Token = token;
+        SilentRequested = silentRequested;
+    }
+
+    internal InstallRequestKind Kind { get; }
+
+    /// <summary>The resolved, existing setup path. Non-null exactly when
+    /// Kind is RunWizard or RunSilent.</summary>
+    internal string? SetupPath { get; }
+
+    /// <summary>Meaningful only when Kind is Refuse.</summary>
+    internal RefusalReason Reason { get; }
+
+    /// <summary>The offending argument, when Reason names one
+    /// (SetupNotFound, UnexpectedArgument). Null for NoSetupPath.</summary>
+    internal string? Token { get; }
+
+    /// <summary>Whether -s / --silent / -S was present anywhere in the
+    /// original arguments, independent of Kind. Fail reads this to choose its
+    /// surface (dialog vs stderr) even for a Refuse request, without
+    /// re-deriving it from args a fourth time.</summary>
+    internal bool SilentRequested { get; }
+
+    private static InstallRequest Refuse(RefusalReason reason, string? token, bool silentRequested) =>
+        new(InstallRequestKind.Refuse, null, reason, token, silentRequested);
+
+    internal static InstallRequest Parse(string[] args)
+    {
+        var silentRequested = args.Any(SetupLocator.IsSilentSwitch);
+
+        if (args.Any(a => a.Equals(SelfCheckSwitch, StringComparison.OrdinalIgnoreCase)))
+        {
+            if (args.Length == 1)
+            {
+                return new InstallRequest(InstallRequestKind.SelfCheck, null, default, null, silentRequested);
+            }
+
+            var otherToken = args.FirstOrDefault(a => !a.Equals(SelfCheckSwitch, StringComparison.OrdinalIgnoreCase))
+                ?? SelfCheckSwitch;
+            return Refuse(RefusalReason.UnexpectedArgument, otherToken, silentRequested);
+        }
+
+        var nonSwitchArgs = args.Where(a => !SetupLocator.IsSilentSwitch(a)).ToArray();
+        if (nonSwitchArgs.Length > 1)
+        {
+            return Refuse(RefusalReason.UnexpectedArgument, nonSwitchArgs[1], silentRequested);
+        }
+
+        var candidate = nonSwitchArgs.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return Refuse(RefusalReason.NoSetupPath, null, silentRequested);
+        }
+
+        // Reuses SetupLocator's own resolution (existence check + GetFullPath)
+        // rather than repeating it — the exact duplication this slice exists
+        // to remove.
+        var setupPath = SetupLocator.Locate(args);
+        if (setupPath == null)
+        {
+            return Refuse(RefusalReason.SetupNotFound, candidate, silentRequested);
+        }
+
+        var kind = silentRequested ? InstallRequestKind.RunSilent : InstallRequestKind.RunWizard;
+        return new InstallRequest(kind, setupPath, default, null, silentRequested);
+    }
+}

--- a/src/Syrtis.Installer/PayloadIdentity.cs
+++ b/src/Syrtis.Installer/PayloadIdentity.cs
@@ -1,0 +1,35 @@
+namespace Syrtis.Installer;
+
+/// <summary>Choosing what the Welcome page says it is about to install.
+///
+/// <para>Split out from <see cref="WizardForm"/> for one reason: reading a
+/// PE file's version resource cannot be tested from
+/// <c>TokenBar.Core.Tests</c>, but deciding what to do with what comes back
+/// can be, and the deciding is where the mistake was. The wizard read both
+/// halves of "will install {product} version {version}" from its own assembly,
+/// which is a claim about the wrapper dressed as a claim about the
+/// payload.</para></summary>
+internal static class PayloadIdentity
+{
+    /// <summary>The payload's own answer when it has one, this wrapper's when
+    /// it does not, and a constant when neither does.
+    ///
+    /// <para>Whitespace counts as absent. A version resource that exists but
+    /// is blank is common enough in stub executables, and " version  " on the
+    /// Welcome page reads as a bug rather than as a missing value.</para>
+    /// </summary>
+    internal static string Choose(string? fromPayload, string? fromWrapper, string fallback)
+    {
+        if (!string.IsNullOrWhiteSpace(fromPayload))
+        {
+            return fromPayload!.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(fromWrapper))
+        {
+            return fromWrapper!.Trim();
+        }
+
+        return fallback;
+    }
+}

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -70,7 +70,7 @@ internal static class Program
         try
         {
             var result = SetupRunner.Run(
-                setupPath, SetupRunner.DefaultInstallDirectory, SetupRunner.DefaultLogPath);
+                setupPath, SetupRunner.DefaultInstallDirectory, SetupRunner.NewLogPath());
             return result.ExitCode;
         }
         // Catch breadth deliberately matches the GUI path's task.IsFaulted,

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -14,7 +14,21 @@ internal static class Program
 
     /// <summary>No window at all: runs Setup against the default per-user
     /// directory and propagates its exit code. Must not construct any UI
-    /// type, so this path never touches System.Windows.Forms.</summary>
+    /// type, so this path never touches System.Windows.Forms.
+    ///
+    /// <para><b>Known limitation, deferred to slice 1b.</b> This assembly is a
+    /// WinExe, so it is a Windows-subsystem process and does not attach the
+    /// parent's console. Standard handles are inherited when they are pipes or
+    /// files — which is why every measurement of these messages has shown them,
+    /// including the ones taken over SSH — but a person typing this in a real
+    /// console window gets the exit code and no text. The contract this branch
+    /// actually makes is the exit code (1 never reached Setup, -1 could not
+    /// start it, anything else is Setup's own), and that holds everywhere; the
+    /// text is a convenience that is present exactly when something is
+    /// capturing it. Making it unconditional means AttachConsole
+    /// (ATTACH_PARENT_PROCESS), which cannot be verified from a remote session
+    /// for the same reason the defect cannot be reproduced there, so it waits
+    /// for 1b and a real console.</para></summary>
     private static int RunSilent(string[] args)
     {
         var setupPath = SetupLocator.Locate(args);

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -108,6 +108,7 @@ internal static class Program
         RefusalReason.NoSetupPath => Strings.ErrorNoSetupPathArg,
         RefusalReason.SetupNotFound => Strings.ErrorSetupNotFound(request.Token!),
         RefusalReason.UnexpectedArgument => Strings.ErrorUnexpectedArg(request.Token!),
+        RefusalReason.UnsupportedSwitch => Strings.ErrorUnsupportedSwitch(request.Token!),
         _ => throw new InvalidOperationException($"Unknown refusal reason: {request.Reason}"),
     };
 }

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace Syrtis.Installer;
@@ -8,8 +7,39 @@ internal static class Program
     [STAThread]
     private static int Main(string[] args)
     {
+        // Reject what we do not understand before doing anything with it. The
+        // wizard used to take the first non-switch argument as the setup path
+        // and drop everything else on the floor, so
+        // "--silent setup.exe --installto D:\X" installed to the default
+        // directory and said nothing at all. Slice 1b publishes this under
+        // Setup.exe's own filename, and Setup does support --installto, so a
+        // script carrying one would have been silently disobeyed — the worst
+        // available outcome for an unattended install.
+        var extra = args.Where(a => !SetupLocator.IsSilentSwitch(a)).Skip(1).FirstOrDefault();
+        if (extra != null)
+        {
+            return Fail(Strings.ErrorUnexpectedArg(extra), args);
+        }
+
         var silent = args.Any(SetupLocator.IsSilentSwitch);
         return silent ? RunSilent(args) : RunGui(args);
+    }
+
+    /// <summary>Report a startup problem on whichever surface exists, and
+    /// exit 1. Interactive gets a dialog; anything else gets stderr, which is
+    /// subject to the console limitation documented on RunSilent.</summary>
+    private static int Fail(string message, string[] args)
+    {
+        if (!args.Any(SetupLocator.IsSilentSwitch) && Environment.UserInteractive)
+        {
+            MessageBox.Show(message, Strings.WindowTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        else
+        {
+            Console.Error.WriteLine(message);
+        }
+
+        return 1;
     }
 
     /// <summary>No window at all: runs Setup against the default per-user
@@ -48,16 +78,19 @@ internal static class Program
         // interactive wizard cannot. The GUI path already turns the same
         // failure into its Done page via task.IsFaulted; this is the headless
         // equivalent.
-        //
-        // Win32Exception lives in System.dll, not System.Windows.Forms.dll, so
-        // catching it here does not put a UI type on this path.
         try
         {
             var result = SetupRunner.Run(
                 setupPath, SetupRunner.DefaultInstallDirectory, SetupRunner.DefaultLogPath);
             return result.ExitCode;
         }
-        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException)
+        // Catch breadth deliberately matches the GUI path's task.IsFaulted,
+        // which catches everything. Naming two exception types here left
+        // UnauthorizedAccessException and anything else still exiting
+        // -532462766 — the same crash this branch exists to prevent, narrowed
+        // rather than removed. The contract is a stable exit code, so nothing
+        // Process.Start can raise may escape it.
+        catch (Exception ex)
         {
             Console.Error.WriteLine(Strings.ErrorSetupLaunchFailed(setupPath, ex.Message));
             // -1 rather than 1: 1 already means "we never got as far as

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -1,0 +1,64 @@
+using System.Windows.Forms;
+
+namespace Syrtis.Installer;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        var silent = args.Any(a => a.Equals("--silent", StringComparison.OrdinalIgnoreCase));
+        return silent ? RunSilent(args) : RunGui(args);
+    }
+
+    /// <summary>No window at all: runs Setup against the default per-user
+    /// directory and propagates its exit code. Must not construct any UI
+    /// type, so this path never touches System.Windows.Forms.</summary>
+    private static int RunSilent(string[] args)
+    {
+        var setupPath = SetupLocator.Locate(args);
+        if (setupPath == null)
+        {
+            Console.Error.WriteLine(MissingSetupMessage(args));
+            return 1;
+        }
+
+        var result = SetupRunner.Run(setupPath, SetupRunner.DefaultInstallDirectory, SetupRunner.DefaultLogPath);
+        return result.ExitCode;
+    }
+
+    private static int RunGui(string[] args)
+    {
+        var setupPath = SetupLocator.Locate(args);
+        if (setupPath == null)
+        {
+            var message = MissingSetupMessage(args);
+            // MessageBox needs a window station/desktop (Environment.UserInteractive);
+            // without one it throws instead of showing anything, which would
+            // turn "no argument" into a crash. Console is the fallback there.
+            if (Environment.UserInteractive)
+            {
+                MessageBox.Show(message, Strings.WindowTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            else
+            {
+                Console.Error.WriteLine(message);
+            }
+
+            return 1;
+        }
+
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.Run(new WizardForm(setupPath));
+        return 0;
+    }
+
+    private static string MissingSetupMessage(string[] args)
+    {
+        var candidate = args.FirstOrDefault(a => !a.Equals("--silent", StringComparison.OrdinalIgnoreCase));
+        return string.IsNullOrWhiteSpace(candidate)
+            ? Strings.ErrorNoSetupPathArg
+            : Strings.ErrorSetupNotFound(candidate);
+    }
+}

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -7,30 +7,24 @@ internal static class Program
     [STAThread]
     private static int Main(string[] args)
     {
-        // Reject what we do not understand before doing anything with it. The
-        // wizard used to take the first non-switch argument as the setup path
-        // and drop everything else on the floor, so
-        // "--silent setup.exe --installto D:\X" installed to the default
-        // directory and said nothing at all. Slice 1b publishes this under
-        // Setup.exe's own filename, and Setup does support --installto, so a
-        // script carrying one would have been silently disobeyed — the worst
-        // available outcome for an unattended install.
-        var extra = args.Where(a => !SetupLocator.IsSilentSwitch(a)).Skip(1).FirstOrDefault();
-        if (extra != null)
+        var request = InstallRequest.Parse(args);
+        return request.Kind switch
         {
-            return Fail(Strings.ErrorUnexpectedArg(extra), args);
-        }
-
-        var silent = args.Any(SetupLocator.IsSilentSwitch);
-        return silent ? RunSilent(args) : RunGui(args);
+            InstallRequestKind.SelfCheck => SelfCheck.Run(),
+            InstallRequestKind.Refuse => Fail(request),
+            InstallRequestKind.RunSilent => RunSilent(request),
+            InstallRequestKind.RunWizard => RunGui(request),
+            _ => throw new InvalidOperationException($"Unknown request kind: {request.Kind}"),
+        };
     }
 
     /// <summary>Report a startup problem on whichever surface exists, and
     /// exit 1. Interactive gets a dialog; anything else gets stderr, which is
     /// subject to the console limitation documented on RunSilent.</summary>
-    private static int Fail(string message, string[] args)
+    private static int Fail(InstallRequest request)
     {
-        if (!args.Any(SetupLocator.IsSilentSwitch) && Environment.UserInteractive)
+        var message = MissingSetupMessage(request);
+        if (!request.SilentRequested && Environment.UserInteractive)
         {
             MessageBox.Show(message, Strings.WindowTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
@@ -39,7 +33,7 @@ internal static class Program
             Console.Error.WriteLine(message);
         }
 
-        return 1;
+        return ExitCodes.BadArguments;
     }
 
     /// <summary>No window at all: runs Setup against the default per-user
@@ -59,16 +53,11 @@ internal static class Program
     /// (ATTACH_PARENT_PROCESS), which cannot be verified from a remote session
     /// for the same reason the defect cannot be reproduced there, so it waits
     /// for 1b and a real console.</para></summary>
-    private static int RunSilent(string[] args)
+    private static int RunSilent(InstallRequest request)
     {
-        var setupPath = SetupLocator.Locate(args);
-        if (setupPath == null)
-        {
-            Console.Error.WriteLine(MissingSetupMessage(args));
-            return 1;
-        }
+        var setupPath = request.SetupPath!;
 
-        // Locate only proves the file is there. Windows can still refuse to
+        // Locate only proved the file is there. Windows can still refuse to
         // run it — quarantined between the check and here, blocked by policy,
         // permissions changed, or simply not an executable — and Process.Start
         // then throws. Measured: --silent against an existing .txt exited
@@ -93,51 +82,32 @@ internal static class Program
         catch (Exception ex)
         {
             Console.Error.WriteLine(Strings.ErrorSetupLaunchFailed(setupPath, ex.Message));
-            // -1 rather than 1: 1 already means "we never got as far as
-            // running it", and Setup's own codes are small positives, so a
-            // caller can tell "Setup failed" from "Setup never started".
-            // Matches the code the GUI path records for a faulted launch.
-            return LaunchFailedExitCode;
+            // LaunchFailed rather than BadArguments: BadArguments already means
+            // "we never got as far as running it", and Setup's own codes are
+            // small positives, so a caller can tell "Setup failed" from "Setup
+            // never started". Matches the code the GUI path records for a
+            // faulted launch.
+            return ExitCodes.LaunchFailed;
         }
     }
 
-    /// <summary>Returned when Setup.exe could not be started at all, as
-    /// opposed to starting and failing. Kept away from 1 (bad or missing
-    /// argument) and from Setup's own small positive codes.</summary>
-    internal const int LaunchFailedExitCode = -1;
-
-    private static int RunGui(string[] args)
+    private static int RunGui(InstallRequest request)
     {
-        var setupPath = SetupLocator.Locate(args);
-        if (setupPath == null)
-        {
-            var message = MissingSetupMessage(args);
-            // MessageBox needs a window station/desktop (Environment.UserInteractive);
-            // without one it throws instead of showing anything, which would
-            // turn "no argument" into a crash. Console is the fallback there.
-            if (Environment.UserInteractive)
-            {
-                MessageBox.Show(message, Strings.WindowTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-            else
-            {
-                Console.Error.WriteLine(message);
-            }
-
-            return 1;
-        }
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
-        Application.Run(new WizardForm(setupPath));
-        return 0;
+        Application.Run(new WizardForm(request.SetupPath!));
+        return ExitCodes.Ok;
     }
 
-    private static string MissingSetupMessage(string[] args)
+    /// <summary>Renders a Refuse request's reason + token pair into the
+    /// sentence a person reads. Kept separate from InstallRequest itself so
+    /// that parsing never touches Strings, and so a test can assert the
+    /// reason/token pair without going through culture-dependent text.</summary>
+    private static string MissingSetupMessage(InstallRequest request) => request.Reason switch
     {
-        var candidate = args.FirstOrDefault(a => !SetupLocator.IsSilentSwitch(a));
-        return string.IsNullOrWhiteSpace(candidate)
-            ? Strings.ErrorNoSetupPathArg
-            : Strings.ErrorSetupNotFound(candidate);
-    }
+        RefusalReason.NoSetupPath => Strings.ErrorNoSetupPathArg,
+        RefusalReason.SetupNotFound => Strings.ErrorSetupNotFound(request.Token!),
+        RefusalReason.UnexpectedArgument => Strings.ErrorUnexpectedArg(request.Token!),
+        _ => throw new InvalidOperationException($"Unknown refusal reason: {request.Reason}"),
+    };
 }

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -8,7 +8,7 @@ internal static class Program
     [STAThread]
     private static int Main(string[] args)
     {
-        var silent = args.Any(a => a.Equals("--silent", StringComparison.OrdinalIgnoreCase));
+        var silent = args.Any(SetupLocator.IsSilentSwitch);
         return silent ? RunSilent(args) : RunGui(args);
     }
 
@@ -88,7 +88,7 @@ internal static class Program
 
     private static string MissingSetupMessage(string[] args)
     {
-        var candidate = args.FirstOrDefault(a => !a.Equals("--silent", StringComparison.OrdinalIgnoreCase));
+        var candidate = args.FirstOrDefault(a => !SetupLocator.IsSilentSwitch(a));
         return string.IsNullOrWhiteSpace(candidate)
             ? Strings.ErrorNoSetupPathArg
             : Strings.ErrorSetupNotFound(candidate);

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace Syrtis.Installer;
@@ -23,9 +24,40 @@ internal static class Program
             return 1;
         }
 
-        var result = SetupRunner.Run(setupPath, SetupRunner.DefaultInstallDirectory, SetupRunner.DefaultLogPath);
-        return result.ExitCode;
+        // Locate only proves the file is there. Windows can still refuse to
+        // run it — quarantined between the check and here, blocked by policy,
+        // permissions changed, or simply not an executable — and Process.Start
+        // then throws. Measured: --silent against an existing .txt exited
+        // -532462766 (0xE0434352, unhandled managed exception) with a
+        // Win32Exception on stderr. That defeats the entire point of this
+        // branch, which exists so that scripted installs keep working when the
+        // interactive wizard cannot. The GUI path already turns the same
+        // failure into its Done page via task.IsFaulted; this is the headless
+        // equivalent.
+        //
+        // Win32Exception lives in System.dll, not System.Windows.Forms.dll, so
+        // catching it here does not put a UI type on this path.
+        try
+        {
+            var result = SetupRunner.Run(
+                setupPath, SetupRunner.DefaultInstallDirectory, SetupRunner.DefaultLogPath);
+            return result.ExitCode;
+        }
+        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException)
+        {
+            Console.Error.WriteLine(Strings.ErrorSetupLaunchFailed(setupPath, ex.Message));
+            // -1 rather than 1: 1 already means "we never got as far as
+            // running it", and Setup's own codes are small positives, so a
+            // caller can tell "Setup failed" from "Setup never started".
+            // Matches the code the GUI path records for a faulted launch.
+            return LaunchFailedExitCode;
+        }
     }
+
+    /// <summary>Returned when Setup.exe could not be started at all, as
+    /// opposed to starting and failing. Kept away from 1 (bad or missing
+    /// argument) and from Setup's own small positive codes.</summary>
+    internal const int LaunchFailedExitCode = -1;
 
     private static int RunGui(string[] args)
     {

--- a/src/Syrtis.Installer/SelfCheck.cs
+++ b/src/Syrtis.Installer/SelfCheck.cs
@@ -1,0 +1,47 @@
+namespace Syrtis.Installer;
+
+/// <summary>Runs on the framework that actually ships, via the hidden
+/// --self-check switch, so InstallPath's net48-only behaviour (Path APIs
+/// throwing on invalid characters, where .NET Core's do not) is pinned
+/// somewhere runnable — TokenBar.Core.Tests is net10 and also runs on macOS,
+/// so it cannot see this. Not wired into CI yet; runnable by hand on the
+/// Windows host. Deliberately not testable from Core.Tests, and deliberately
+/// not pulled into it — see InstallPath's own remarks.</summary>
+internal static class SelfCheck
+{
+    internal static int Run()
+    {
+        var failures = new List<string>();
+
+        void Expect(string label, bool actual, bool expected)
+        {
+            if (actual != expected)
+            {
+                failures.Add($"{label}: expected {expected}, got {actual}");
+            }
+        }
+
+        // Rooted but not fully qualified — resolves silently against the
+        // process's current drive/directory (finding: the whitelist trap
+        // documented on InstallPath.IsValidInstallPath). Must be rejected.
+        Expect("IsValidInstallPath(\"C:\")", InstallPath.IsValidInstallPath("C:"), false);
+        Expect("IsValidInstallPath(\"\\Syrtis\")", InstallPath.IsValidInstallPath(@"\Syrtis"), false);
+
+        // Genuinely rooted at a volume. Must be accepted.
+        Expect("IsValidInstallPath(\"C:\\ok\")", InstallPath.IsValidInstallPath(@"C:\ok"), true);
+        Expect("IsValidInstallPath(\"\\\\srv\\share\\x\")", InstallPath.IsValidInstallPath(@"\\srv\share\x"), true);
+
+        // On .NET Framework, Path.IsPathRooted/GetPathRoot throw
+        // ArgumentException for these; IsValidInstallPath must catch and
+        // report them as invalid, not let the exception escape.
+        Expect("IsValidInstallPath(quote)", InstallPath.IsValidInstallPath("C:\\bad\"path"), false);
+        Expect("IsValidInstallPath(pipe)", InstallPath.IsValidInstallPath("C:\\bad|path"), false);
+
+        foreach (var failure in failures)
+        {
+            Console.Error.WriteLine(failure);
+        }
+
+        return failures.Count == 0 ? ExitCodes.Ok : ExitCodes.BadArguments;
+    }
+}

--- a/src/Syrtis.Installer/SetupLocator.cs
+++ b/src/Syrtis.Installer/SetupLocator.cs
@@ -1,0 +1,20 @@
+namespace Syrtis.Installer;
+
+/// <summary>Where Velopack's Setup.exe comes from. Slice 1a takes it as a
+/// command-line argument; slice 1b will embed it in the wizard exe instead.
+/// Keeping the lookup in this one method is the seam 1b swaps.</summary>
+internal static class SetupLocator
+{
+    /// <summary>Resolves the path to Setup.exe from the process arguments, or
+    /// null if none was given / the given path does not exist.</summary>
+    internal static string? Locate(string[] args)
+    {
+        var path = args.FirstOrDefault(a => !a.Equals("--silent", StringComparison.OrdinalIgnoreCase));
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+        {
+            return null;
+        }
+
+        return Path.GetFullPath(path);
+    }
+}

--- a/src/Syrtis.Installer/SetupLocator.cs
+++ b/src/Syrtis.Installer/SetupLocator.cs
@@ -5,11 +5,26 @@ namespace Syrtis.Installer;
 /// Keeping the lookup in this one method is the seam 1b swaps.</summary>
 internal static class SetupLocator
 {
+    /// <summary>Whether an argument is the silent switch, in either of the two
+    /// forms Velopack's own Setup.exe documents (<c>-s, --silent</c> in its
+    /// --help output).
+    ///
+    /// <para>This lives here, and both this class and Program call it, because
+    /// the test was previously written out twice against the same literal and
+    /// the two copies disagreed the moment <c>-s</c> was added: Program would
+    /// have taken the interactive path while Locate treated <c>-s</c> as the
+    /// setup file. Slice 1b publishes this wrapper under Setup.exe's own
+    /// filename, so a script that already says <c>Setup.exe -s</c> has to keep
+    /// working.</para></summary>
+    internal static bool IsSilentSwitch(string arg) =>
+        arg.Equals("--silent", StringComparison.OrdinalIgnoreCase)
+        || arg.Equals("-s", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>Resolves the path to Setup.exe from the process arguments, or
     /// null if none was given / the given path does not exist.</summary>
     internal static string? Locate(string[] args)
     {
-        var path = args.FirstOrDefault(a => !a.Equals("--silent", StringComparison.OrdinalIgnoreCase));
+        var path = args.FirstOrDefault(a => !IsSilentSwitch(a));
         if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
         {
             return null;

--- a/src/Syrtis.Installer/SetupRunner.cs
+++ b/src/Syrtis.Installer/SetupRunner.cs
@@ -29,8 +29,43 @@ internal static class SetupRunner
     internal static string DefaultInstallDirectory =>
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Nyanako.Syrtis");
 
-    internal static string DefaultLogPath =>
-        Path.Combine(Path.GetTempPath(), "syrtis-install.log");
+    /// <summary>A log path belonging to this run and no other.
+    ///
+    /// <para>It used to be a fixed <c>syrtis-install.log</c>, and two separate
+    /// defects came out of that one name. The first was staleness: a leftover
+    /// from an earlier install passes an existence check, so a failure could be
+    /// explained with an unrelated — possibly successful — run's record. That
+    /// was answered with a last-write comparison against the launch instant,
+    /// which was the wrong shape of answer. The second showed why: two wrapper
+    /// instances can overlap, a double-click while an automated
+    /// <c>--silent</c> run is in flight, and then both children write the same
+    /// file. A write by either satisfies the other's timestamp test, because a
+    /// timestamp establishes "written after I started" and never "written by my
+    /// child".</para>
+    ///
+    /// <para>No inference distinguishes those. A name that cannot collide
+    /// does, by construction, and it makes the question unaskable rather than
+    /// answerable — which is the same move as parsing the request once instead
+    /// of deriving it in five places.</para>
+    ///
+    /// <para>Timestamp and process id lead so that someone hunting the file in
+    /// %TEMP% can recognise it, but they are not what makes it unique: the
+    /// first version stopped there, and the test written to pin it failed
+    /// immediately, because two calls in the same second from one process
+    /// produce the same name. Cross-instance uniqueness would have survived on
+    /// the process id alone — which is an argument, and the point of this
+    /// method is not to need one. The random tail settles it outright.</para>
+    ///
+    /// <para><see cref="LogWrittenByThisRun"/> stays, and is now belt to this
+    /// braces: uniqueness settles ownership, the timestamp still answers
+    /// whether Setup got far enough to write anything at all.</para></summary>
+    internal static string NewLogPath() =>
+        Path.Combine(
+            Path.GetTempPath(),
+            $"syrtis-install-{DateTime.UtcNow:yyyyMMdd-HHmmss}"
+                + $"-{Process.GetCurrentProcess().Id}"
+                + $"-{Guid.NewGuid():N}".Substring(0, 9)
+                + ".log");
 
     /// <summary>Wrap one value for a Windows command line.
     ///
@@ -90,12 +125,13 @@ internal static class SetupRunner
     /// <summary>The log path when this run wrote it, null otherwise.
     ///
     /// <para>An existence check is not enough and was shipped once believing
-    /// it was. <see cref="DefaultLogPath"/> is a fixed name in %TEMP%, so a
-    /// file being there says nothing about which install put it there — the
-    /// test machine had a two-day-old copy at exactly that path. Setup can
-    /// start and fail before opening the log, and the Done page would then
-    /// have offered an unrelated, possibly successful, install's record as the
-    /// explanation for this failure.</para>
+    /// it was. Setup can start and fail before it ever opens the log, and an
+    /// existence check cannot see that — the test machine had a two-day-old
+    /// copy at the fixed path this used to use, so the Done page would have
+    /// offered an unrelated run's record as the explanation for a failure.
+    /// <see cref="NewLogPath"/> now removes the ownership half of that
+    /// question; this answers the remaining half, which is whether Setup wrote
+    /// anything at all.</para>
     ///
     /// <para>Deleting the old file before launching was the alternative. This
     /// does not touch the user's disk and has no failure mode of its own: if

--- a/src/Syrtis.Installer/SetupRunner.cs
+++ b/src/Syrtis.Installer/SetupRunner.cs
@@ -3,10 +3,17 @@ using System.Diagnostics;
 namespace Syrtis.Installer;
 
 /// <summary>Result of one Setup.exe invocation.</summary>
-internal readonly struct SetupRunResult(int exitCode, string logPath)
+internal readonly struct SetupRunResult(int exitCode, string logPath, string? launchError = null)
 {
     internal int ExitCode { get; } = exitCode;
     internal string LogPath { get; } = logPath;
+
+    /// <summary>Why Setup could not be <em>started</em>, or null when it ran.
+    /// The distinction matters to what the Done page may say: when Setup never
+    /// started it also never opened the log, so pointing the user at that path
+    /// shows them either nothing or — because the name is fixed — an unrelated
+    /// run from days ago.</summary>
+    internal string? LaunchError { get; } = launchError;
 }
 
 /// <summary>Invokes Velopack's Setup.exe per-user and silently against a
@@ -21,12 +28,44 @@ internal static class SetupRunner
     internal static string DefaultLogPath =>
         Path.Combine(Path.GetTempPath(), "syrtis-install.log");
 
+    /// <summary>Wrap one value for a Windows command line.
+    ///
+    /// <para>CommandLineToArgvW reads <c>\"</c> as a literal quote, so a value
+    /// ending in a backslash does not close its own quotes — it swallows
+    /// everything after it. <c>C:\</c> is exactly what FolderBrowserDialog
+    /// returns for a drive root, and typing a trailing separator is ordinary,
+    /// so this was reachable rather than theoretical. Measured on the x64 host
+    /// before the fix:</para>
+    /// <code>
+    /// --installto "C:\" --silent --log "C:\Temp\syrtis-install.log"
+    ///   argv[0] = [--installto]
+    ///   argv[1] = [C:" --silent --log C:\Temp\syrtis-install.log]
+    /// </code>
+    /// <para>Two arguments, no <c>--silent</c> and no <c>--log</c> — so Setup
+    /// would have run <b>visibly</b>, popping its own window behind a wizard
+    /// stuck on the Installing page with every button disabled and the close
+    /// box intercepted.</para>
+    ///
+    /// <para>Only the run of backslashes immediately before the closing quote
+    /// is doubled. Interior ones are literal to the parser and doubling them
+    /// would corrupt the path.</para></summary>
+    private static string Quote(string value)
+    {
+        var trailing = 0;
+        while (trailing < value.Length && value[value.Length - 1 - trailing] == '\\')
+        {
+            trailing++;
+        }
+
+        return string.Concat("\"", value, new string('\\', trailing), "\"");
+    }
+
     internal static SetupRunResult Run(string setupExePath, string installDir, string logPath)
     {
         var startInfo = new ProcessStartInfo
         {
             FileName = setupExePath,
-            Arguments = $"--installto \"{installDir}\" --silent --log \"{logPath}\"",
+            Arguments = $"--installto {Quote(installDir)} --silent --log {Quote(logPath)}",
             UseShellExecute = false,
             CreateNoWindow = true,
         };

--- a/src/Syrtis.Installer/SetupRunner.cs
+++ b/src/Syrtis.Installer/SetupRunner.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+
+namespace Syrtis.Installer;
+
+/// <summary>Result of one Setup.exe invocation.</summary>
+internal readonly struct SetupRunResult(int exitCode, string logPath)
+{
+    internal int ExitCode { get; } = exitCode;
+    internal string LogPath { get; } = logPath;
+}
+
+/// <summary>Invokes Velopack's Setup.exe per-user and silently against a
+/// chosen install directory, and reports back its exit code. Shared by both
+/// the GUI Installing page (run on a background thread) and `--silent` mode
+/// (run on the main thread, no UI ever constructed).</summary>
+internal static class SetupRunner
+{
+    internal static string DefaultInstallDirectory =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Nyanako.Syrtis");
+
+    internal static string DefaultLogPath =>
+        Path.Combine(Path.GetTempPath(), "syrtis-install.log");
+
+    internal static SetupRunResult Run(string setupExePath, string installDir, string logPath)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = setupExePath,
+            Arguments = $"--installto \"{installDir}\" --silent --log \"{logPath}\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start Setup.exe.");
+        process.WaitForExit();
+        return new SetupRunResult(process.ExitCode, logPath);
+    }
+}

--- a/src/Syrtis.Installer/SetupRunner.cs
+++ b/src/Syrtis.Installer/SetupRunner.cs
@@ -9,14 +9,13 @@ internal readonly struct SetupRunResult(int exitCode, string? logPath, string? l
 
     /// <summary>The log this run produced, or null when it produced none.
     /// Never merely "the path we asked Setup to use" — see
-    /// <see cref="SetupRunner.LogWrittenByThisRun"/>.</summary>
+    /// <see cref="SetupRunner.WrittenLog"/>.</summary>
     internal string? LogPath { get; } = logPath;
 
     /// <summary>Why Setup could not be <em>started</em>, or null when it ran.
     /// The distinction matters to what the Done page may say: when Setup never
     /// started it also never opened the log, so pointing the user at that path
-    /// shows them either nothing or — because the name is fixed — an unrelated
-    /// run from days ago.</summary>
+    /// would show them nothing at all.</summary>
     internal string? LaunchError { get; } = launchError;
 }
 
@@ -56,9 +55,11 @@ internal static class SetupRunner
     /// the process id alone — which is an argument, and the point of this
     /// method is not to need one. The random tail settles it outright.</para>
     ///
-    /// <para><see cref="LogWrittenByThisRun"/> stays, and is now belt to this
-    /// braces: uniqueness settles ownership, the timestamp still answers
-    /// whether Setup got far enough to write anything at all.</para></summary>
+    /// <para>This is also the <em>only</em> mechanism now. It was briefly
+    /// paired with a last-write comparison kept as a second line of defence,
+    /// and that was a mistake: once the name cannot collide, the timestamp adds
+    /// no information and can only be wrong. See
+    /// <see cref="WrittenLog"/>.</para></summary>
     internal static string NewLogPath() =>
         Path.Combine(
             Path.GetTempPath(),
@@ -109,40 +110,36 @@ internal static class SetupRunner
             CreateNoWindow = true,
         };
 
-        // Read the clock before starting, not after: anything Setup writes to
-        // the log necessarily happens later, so ">= startedUtc" is exactly the
-        // set of writes this run caused. DateTime.UtcNow is coarse (about 15
-        // ms) but it rounds down, so the reading can only be at or before the
-        // true launch instant, which keeps the comparison safe without a
-        // fudge factor.
-        var startedUtc = DateTime.UtcNow;
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start Setup.exe.");
         process.WaitForExit();
-        return new SetupRunResult(process.ExitCode, LogWrittenByThisRun(logPath, startedUtc));
+        return new SetupRunResult(process.ExitCode, WrittenLog(logPath));
     }
 
-    /// <summary>The log path when this run wrote it, null otherwise.
+    /// <summary>The log this run produced, or null when Setup never got far
+    /// enough to open one.
     ///
-    /// <para>An existence check is not enough and was shipped once believing
-    /// it was. Setup can start and fail before it ever opens the log, and an
-    /// existence check cannot see that — the test machine had a two-day-old
-    /// copy at the fixed path this used to use, so the Done page would have
-    /// offered an unrelated run's record as the explanation for a failure.
-    /// <see cref="NewLogPath"/> now removes the ownership half of that
-    /// question; this answers the remaining half, which is whether Setup wrote
-    /// anything at all.</para>
+    /// <para>Existence is the whole test, because <see cref="NewLogPath"/>
+    /// hands out a name no other run can hold. That was not always true: with
+    /// one fixed filename a leftover passed an existence check, which was
+    /// answered here with a last-write comparison against the launch instant,
+    /// and then uniqueness was added on top and the comparison kept as a
+    /// second line of defence.</para>
     ///
-    /// <para>Deleting the old file before launching was the alternative. This
-    /// does not touch the user's disk and has no failure mode of its own: if
-    /// the stamp cannot be read at all, the answer is "no log", which is the
-    /// safe direction.</para></summary>
-    internal static string? LogWrittenByThisRun(string logPath, DateTime startedUtc)
+    /// <para>Keeping it was wrong. Against a name that cannot collide the
+    /// comparison carries no information, and it can still be false: %TEMP% on
+    /// FAT or exFAT records write times to two-second granularity, and the
+    /// clock can step backwards mid-install. Either makes a log this run really
+    /// did write appear older than the moment the run began, and the Done page
+    /// would then report that no log exists — hiding the one artifact that
+    /// explains the failure, at the moment it is wanted. A redundant check that
+    /// can produce a false negative is not a second line of defence, it is a
+    /// second way to be wrong.</para></summary>
+    internal static string? WrittenLog(string logPath)
     {
         try
         {
-            var info = new FileInfo(logPath);
-            return info.Exists && info.LastWriteTimeUtc >= startedUtc ? logPath : null;
+            return File.Exists(logPath) ? logPath : null;
         }
         catch (Exception)
         {

--- a/src/Syrtis.Installer/SetupRunner.cs
+++ b/src/Syrtis.Installer/SetupRunner.cs
@@ -53,7 +53,7 @@ internal static class SetupRunner
     /// <para>Only the run of backslashes immediately before the closing quote
     /// is doubled. Interior ones are literal to the parser and doubling them
     /// would corrupt the path.</para></summary>
-    private static string Quote(string value)
+    internal static string Quote(string value)
     {
         var trailing = 0;
         while (trailing < value.Length && value[value.Length - 1 - trailing] == '\\')
@@ -101,7 +101,7 @@ internal static class SetupRunner
     /// does not touch the user's disk and has no failure mode of its own: if
     /// the stamp cannot be read at all, the answer is "no log", which is the
     /// safe direction.</para></summary>
-    private static string? LogWrittenByThisRun(string logPath, DateTime startedUtc)
+    internal static string? LogWrittenByThisRun(string logPath, DateTime startedUtc)
     {
         try
         {

--- a/src/Syrtis.Installer/SetupRunner.cs
+++ b/src/Syrtis.Installer/SetupRunner.cs
@@ -3,10 +3,14 @@ using System.Diagnostics;
 namespace Syrtis.Installer;
 
 /// <summary>Result of one Setup.exe invocation.</summary>
-internal readonly struct SetupRunResult(int exitCode, string logPath, string? launchError = null)
+internal readonly struct SetupRunResult(int exitCode, string? logPath, string? launchError = null)
 {
     internal int ExitCode { get; } = exitCode;
-    internal string LogPath { get; } = logPath;
+
+    /// <summary>The log this run produced, or null when it produced none.
+    /// Never merely "the path we asked Setup to use" — see
+    /// <see cref="SetupRunner.LogWrittenByThisRun"/>.</summary>
+    internal string? LogPath { get; } = logPath;
 
     /// <summary>Why Setup could not be <em>started</em>, or null when it ran.
     /// The distinction matters to what the Done page may say: when Setup never
@@ -70,9 +74,43 @@ internal static class SetupRunner
             CreateNoWindow = true,
         };
 
+        // Read the clock before starting, not after: anything Setup writes to
+        // the log necessarily happens later, so ">= startedUtc" is exactly the
+        // set of writes this run caused. DateTime.UtcNow is coarse (about 15
+        // ms) but it rounds down, so the reading can only be at or before the
+        // true launch instant, which keeps the comparison safe without a
+        // fudge factor.
+        var startedUtc = DateTime.UtcNow;
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start Setup.exe.");
         process.WaitForExit();
-        return new SetupRunResult(process.ExitCode, logPath);
+        return new SetupRunResult(process.ExitCode, LogWrittenByThisRun(logPath, startedUtc));
+    }
+
+    /// <summary>The log path when this run wrote it, null otherwise.
+    ///
+    /// <para>An existence check is not enough and was shipped once believing
+    /// it was. <see cref="DefaultLogPath"/> is a fixed name in %TEMP%, so a
+    /// file being there says nothing about which install put it there — the
+    /// test machine had a two-day-old copy at exactly that path. Setup can
+    /// start and fail before opening the log, and the Done page would then
+    /// have offered an unrelated, possibly successful, install's record as the
+    /// explanation for this failure.</para>
+    ///
+    /// <para>Deleting the old file before launching was the alternative. This
+    /// does not touch the user's disk and has no failure mode of its own: if
+    /// the stamp cannot be read at all, the answer is "no log", which is the
+    /// safe direction.</para></summary>
+    private static string? LogWrittenByThisRun(string logPath, DateTime startedUtc)
+    {
+        try
+        {
+            var info = new FileInfo(logPath);
+            return info.Exists && info.LastWriteTimeUtc >= startedUtc ? logPath : null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 }

--- a/src/Syrtis.Installer/Strings.cs
+++ b/src/Syrtis.Installer/Strings.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+
+namespace Syrtis.Installer;
+
+/// <summary>Minimal bilingual string table for the installer wizard. This
+/// project is net48 and cannot reference TokenBar.Core's i18n (net10), so it
+/// carries its own: every user-visible string as an English/Chinese pair,
+/// picked once from <see cref="CultureInfo.CurrentUICulture"/>. No resx, no
+/// satellite assemblies — mirrors the zh-Hant/zh-TW/zh-HK/zh-MO detection in
+/// TokenBar.App's AppLanguage.Resolve.</summary>
+internal static class Strings
+{
+    private static readonly bool IsChinese = DetectChinese(CultureInfo.CurrentUICulture.Name);
+
+    private static bool DetectChinese(string tag) =>
+        tag.StartsWith("zh-Hant", StringComparison.OrdinalIgnoreCase)
+        || tag.StartsWith("zh-TW", StringComparison.OrdinalIgnoreCase)
+        || tag.StartsWith("zh-HK", StringComparison.OrdinalIgnoreCase)
+        || tag.StartsWith("zh-MO", StringComparison.OrdinalIgnoreCase);
+
+    private static string T(string en, string zh) => IsChinese ? zh : en;
+
+    // Command-line / no-UI errors.
+    internal static string ErrorNoSetupPathArg => T(
+        "Usage: Syrtis.Installer.exe <path-to-setup.exe>",
+        "用法：Syrtis.Installer.exe <setup.exe 的路徑>");
+
+    internal static string ErrorSetupNotFound(string path) => T(
+        $"Setup file not found: {path}",
+        $"找不到安裝檔：{path}");
+
+    // Window chrome.
+    internal static string WindowTitle => T("Syrtis Setup", "Syrtis 安裝精靈");
+
+    // Buttons.
+    internal static string ButtonBack => T("< Back", "< 上一步");
+    internal static string ButtonNext => T("Next >", "下一步 >");
+    internal static string ButtonCancel => T("Cancel", "取消");
+    internal static string ButtonFinish => T("Finish", "完成");
+    internal static string ButtonBrowse => T("Browse…", "瀏覽…");
+
+    // Page 1: Welcome.
+    internal static string WelcomeHeading(string productName) => T(
+        $"Welcome to {productName} Setup",
+        $"歡迎使用 {productName} 安裝精靈");
+    internal static string WelcomeBody(string productName, string version) => T(
+        $"This wizard will install {productName} version {version} on your computer.\n\nClick Next to continue.",
+        $"此精靈將在您的電腦上安裝 {productName} 版本 {version}。\n\n按下一步繼續。");
+
+    // Page 2: Location.
+    internal static string LocationHeading => T("Choose Install Location", "選擇安裝位置");
+    internal static string LocationBody => T(
+        "Setup will install Syrtis to the following folder. To install to this folder, click Next. To install to a different folder, click Browse.",
+        "安裝程式將把 Syrtis 安裝到下列資料夾。若要安裝到此資料夾，請按下一步；若要選擇其他資料夾，請按瀏覽。");
+    internal static string LocationPerUserNotice => T(
+        "This installs for the current user only and does not require administrator rights.",
+        "此安裝僅適用於目前使用者，不需要系統管理員權限。");
+    internal static string LocationInvalidPath => T(
+        "Enter a valid absolute folder path.",
+        "請輸入有效的絕對資料夾路徑。");
+    internal static string BrowseDialogDescription => T(
+        "Select the folder to install Syrtis into.",
+        "選擇要安裝 Syrtis 的資料夾。");
+
+    // Page 3: Installing.
+    internal static string InstallingHeading => T("Installing", "安裝中");
+    internal static string InstallingStatus => T(
+        "Please wait while Syrtis is being installed…",
+        "請稍候，Syrtis 正在安裝中…");
+
+    // Page 4: Done.
+    internal static string DoneHeadingSuccess => T("Setup Complete", "安裝完成");
+    internal static string DoneBodySuccess(string productName) => T(
+        $"{productName} has been installed on your computer.",
+        $"{productName} 已成功安裝到您的電腦。");
+    internal static string DoneLaunchCheckbox(string productName) => T(
+        $"Launch {productName}", $"啟動 {productName}");
+    internal static string DoneHeadingFailure => T("Setup Failed", "安裝失敗");
+    internal static string DoneBodyFailure(string productName, int exitCode, string logPath) => T(
+        $"{productName} installation failed (exit code {exitCode}).\n\nSee the log file for details:\n{logPath}",
+        $"{productName} 安裝失敗（結束代碼 {exitCode}）。\n\n詳情請參閱記錄檔：\n{logPath}");
+}

--- a/src/Syrtis.Installer/Strings.cs
+++ b/src/Syrtis.Installer/Strings.cs
@@ -29,6 +29,10 @@ internal static class Strings
         $"Setup file not found: {path}",
         $"找不到安裝檔：{path}");
 
+    internal static string ErrorUnexpectedArg(string arg) => T(
+        $"Unrecognised argument: {arg}\nUsage: Syrtis.Installer.exe [-s|--silent] <path-to-setup.exe>",
+        $"無法辨識的參數：{arg}\n用法：Syrtis.Installer.exe [-s|--silent] <setup.exe 的路徑>");
+
     internal static string ErrorSetupLaunchFailed(string path, string reason) => T(
         $"Could not start the setup file: {path}\n{reason}",
         $"無法啟動安裝檔：{path}\n{reason}");
@@ -83,4 +87,16 @@ internal static class Strings
     internal static string DoneBodyFailure(string productName, int exitCode, string logPath) => T(
         $"{productName} installation failed (exit code {exitCode}).\n\nSee the log file for details:\n{logPath}",
         $"{productName} 安裝失敗（結束代碼 {exitCode}）。\n\n詳情請參閱記錄檔：\n{logPath}");
+
+    /// <summary>Setup ran and failed, but wrote no log. Says so rather than
+    /// naming a path that is absent or left over from an unrelated run.</summary>
+    internal static string DoneBodyFailureNoLog(string productName, int exitCode) => T(
+        $"{productName} installation failed (exit code {exitCode}).\n\nNo log file was written.",
+        $"{productName} 安裝失敗（結束代碼 {exitCode}）。\n\n沒有產生記錄檔。");
+
+    /// <summary>Setup could not be started at all. There is no exit code worth
+    /// showing and no log, so this shows the reason instead.</summary>
+    internal static string DoneBodyLaunchFailed(string productName, string reason) => T(
+        $"The {productName} setup file could not be started.\n\n{reason}",
+        $"無法啟動 {productName} 的安裝檔。\n\n{reason}");
 }

--- a/src/Syrtis.Installer/Strings.cs
+++ b/src/Syrtis.Installer/Strings.cs
@@ -12,7 +12,7 @@ internal static class Strings
 {
     private static readonly bool IsChinese = DetectChinese(CultureInfo.CurrentUICulture.Name);
 
-    private static bool DetectChinese(string tag) =>
+    internal static bool DetectChinese(string tag) =>
         tag.StartsWith("zh-Hant", StringComparison.OrdinalIgnoreCase)
         || tag.StartsWith("zh-TW", StringComparison.OrdinalIgnoreCase)
         || tag.StartsWith("zh-HK", StringComparison.OrdinalIgnoreCase)

--- a/src/Syrtis.Installer/Strings.cs
+++ b/src/Syrtis.Installer/Strings.cs
@@ -33,6 +33,15 @@ internal static class Strings
         $"Unrecognised argument: {arg}\nUsage: Syrtis.Installer.exe [-s|--silent] <path-to-setup.exe>",
         $"無法辨識的參數：{arg}\n用法：Syrtis.Installer.exe [-s|--silent] <setup.exe 的路徑>");
 
+    /// <summary>A switch this wrapper does not support. Named separately from
+    /// ErrorUnexpectedArg because after slice 1b this runs under Setup.exe's
+    /// own filename, so the script that hits this is likely carrying Setup's
+    /// options — and the useful thing to say is which switch was dropped, not
+    /// that some token was surplus.</summary>
+    internal static string ErrorUnsupportedSwitch(string arg) => T(
+        $"This installer does not support {arg}.\nUsage: Syrtis.Installer.exe [-s|--silent] <path-to-setup.exe>",
+        $"此安裝程式不支援 {arg}。\n用法：Syrtis.Installer.exe [-s|--silent] <setup.exe 的路徑>");
+
     internal static string ErrorSetupLaunchFailed(string path, string reason) => T(
         $"Could not start the setup file: {path}\n{reason}",
         $"無法啟動安裝檔：{path}\n{reason}");

--- a/src/Syrtis.Installer/Strings.cs
+++ b/src/Syrtis.Installer/Strings.cs
@@ -29,6 +29,10 @@ internal static class Strings
         $"Setup file not found: {path}",
         $"找不到安裝檔：{path}");
 
+    internal static string ErrorSetupLaunchFailed(string path, string reason) => T(
+        $"Could not start the setup file: {path}\n{reason}",
+        $"無法啟動安裝檔：{path}\n{reason}");
+
     // Window chrome.
     internal static string WindowTitle => T("Syrtis Setup", "Syrtis 安裝精靈");
 

--- a/src/Syrtis.Installer/Syrtis.Installer.csproj
+++ b/src/Syrtis.Installer/Syrtis.Installer.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Classic Windows install wizard fronting Velopack's Setup.exe. net48
+       WinForms, deliberately not net10: it must run on a machine with no
+       .NET runtime installed at all, before anything this installer places
+       gets a chance to. Not in TokenBar.slnx for the same reason TokenBar.App
+       isn't — that solution is the macOS inner loop, restored in locked mode
+       by scripts/check.sh, and net48 WinForms cannot build there. -->
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <Platforms>AnyCPU</Platforms>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>Syrtis.Installer</AssemblyName>
+    <RootNamespace>Syrtis.Installer</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <!-- The build host has the 4.8.1 runtime but no Visual Studio targeting
+         packs; this reference assembly package is what lets `dotnet build`
+         resolve net48 without one. -->
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reuse TokenBar.App's brandmark rather than copying the binary: built
+         into this exe's own resources via ApplicationIcon below, and also
+         copied to the output directory (Link, not a physical copy in this
+         directory) so WizardForm can load it at runtime for the Welcome
+         page's large icon. -->
+    <Content Include="..\TokenBar.App\Assets\syrtis.ico" Link="syrtis.ico" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ApplicationIcon>..\TokenBar.App\Assets\syrtis.ico</ApplicationIcon>
+  </PropertyGroup>
+
+</Project>

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -166,7 +166,7 @@ internal sealed class WizardForm : Form
                 break;
             case WizardStep.Location:
                 _backButton.Enabled = true;
-                _nextButton.Enabled = IsValidInstallPath(_locationTextBox?.Text ?? string.Empty);
+                _nextButton.Enabled = InstallPath.IsValidInstallPath(_locationTextBox?.Text ?? string.Empty);
                 _cancelButton.Enabled = true;
                 break;
             case WizardStep.Installing:
@@ -282,9 +282,9 @@ internal sealed class WizardForm : Form
             AutoSize = true,
             ForeColor = Color.Firebrick,
             Margin = new Padding(0, 8, 0, 0),
-            Visible = !IsValidInstallPath(_installDir),
+            Visible = !InstallPath.IsValidInstallPath(_installDir),
         };
-        textBox.TextChanged += (_, _) => invalidHint.Visible = !IsValidInstallPath(textBox.Text);
+        textBox.TextChanged += (_, _) => invalidHint.Visible = !InstallPath.IsValidInstallPath(textBox.Text);
         layout.Controls.Add(invalidHint);
 
         return layout;
@@ -295,76 +295,13 @@ internal sealed class WizardForm : Form
         using var dialog = new FolderBrowserDialog
         {
             Description = Strings.BrowseDialogDescription,
-            SelectedPath = IsValidInstallPath(textBox.Text) ? textBox.Text : SetupRunner.DefaultInstallDirectory,
+            SelectedPath = InstallPath.IsValidInstallPath(textBox.Text) ? textBox.Text : SetupRunner.DefaultInstallDirectory,
             ShowNewFolderButton = true,
         };
         if (dialog.ShowDialog(this) == DialogResult.OK)
         {
             textBox.Text = dialog.SelectedPath;
         }
-    }
-
-    /// <summary>A "usable absolute directory path": rooted, and syntactically
-    /// well-formed (Path.GetFullPath does not throw). Whether it can actually
-    /// be created is left to Setup.exe, which reports failure through its
-    /// exit code on the Done page — this is user-typing feedback, not a
-    /// filesystem permission check.</summary>
-    private static bool IsValidInstallPath(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-
-        // EVERY System.IO.Path call belongs inside this try. On .NET Framework
-        // — measured, not assumed, on 4.8.9337.0 — IsPathRooted and GetPathRoot
-        // both call CheckInvalidPathChars and throw ArgumentException, so a
-        // single quote in C:\bad" throws from all three of these. This runs
-        // from TextChanged on the UI thread, so one outside the guard is an
-        // unhandled exception on a keystroke rather than the invalid-path hint.
-        // .NET Core stopped throwing from these; that is not the target here.
-        try
-        {
-            if (!Path.IsPathRooted(path))
-            {
-                return false;
-            }
-
-            // Rooted is not the same as fully qualified, and there is more than
-            // one way to be rooted without naming a volume. .NET Framework has
-            // no Path.IsPathFullyQualified (that arrived in .NET Core 2.1), so
-            // the test is on the root, and it is a whitelist: the root must
-            // identify a volume. An earlier revision listed the bad shapes
-            // instead and shipped with the second one still open.
-            //
-            // Measured on 4.8.9337.0, process directory C:\Users\Nanako:
-            //
-            //   "C:\ok"          root "C:\"          -> qualified
-            //   "\\srv\share\x"  root "\\srv\share"  -> qualified
-            //   "C:"             root "C:"           -> C:\Users\Nanako
-            //   "\Syrtis"        root "\"            -> C:\Syrtis
-            //   "/Syrtis"        root "\"            -> C:\Syrtis
-            //
-            // The last three are the trap: every one of them passes
-            // IsPathRooted and resolves silently against the process's current
-            // drive or directory, so the user reads an absolute path and Setup
-            // installs somewhere they never named. GetPathRoot normalises "//"
-            // to "\\", so the UNC test needs only the one form.
-            var root = Path.GetPathRoot(path);
-            var namesAVolume =
-                (root.Length >= 3 && root[1] == ':')
-                || root.StartsWith(@"\\", StringComparison.Ordinal);
-            if (!namesAVolume)
-            {
-                return false;
-            }
-
-            Path.GetFullPath(path);
-            return true;
-        }
-        catch (ArgumentException) { return false; }
-        catch (NotSupportedException) { return false; }
-        catch (PathTooLongException) { return false; }
     }
 
     // --- Page 3: Installing --------------------------------------------------
@@ -431,7 +368,7 @@ internal sealed class WizardForm : Form
                     // message and the two surfaces have to agree.
                     _result = task.IsFaulted
                         ? new SetupRunResult(
-                            Program.LaunchFailedExitCode,
+                            ExitCodes.LaunchFailed,
                             // No log: Setup never ran, so it wrote nothing.
                             // Carrying the path here would put the same stale
                             // file back into the result by another door.
@@ -471,7 +408,7 @@ internal sealed class WizardForm : Form
         {
             // Unreachable: Done is only entered from the install continuation,
             // which always assigns _result first.
-            return Strings.DoneBodyFailureNoLog(_productName, Program.LaunchFailedExitCode);
+            return Strings.DoneBodyFailureNoLog(_productName, ExitCodes.LaunchFailed);
         }
 
         if (!string.IsNullOrEmpty(result.LaunchError))
@@ -581,7 +518,7 @@ internal sealed class WizardForm : Form
                 GoToStep(WizardStep.Location);
                 break;
             case WizardStep.Location:
-                if (IsValidInstallPath(_installDir))
+                if (InstallPath.IsValidInstallPath(_installDir))
                 {
                     GoToStep(WizardStep.Installing);
                     StartInstall();

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -37,9 +37,26 @@ internal sealed class WizardForm : Form
     internal WizardForm(string setupExePath)
     {
         _setupExePath = setupExePath;
-        _productName = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "Syrtis";
-        _versionText = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "?";
+
+        // The Welcome page states what will be installed, so both halves of
+        // that sentence are claims about the payload, not about this wrapper.
+        // They were read from this assembly, which is only correct by accident:
+        // in slice 1a the setup file is whatever path was passed in, and the
+        // repo version stamped on this exe has nothing to do with it. Velopack's
+        // Setup.exe does carry the app's own identity — measured on a packed
+        // 0.2.1 build, FileVersion 0.2.1 and ProductName Syrtis, not Velopack's
+        // own — so ask the file that is about to be run.
+        var payload = ReadPayloadIdentity(setupExePath);
+        var self = Assembly.GetExecutingAssembly();
+        _productName = PayloadIdentity.Choose(
+            payload.Product,
+            self.GetCustomAttribute<AssemblyProductAttribute>()?.Product,
+            "Syrtis");
+        _versionText = PayloadIdentity.Choose(
+            payload.Version,
+            self.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? self.GetName().Version?.ToString(),
+            "?");
 
         AutoScaleMode = AutoScaleMode.Dpi;
         AutoScaleDimensions = new SizeF(96f, 96f);
@@ -108,6 +125,23 @@ internal sealed class WizardForm : Form
         };
 
         GoToStep(WizardStep.Welcome);
+    }
+
+    /// <summary>Product name and version as declared by the setup file itself.
+    /// Either may come back null: a file with no version resource, or an
+    /// unreadable one. Never throws — a Welcome page is not worth failing an
+    /// install over.</summary>
+    private static (string? Product, string? Version) ReadPayloadIdentity(string setupExePath)
+    {
+        try
+        {
+            var info = FileVersionInfo.GetVersionInfo(setupExePath);
+            return (info.ProductName, info.ProductVersion ?? info.FileVersion);
+        }
+        catch (Exception)
+        {
+            return (null, null);
+        }
     }
 
     private static Button MakeButton(string text, EventHandler onClick)

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -432,7 +432,10 @@ internal sealed class WizardForm : Form
                     _result = task.IsFaulted
                         ? new SetupRunResult(
                             Program.LaunchFailedExitCode,
-                            logPath,
+                            // No log: Setup never ran, so it wrote nothing.
+                            // Carrying the path here would put the same stale
+                            // file back into the result by another door.
+                            logPath: null,
                             Describe(task.Exception))
                         : task.Result;
                     GoToStep(WizardStep.Done);
@@ -455,11 +458,13 @@ internal sealed class WizardForm : Form
     /// user: Setup never started (show why, and do not mention a log), Setup
     /// ran and failed with a log to read, and Setup ran and failed without one.
     ///
-    /// <para>The log check is not decoration. DefaultLogPath is a fixed name in
-    /// %TEMP%, so an absent log and a stale log look identical from here — the
-    /// test machine had a two-day-old copy sitting at that exact path — and
-    /// sending someone to a successful install's log to explain a failure is
-    /// worse than saying nothing.</para></summary>
+    /// <para>Whether there is a log is not decided here. This asks the result,
+    /// and SetupRunner answers by whether the file was written during the run
+    /// it just performed. An earlier version tested File.Exists at this point
+    /// and was wrong in the way that matters: DefaultLogPath is a fixed name in
+    /// %TEMP%, so a leftover from a previous install passes an existence check
+    /// and the page would offer an unrelated run's record — possibly a
+    /// successful one — as the explanation for this failure.</para></summary>
     private string FailureBody()
     {
         if (_result is not { } result)
@@ -474,8 +479,8 @@ internal sealed class WizardForm : Form
             return Strings.DoneBodyLaunchFailed(_productName, result.LaunchError!);
         }
 
-        return File.Exists(result.LogPath)
-            ? Strings.DoneBodyFailure(_productName, result.ExitCode, result.LogPath)
+        return result.LogPath is { } log
+            ? Strings.DoneBodyFailure(_productName, result.ExitCode, log)
             : Strings.DoneBodyFailureNoLog(_productName, result.ExitCode);
     }
 

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -355,7 +355,7 @@ internal sealed class WizardForm : Form
         // string arriving there can still legitimately end in one.
         _installDir = Path.GetFullPath(_installDir);
         var installDir = _installDir;
-        var logPath = SetupRunner.DefaultLogPath;
+        var logPath = SetupRunner.NewLogPath();
 
         Task.Run(() => SetupRunner.Run(setupExePath, installDir, logPath))
             .ContinueWith(
@@ -398,7 +398,7 @@ internal sealed class WizardForm : Form
     /// <para>Whether there is a log is not decided here. This asks the result,
     /// and SetupRunner answers by whether the file was written during the run
     /// it just performed. An earlier version tested File.Exists at this point
-    /// and was wrong in the way that matters: DefaultLogPath is a fixed name in
+    /// and was wrong in the way that matters: the log path used to be a fixed name in
     /// %TEMP%, so a leftover from a previous install passes an existence check
     /// and the page would offer an unrelated run's record — possibly a
     /// successful one — as the explanation for this failure.</para></summary>

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -406,9 +406,16 @@ internal sealed class WizardForm : Form
         var setupExePath = _setupExePath;
         // Normalise here rather than while the user types — rewriting the box
         // under a caret fights whoever is editing it. What Setup receives is
-        // therefore the resolved path, not the keystrokes: "C:\a\..\b" and a
-        // trailing separator both reach it in one canonical form, and the
-        // directory recorded for the Launch button below is the same one.
+        // therefore the resolved path rather than the keystrokes, and the
+        // directory the Launch button composes against below is the same one.
+        //
+        // GetFullPath folds "C:\a\..\b" to "C:\b" but it does NOT drop a
+        // trailing separator — measured: GetFullPath("C:\foo\") is "C:\foo\".
+        // An earlier version of this comment claimed both, having checked only
+        // the first, and that unchecked half is what hid a P1: a value ending
+        // in a backslash used to break out of its own quotes on the command
+        // line. SetupRunner.Quote handles it now; the point here is that the
+        // string arriving there can still legitimately end in one.
         _installDir = Path.GetFullPath(_installDir);
         var installDir = _installDir;
         var logPath = SetupRunner.DefaultLogPath;
@@ -417,8 +424,16 @@ internal sealed class WizardForm : Form
             .ContinueWith(
                 task =>
                 {
+                    // Carry the reason, not just the code. Discarding
+                    // task.Exception left the Done page able to say only
+                    // "exit code -1" and then send the user to a log Setup
+                    // never opened — the silent path already reports the
+                    // message and the two surfaces have to agree.
                     _result = task.IsFaulted
-                        ? new SetupRunResult(-1, logPath)
+                        ? new SetupRunResult(
+                            Program.LaunchFailedExitCode,
+                            logPath,
+                            Describe(task.Exception))
                         : task.Result;
                     GoToStep(WizardStep.Done);
                 },
@@ -427,7 +442,42 @@ internal sealed class WizardForm : Form
                 TaskScheduler.FromCurrentSynchronizationContext());
     }
 
+    /// <summary>The innermost message of a faulted install task. Task wraps
+    /// everything in AggregateException, whose own message is boilerplate
+    /// about one or more errors — useless on a dialog.</summary>
+    private static string Describe(AggregateException? fault) =>
+        fault?.GetBaseException().Message ?? string.Empty;
+
     // --- Page 4: Done ----------------------------------------------------
+
+    /// <summary>What the Done page says when the install did not succeed.
+    /// Three distinct cases, because they need three different things from the
+    /// user: Setup never started (show why, and do not mention a log), Setup
+    /// ran and failed with a log to read, and Setup ran and failed without one.
+    ///
+    /// <para>The log check is not decoration. DefaultLogPath is a fixed name in
+    /// %TEMP%, so an absent log and a stale log look identical from here — the
+    /// test machine had a two-day-old copy sitting at that exact path — and
+    /// sending someone to a successful install's log to explain a failure is
+    /// worse than saying nothing.</para></summary>
+    private string FailureBody()
+    {
+        if (_result is not { } result)
+        {
+            // Unreachable: Done is only entered from the install continuation,
+            // which always assigns _result first.
+            return Strings.DoneBodyFailureNoLog(_productName, Program.LaunchFailedExitCode);
+        }
+
+        if (!string.IsNullOrEmpty(result.LaunchError))
+        {
+            return Strings.DoneBodyLaunchFailed(_productName, result.LaunchError!);
+        }
+
+        return File.Exists(result.LogPath)
+            ? Strings.DoneBodyFailure(_productName, result.ExitCode, result.LogPath)
+            : Strings.DoneBodyFailureNoLog(_productName, result.ExitCode);
+    }
 
     private Control BuildDonePage()
     {
@@ -444,7 +494,7 @@ internal sealed class WizardForm : Form
 
         var bodyText = succeeded
             ? Strings.DoneBodySuccess(_productName)
-            : Strings.DoneBodyFailure(_productName, _result?.ExitCode ?? -1, _result?.LogPath ?? SetupRunner.DefaultLogPath);
+            : FailureBody();
         layout.Controls.Add(new Label
         {
             Text = bodyText,

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -330,16 +330,31 @@ internal sealed class WizardForm : Form
                 return false;
             }
 
-            // Rooted is not the same as fully qualified. "C:" and "C:sub" are
-            // both rooted, and both resolve against that drive's *current
-            // directory* — GetFullPath("C:") returned C:\Users\Nanako on the
-            // test host — so the user reads "C:" as the root of C: and Setup
-            // installs somewhere else entirely. Reject the drive-relative form
-            // specifically: the test is on the root rather than on a separator
-            // so that a UNC path, whose root ("\\srv\share") has no trailing
-            // separator either, still passes.
+            // Rooted is not the same as fully qualified, and there is more than
+            // one way to be rooted without naming a volume. .NET Framework has
+            // no Path.IsPathFullyQualified (that arrived in .NET Core 2.1), so
+            // the test is on the root, and it is a whitelist: the root must
+            // identify a volume. An earlier revision listed the bad shapes
+            // instead and shipped with the second one still open.
+            //
+            // Measured on 4.8.9337.0, process directory C:\Users\Nanako:
+            //
+            //   "C:\ok"          root "C:\"          -> qualified
+            //   "\\srv\share\x"  root "\\srv\share"  -> qualified
+            //   "C:"             root "C:"           -> C:\Users\Nanako
+            //   "\Syrtis"        root "\"            -> C:\Syrtis
+            //   "/Syrtis"        root "\"            -> C:\Syrtis
+            //
+            // The last three are the trap: every one of them passes
+            // IsPathRooted and resolves silently against the process's current
+            // drive or directory, so the user reads an absolute path and Setup
+            // installs somewhere they never named. GetPathRoot normalises "//"
+            // to "\\", so the UNC test needs only the one form.
             var root = Path.GetPathRoot(path);
-            if (root.Length == 2 && root[1] == ':')
+            var namesAVolume =
+                (root.Length >= 3 && root[1] == ':')
+                || root.StartsWith(@"\\", StringComparison.Ordinal);
+            if (!namesAVolume)
             {
                 return false;
             }

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -151,6 +151,11 @@ internal sealed class WizardForm : Form
         _nextButton.Visible = !showFinish;
         _cancelButton.Visible = !showFinish;
         _finishButton.Visible = showFinish;
+        // AcceptButton has to follow the page, not be set once at construction:
+        // Enter fires the assigned button even when it is hidden, so leaving
+        // Next as the accept button left the Done page with no keyboard route
+        // to the only control on it. Nothing visible would have happened.
+        AcceptButton = showFinish ? _finishButton : _nextButton;
 
         switch (_step)
         {
@@ -306,25 +311,39 @@ internal sealed class WizardForm : Form
     /// filesystem permission check.</summary>
     private static bool IsValidInstallPath(string path)
     {
-        if (string.IsNullOrWhiteSpace(path) || !Path.IsPathRooted(path))
+        if (string.IsNullOrWhiteSpace(path))
         {
             return false;
         }
 
-        // Rooted is not the same as fully qualified. "C:" and "C:sub" are both
-        // rooted, and both resolve against that drive's *current directory* —
-        // so the user reads "C:" as the root of C: and Setup installs somewhere
-        // else entirely. Reject the drive-relative form specifically; the test
-        // is on the root rather than on a separator so that a UNC path, whose
-        // root has no trailing separator either, still passes.
-        var root = Path.GetPathRoot(path);
-        if (root.Length == 2 && root[1] == ':')
-        {
-            return false;
-        }
-
+        // EVERY System.IO.Path call belongs inside this try. On .NET Framework
+        // — measured, not assumed, on 4.8.9337.0 — IsPathRooted and GetPathRoot
+        // both call CheckInvalidPathChars and throw ArgumentException, so a
+        // single quote in C:\bad" throws from all three of these. This runs
+        // from TextChanged on the UI thread, so one outside the guard is an
+        // unhandled exception on a keystroke rather than the invalid-path hint.
+        // .NET Core stopped throwing from these; that is not the target here.
         try
         {
+            if (!Path.IsPathRooted(path))
+            {
+                return false;
+            }
+
+            // Rooted is not the same as fully qualified. "C:" and "C:sub" are
+            // both rooted, and both resolve against that drive's *current
+            // directory* — GetFullPath("C:") returned C:\Users\Nanako on the
+            // test host — so the user reads "C:" as the root of C: and Setup
+            // installs somewhere else entirely. Reject the drive-relative form
+            // specifically: the test is on the root rather than on a separator
+            // so that a UNC path, whose root ("\\srv\share") has no trailing
+            // separator either, still passes.
+            var root = Path.GetPathRoot(path);
+            if (root.Length == 2 && root[1] == ':')
+            {
+                return false;
+            }
+
             Path.GetFullPath(path);
             return true;
         }

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -311,6 +311,18 @@ internal sealed class WizardForm : Form
             return false;
         }
 
+        // Rooted is not the same as fully qualified. "C:" and "C:sub" are both
+        // rooted, and both resolve against that drive's *current directory* —
+        // so the user reads "C:" as the root of C: and Setup installs somewhere
+        // else entirely. Reject the drive-relative form specifically; the test
+        // is on the root rather than on a separator so that a UNC path, whose
+        // root has no trailing separator either, still passes.
+        var root = Path.GetPathRoot(path);
+        if (root.Length == 2 && root[1] == ':')
+        {
+            return false;
+        }
+
         try
         {
             Path.GetFullPath(path);
@@ -358,6 +370,12 @@ internal sealed class WizardForm : Form
     private void StartInstall()
     {
         var setupExePath = _setupExePath;
+        // Normalise here rather than while the user types — rewriting the box
+        // under a caret fights whoever is editing it. What Setup receives is
+        // therefore the resolved path, not the keystrokes: "C:\a\..\b" and a
+        // trailing separator both reach it in one canonical form, and the
+        // directory recorded for the Launch button below is the same one.
+        _installDir = Path.GetFullPath(_installDir);
         var installDir = _installDir;
         var logPath = SetupRunner.DefaultLogPath;
 

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -1,0 +1,487 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace Syrtis.Installer;
+
+/// <summary>The four-page install wizard: Welcome, Location, Installing, Done.
+/// One fixed-size form; pages swap in and out of a single content panel, with
+/// a Back / Next / Cancel bar along the bottom (Done replaces that bar with a
+/// single Finish button). Per-user only — never asks about machine-wide
+/// install, never elevates.</summary>
+internal sealed class WizardForm : Form
+{
+    private enum WizardStep { Welcome, Location, Installing, Done }
+
+    private readonly string _setupExePath;
+    private readonly string _productName;
+    private readonly string _versionText;
+
+    private WizardStep _step = WizardStep.Welcome;
+    private string _installDir = SetupRunner.DefaultInstallDirectory;
+    private SetupRunResult? _result;
+
+    private readonly Panel _content;
+    private readonly Button _backButton;
+    private readonly Button _nextButton;
+    private readonly Button _cancelButton;
+    private readonly Button _finishButton;
+
+    // Set while the Location page is on screen; used to keep Next's enabled
+    // state in sync as the user types.
+    private TextBox? _locationTextBox;
+
+    // Set while the Done page is on screen; read when Finish is clicked.
+    private CheckBox? _launchCheckBox;
+
+    internal WizardForm(string setupExePath)
+    {
+        _setupExePath = setupExePath;
+        _productName = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "Syrtis";
+        _versionText = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "?";
+
+        AutoScaleMode = AutoScaleMode.Dpi;
+        AutoScaleDimensions = new SizeF(96f, 96f);
+        Text = Strings.WindowTitle;
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        StartPosition = FormStartPosition.CenterScreen;
+        ClientSize = new Size(500, 360);
+        var iconPath = Path.Combine(AppContext.BaseDirectory, "syrtis.ico");
+        if (File.Exists(iconPath))
+        {
+            try { Icon = new Icon(iconPath); } catch (ArgumentException) { /* corrupt/unreadable icon file: keep the default */ }
+        }
+
+        var root = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 3,
+        };
+        root.RowStyles.Add(new RowStyle(SizeType.Percent, 100f));
+        root.RowStyles.Add(new RowStyle(SizeType.Absolute, 1f));
+        root.RowStyles.Add(new RowStyle(SizeType.Absolute, 48f));
+
+        _content = new Panel { Dock = DockStyle.Fill, Padding = new Padding(16) };
+
+        var separator = new Panel { Dock = DockStyle.Fill, BackColor = SystemColors.ControlDark };
+
+        var buttonBar = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            FlowDirection = FlowDirection.RightToLeft,
+            Padding = new Padding(12, 10, 12, 10),
+        };
+
+        _cancelButton = MakeButton(Strings.ButtonCancel, OnCancelClicked);
+        _nextButton = MakeButton(Strings.ButtonNext, OnNextClicked);
+        _backButton = MakeButton(Strings.ButtonBack, OnBackClicked);
+        _finishButton = MakeButton(Strings.ButtonFinish, OnFinishClicked);
+        // Added in the visual left-to-right order Back, Next, Cancel: a
+        // RightToLeft FlowLayoutPanel places the first added control
+        // rightmost, so Cancel goes in first. Finish's position doesn't
+        // matter — it's shown alone, replacing the other three.
+        buttonBar.Controls.Add(_cancelButton);
+        buttonBar.Controls.Add(_nextButton);
+        buttonBar.Controls.Add(_backButton);
+        buttonBar.Controls.Add(_finishButton);
+
+        root.Controls.Add(_content, 0, 0);
+        root.Controls.Add(separator, 0, 1);
+        root.Controls.Add(buttonBar, 0, 2);
+        Controls.Add(root);
+
+        AcceptButton = _nextButton;
+
+        FormClosing += (_, e) =>
+        {
+            // Killing Setup mid-install would leave a broken install; the
+            // Installing page already disables Cancel for the same reason,
+            // this closes the same door via the title-bar X / Alt+F4.
+            if (_step == WizardStep.Installing)
+            {
+                e.Cancel = true;
+            }
+        };
+
+        GoToStep(WizardStep.Welcome);
+    }
+
+    private static Button MakeButton(string text, EventHandler onClick)
+    {
+        var button = new Button
+        {
+            Text = text,
+            AutoSize = true,
+            MinimumSize = new Size(90, 26),
+            Margin = new Padding(6, 0, 0, 0),
+        };
+        button.Click += onClick;
+        return button;
+    }
+
+    private void GoToStep(WizardStep step)
+    {
+        _step = step;
+        _content.Controls.Clear();
+        _locationTextBox = null;
+        _launchCheckBox = null;
+
+        Control page = step switch
+        {
+            WizardStep.Welcome => BuildWelcomePage(),
+            WizardStep.Location => BuildLocationPage(),
+            WizardStep.Installing => BuildInstallingPage(),
+            WizardStep.Done => BuildDonePage(),
+            _ => throw new InvalidOperationException($"Unknown wizard step: {step}"),
+        };
+        page.Dock = DockStyle.Fill;
+        _content.Controls.Add(page);
+
+        UpdateButtons();
+    }
+
+    private void UpdateButtons()
+    {
+        var showFinish = _step == WizardStep.Done;
+        _backButton.Visible = !showFinish;
+        _nextButton.Visible = !showFinish;
+        _cancelButton.Visible = !showFinish;
+        _finishButton.Visible = showFinish;
+
+        switch (_step)
+        {
+            case WizardStep.Welcome:
+                _backButton.Enabled = false;
+                _nextButton.Enabled = true;
+                _cancelButton.Enabled = true;
+                break;
+            case WizardStep.Location:
+                _backButton.Enabled = true;
+                _nextButton.Enabled = IsValidInstallPath(_locationTextBox?.Text ?? string.Empty);
+                _cancelButton.Enabled = true;
+                break;
+            case WizardStep.Installing:
+                // All three disabled, Cancel included: there is no safe way
+                // to interrupt Setup.exe once it has started.
+                _backButton.Enabled = false;
+                _nextButton.Enabled = false;
+                _cancelButton.Enabled = false;
+                break;
+            case WizardStep.Done:
+                _finishButton.Enabled = true;
+                break;
+        }
+    }
+
+    // --- Page 1: Welcome ---------------------------------------------------
+
+    private Control BuildWelcomePage()
+    {
+        var layout = new TableLayoutPanel { ColumnCount = 1, RowCount = 3, Dock = DockStyle.Fill };
+
+        var iconPath = Path.Combine(AppContext.BaseDirectory, "syrtis.ico");
+        if (File.Exists(iconPath))
+        {
+            try
+            {
+                using var icon = new Icon(iconPath, new Size(96, 96));
+                var picture = new PictureBox
+                {
+                    Image = icon.ToBitmap(),
+                    SizeMode = PictureBoxSizeMode.Zoom,
+                    Size = new Size(96, 96),
+                    Margin = new Padding(0, 8, 0, 16),
+                };
+                layout.Controls.Add(picture);
+            }
+            catch (ArgumentException) { /* corrupt/unreadable icon file: show no image */ }
+        }
+
+        var heading = new Label
+        {
+            Text = Strings.WelcomeHeading(_productName),
+            Font = new Font(Font.FontFamily, 13f, FontStyle.Bold),
+            AutoSize = true,
+            Margin = new Padding(0, 0, 0, 8),
+        };
+        layout.Controls.Add(heading);
+
+        var body = new Label
+        {
+            Text = Strings.WelcomeBody(_productName, _versionText),
+            AutoSize = true,
+            MaximumSize = new Size(440, 0),
+        };
+        layout.Controls.Add(body);
+
+        return layout;
+    }
+
+    // --- Page 2: Location ---------------------------------------------------
+
+    private Control BuildLocationPage()
+    {
+        var layout = new TableLayoutPanel { ColumnCount = 1, RowCount = 5, Dock = DockStyle.Fill, AutoSize = true };
+
+        layout.Controls.Add(new Label
+        {
+            Text = Strings.LocationHeading,
+            Font = new Font(Font.FontFamily, 12f, FontStyle.Bold),
+            AutoSize = true,
+            Margin = new Padding(0, 0, 0, 8),
+        });
+
+        layout.Controls.Add(new Label
+        {
+            Text = Strings.LocationBody,
+            AutoSize = true,
+            MaximumSize = new Size(460, 0),
+            Margin = new Padding(0, 0, 0, 12),
+        });
+
+        var pathRow = new TableLayoutPanel { ColumnCount = 2, AutoSize = true, Dock = DockStyle.Top };
+        pathRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+        pathRow.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+
+        var textBox = new TextBox { Text = _installDir, Width = 320, Anchor = AnchorStyles.Left | AnchorStyles.Right };
+        textBox.TextChanged += (_, _) =>
+        {
+            _installDir = textBox.Text;
+            UpdateButtons();
+        };
+        _locationTextBox = textBox;
+
+        var browseButton = new Button { Text = Strings.ButtonBrowse, AutoSize = true, Margin = new Padding(8, 0, 0, 0) };
+        browseButton.Click += (_, _) => BrowseForFolder(textBox);
+
+        pathRow.Controls.Add(textBox, 0, 0);
+        pathRow.Controls.Add(browseButton, 1, 0);
+        layout.Controls.Add(pathRow);
+
+        layout.Controls.Add(new Label
+        {
+            Text = Strings.LocationPerUserNotice,
+            AutoSize = true,
+            MaximumSize = new Size(460, 0),
+            Margin = new Padding(0, 16, 0, 0),
+            ForeColor = SystemColors.GrayText,
+        });
+
+        var invalidHint = new Label
+        {
+            Text = Strings.LocationInvalidPath,
+            AutoSize = true,
+            ForeColor = Color.Firebrick,
+            Margin = new Padding(0, 8, 0, 0),
+            Visible = !IsValidInstallPath(_installDir),
+        };
+        textBox.TextChanged += (_, _) => invalidHint.Visible = !IsValidInstallPath(textBox.Text);
+        layout.Controls.Add(invalidHint);
+
+        return layout;
+    }
+
+    private void BrowseForFolder(TextBox textBox)
+    {
+        using var dialog = new FolderBrowserDialog
+        {
+            Description = Strings.BrowseDialogDescription,
+            SelectedPath = IsValidInstallPath(textBox.Text) ? textBox.Text : SetupRunner.DefaultInstallDirectory,
+            ShowNewFolderButton = true,
+        };
+        if (dialog.ShowDialog(this) == DialogResult.OK)
+        {
+            textBox.Text = dialog.SelectedPath;
+        }
+    }
+
+    /// <summary>A "usable absolute directory path": rooted, and syntactically
+    /// well-formed (Path.GetFullPath does not throw). Whether it can actually
+    /// be created is left to Setup.exe, which reports failure through its
+    /// exit code on the Done page — this is user-typing feedback, not a
+    /// filesystem permission check.</summary>
+    private static bool IsValidInstallPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Path.IsPathRooted(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            Path.GetFullPath(path);
+            return true;
+        }
+        catch (ArgumentException) { return false; }
+        catch (NotSupportedException) { return false; }
+        catch (PathTooLongException) { return false; }
+    }
+
+    // --- Page 3: Installing --------------------------------------------------
+
+    private Control BuildInstallingPage()
+    {
+        var layout = new TableLayoutPanel { ColumnCount = 1, RowCount = 3, Dock = DockStyle.Fill };
+
+        layout.Controls.Add(new Label
+        {
+            Text = Strings.InstallingHeading,
+            Font = new Font(Font.FontFamily, 12f, FontStyle.Bold),
+            AutoSize = true,
+            Margin = new Padding(0, 0, 0, 8),
+        });
+
+        layout.Controls.Add(new Label
+        {
+            Text = Strings.InstallingStatus,
+            AutoSize = true,
+            Margin = new Padding(0, 0, 0, 16),
+        });
+
+        // Velopack's Setup.exe --silent reports no progress; an indeterminate
+        // bar is the honest control here, not a faked percentage.
+        layout.Controls.Add(new ProgressBar
+        {
+            Style = ProgressBarStyle.Marquee,
+            MarqueeAnimationSpeed = 30,
+            Width = 440,
+            Height = 20,
+        });
+
+        return layout;
+    }
+
+    private void StartInstall()
+    {
+        var setupExePath = _setupExePath;
+        var installDir = _installDir;
+        var logPath = SetupRunner.DefaultLogPath;
+
+        Task.Run(() => SetupRunner.Run(setupExePath, installDir, logPath))
+            .ContinueWith(
+                task =>
+                {
+                    _result = task.IsFaulted
+                        ? new SetupRunResult(-1, logPath)
+                        : task.Result;
+                    GoToStep(WizardStep.Done);
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.FromCurrentSynchronizationContext());
+    }
+
+    // --- Page 4: Done ----------------------------------------------------
+
+    private Control BuildDonePage()
+    {
+        var layout = new TableLayoutPanel { ColumnCount = 1, RowCount = 3, Dock = DockStyle.Fill };
+        var succeeded = _result is { ExitCode: 0 };
+
+        layout.Controls.Add(new Label
+        {
+            Text = succeeded ? Strings.DoneHeadingSuccess : Strings.DoneHeadingFailure,
+            Font = new Font(Font.FontFamily, 13f, FontStyle.Bold),
+            AutoSize = true,
+            Margin = new Padding(0, 0, 0, 8),
+        });
+
+        var bodyText = succeeded
+            ? Strings.DoneBodySuccess(_productName)
+            : Strings.DoneBodyFailure(_productName, _result?.ExitCode ?? -1, _result?.LogPath ?? SetupRunner.DefaultLogPath);
+        layout.Controls.Add(new Label
+        {
+            Text = bodyText,
+            AutoSize = true,
+            MaximumSize = new Size(460, 0),
+            Margin = new Padding(0, 0, 0, 16),
+        });
+
+        if (succeeded)
+        {
+            var checkBox = new CheckBox
+            {
+                Text = Strings.DoneLaunchCheckbox(_productName),
+                Checked = true,
+                AutoSize = true,
+            };
+            _launchCheckBox = checkBox;
+            layout.Controls.Add(checkBox);
+        }
+
+        return layout;
+    }
+
+    private void OnFinishClicked(object? sender, EventArgs e)
+    {
+        if (_result is { ExitCode: 0 } && _launchCheckBox is { Checked: true })
+        {
+            LaunchInstalledApp();
+        }
+
+        Close();
+    }
+
+    /// <summary>Velopack's per-user layout places the runnable app at
+    /// "&lt;installDir&gt;\current\&lt;AssemblyName&gt;.App.exe".
+    ///
+    /// <para>Checked against a real install rather than inferred: Velopack's
+    /// own Start Menu and Desktop shortcuts both target
+    /// <c>...\Nyanako.Syrtis\current\Syrtis.App.exe</c>. There is also a
+    /// 518 KB stub at the install root, and pointing here rather than at that
+    /// stub is deliberate — it is what Velopack itself points at.</para>
+    ///
+    /// <para>Best-effort: if the app cannot be found or started, Setup already
+    /// reported success, so this silently does nothing rather than surfacing a
+    /// second dialog for what is a launch convenience.</para></summary>
+    private void LaunchInstalledApp()
+    {
+        var exePath = Path.Combine(_installDir, "current", $"{_productName}.App.exe");
+        if (!File.Exists(exePath))
+        {
+            return;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo { FileName = exePath, UseShellExecute = true });
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            // Best-effort launch; installation itself already succeeded.
+        }
+    }
+
+    // --- Navigation ----------------------------------------------------------
+
+    private void OnBackClicked(object? sender, EventArgs e)
+    {
+        if (_step == WizardStep.Location)
+        {
+            GoToStep(WizardStep.Welcome);
+        }
+    }
+
+    private void OnNextClicked(object? sender, EventArgs e)
+    {
+        switch (_step)
+        {
+            case WizardStep.Welcome:
+                GoToStep(WizardStep.Location);
+                break;
+            case WizardStep.Location:
+                if (IsValidInstallPath(_installDir))
+                {
+                    GoToStep(WizardStep.Installing);
+                    StartInstall();
+                }
+                break;
+        }
+    }
+
+    private void OnCancelClicked(object? sender, EventArgs e) => Close();
+}

--- a/src/Syrtis.Installer/app.manifest
+++ b/src/Syrtis.Installer/app.manifest
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Syrtis.Installer" />
+
+  <!-- Per-user installer: runs at the invoking user's own rights, never
+       elevates. -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <!-- Paired with the DpiAwareness entry in App.config's
+       System.Windows.Forms.ApplicationConfigurationSection: WinForms needs
+       both to render crisply under PerMonitorV2 scaling (e.g. 150%) instead
+       of being DPI-virtualized (blurry, GDI-scaled text and controls). -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</gdiScaling>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/Syrtis.Installer/packages.lock.json
+++ b/src/Syrtis.Installer/packages.lock.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net48": "1.0.3"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net48": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "zMk4D+9zyiEWByyQ7oPImPN/Jhpj166Ky0Nlla4eXlNL8hI/BtSJsgR8Inldd4NNpIAH3oh8yym0W2DrhXdSLQ=="
+      }
+    },
+    ".NETFramework,Version=v4.8/win-x86": {}
+  }
+}

--- a/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
+++ b/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
@@ -1,0 +1,281 @@
+using Syrtis.Installer;
+
+namespace TokenBar.Core.Tests;
+
+// Covers the installer's boundary logic that is honestly testable from a net10
+// suite that also runs on macOS: SetupRunner.Quote (pure string), Install-
+// Request.Parse (pure argument parsing), SetupRunner.LogWrittenByThisRun
+// (FileInfo + timestamps, cross-platform), and Strings.DetectChinese (a pure
+// tag -> bool function).
+//
+// Deliberately NOT covered here: InstallPath.IsValidInstallPath. Its
+// Path.IsPathRooted/GetPathRoot/GetFullPath semantics differ between net48
+// (throws on invalid characters, measured on 4.8.9337.0) and .NET Core
+// (does not throw), and this suite also runs on macOS, where
+// Path.IsPathRooted("C:\") is false regardless of framework. A test against it
+// here would be green for the wrong reason or red for the wrong reason. That
+// surface is exercised instead by `Syrtis.Installer.exe --self-check` on the
+// framework that actually ships. See TokenBar.Core.Tests.csproj for the same
+// note next to the <Compile Include> list.
+//
+// No test in this file may read a Strings member whose value depends on
+// ambient culture. Only Strings.DetectChinese(tag) — which takes the tag as a
+// parameter rather than reading CultureInfo.CurrentUICulture — is referenced.
+public class InstallerBoundaryTests
+{
+    // --- SetupRunner.Quote ---------------------------------------------------
+    //
+    // CommandLineToArgvW is Windows-only, so these assert the produced string
+    // directly (surrounding quotes, and only the trailing run of backslashes
+    // doubled) rather than round-tripping through an actual argv parser.
+
+    [Theory]
+    [InlineData(@"C:\")]
+    [InlineData(@"C:\Install Here\")]
+    [InlineData(@"C:\SyrtisTest\Syrtis")]
+    [InlineData(@"\\srv\share\")]
+    [InlineData(@"C:\a\b\\")]
+    public void Quote_survives_round_trip(string value)
+    {
+        var quoted = SetupRunner.Quote(value);
+
+        // Built independently of SetupRunner.Quote's own algorithm, so this
+        // is not tautological: only the run of trailing backslashes is
+        // doubled, everything before it is untouched.
+        var trailing = 0;
+        while (trailing < value.Length && value[value.Length - 1 - trailing] == '\\')
+        {
+            trailing++;
+        }
+
+        var expected = "\"" + value + new string('\\', trailing) + "\"";
+
+        Assert.Equal(expected, quoted);
+        Assert.StartsWith("\"", quoted);
+        Assert.EndsWith("\"", quoted);
+    }
+
+    // --- SetupRunner.LogWrittenByThisRun --------------------------------------
+
+    [Fact]
+    public void LogWrittenByThisRun_absent_file_is_null()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        Assert.Null(SetupRunner.LogWrittenByThisRun(path, DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void LogWrittenByThisRun_two_days_stale_is_null()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        File.WriteAllText(path, "stale");
+        try
+        {
+            var start = DateTime.UtcNow;
+            File.SetLastWriteTimeUtc(path, start.AddDays(-2));
+
+            Assert.Null(SetupRunner.LogWrittenByThisRun(path, start));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LogWrittenByThisRun_one_second_before_start_is_null()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        File.WriteAllText(path, "just before");
+        try
+        {
+            var start = DateTime.UtcNow;
+            File.SetLastWriteTimeUtc(path, start.AddSeconds(-1));
+
+            Assert.Null(SetupRunner.LogWrittenByThisRun(path, start));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LogWrittenByThisRun_written_after_start_returns_path()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var start = DateTime.UtcNow;
+        File.WriteAllText(path, "fresh");
+        try
+        {
+            File.SetLastWriteTimeUtc(path, start.AddSeconds(1));
+
+            Assert.Equal(path, SetupRunner.LogWrittenByThisRun(path, start));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // --- InstallRequest.Parse -------------------------------------------------
+
+    [Fact]
+    public void Parse_self_check_alone_is_self_check_mode()
+    {
+        var request = InstallRequest.Parse(["--self-check"]);
+
+        Assert.Equal(InstallRequestKind.SelfCheck, request.Kind);
+    }
+
+    [Fact]
+    public void Parse_self_check_with_anything_else_is_a_refusal()
+    {
+        var request = InstallRequest.Parse(["--self-check", "extra"]);
+
+        Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+        Assert.Equal(RefusalReason.UnexpectedArgument, request.Reason);
+        Assert.Equal("extra", request.Token);
+    }
+
+    [Theory]
+    [InlineData("-s")]
+    [InlineData("--silent")]
+    [InlineData("-S")]
+    public void Parse_recognises_every_silent_switch_spelling(string silentSwitch)
+    {
+        var setupPath = CreateTempFile();
+        try
+        {
+            var request = InstallRequest.Parse([silentSwitch, setupPath]);
+
+            Assert.Equal(InstallRequestKind.RunSilent, request.Kind);
+        }
+        finally
+        {
+            File.Delete(setupPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_silent_switch_before_path_works()
+    {
+        var setupPath = CreateTempFile();
+        try
+        {
+            var request = InstallRequest.Parse(["-s", setupPath]);
+
+            Assert.Equal(InstallRequestKind.RunSilent, request.Kind);
+            Assert.Equal(Path.GetFullPath(setupPath), request.SetupPath);
+        }
+        finally
+        {
+            File.Delete(setupPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_silent_switch_after_path_works()
+    {
+        var setupPath = CreateTempFile();
+        try
+        {
+            var request = InstallRequest.Parse([setupPath, "-s"]);
+
+            Assert.Equal(InstallRequestKind.RunSilent, request.Kind);
+            Assert.Equal(Path.GetFullPath(setupPath), request.SetupPath);
+        }
+        finally
+        {
+            File.Delete(setupPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_second_non_switch_argument_is_unexpected()
+    {
+        var setupPath = CreateTempFile();
+        try
+        {
+            var request = InstallRequest.Parse([setupPath, "extra-token"]);
+
+            Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+            Assert.Equal(RefusalReason.UnexpectedArgument, request.Reason);
+            Assert.Equal("extra-token", request.Token);
+        }
+        finally
+        {
+            File.Delete(setupPath);
+        }
+    }
+
+    [Fact]
+    public void Parse_no_path_at_all_is_no_setup_path()
+    {
+        var request = InstallRequest.Parse([]);
+
+        Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+        Assert.Equal(RefusalReason.NoSetupPath, request.Reason);
+    }
+
+    [Fact]
+    public void Parse_no_path_with_only_silent_switch_is_no_setup_path()
+    {
+        var request = InstallRequest.Parse(["--silent"]);
+
+        Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+        Assert.Equal(RefusalReason.NoSetupPath, request.Reason);
+    }
+
+    [Fact]
+    public void Parse_missing_setup_file_is_setup_not_found()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        var request = InstallRequest.Parse([missing]);
+
+        Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+        Assert.Equal(RefusalReason.SetupNotFound, request.Reason);
+        Assert.Equal(missing, request.Token);
+    }
+
+    [Fact]
+    public void Parse_existing_path_without_silent_switch_is_run_wizard()
+    {
+        var setupPath = CreateTempFile();
+        try
+        {
+            var request = InstallRequest.Parse([setupPath]);
+
+            Assert.Equal(InstallRequestKind.RunWizard, request.Kind);
+            Assert.Equal(Path.GetFullPath(setupPath), request.SetupPath);
+        }
+        finally
+        {
+            File.Delete(setupPath);
+        }
+    }
+
+    private static string CreateTempFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        File.WriteAllText(path, "setup");
+        return path;
+    }
+
+    // --- Strings.DetectChinese -------------------------------------------------
+
+    [Theory]
+    [InlineData("zh-Hant", true)]
+    [InlineData("zh-TW", true)]
+    [InlineData("zh-HK", true)]
+    [InlineData("zh-MO", true)]
+    [InlineData("en-US", false)]
+    [InlineData("ja-JP", false)]
+    [InlineData("zh", false)]
+    public void DetectChinese_matches_current_implementation(string tag, bool expected)
+    {
+        Assert.Equal(expected, Strings.DetectChinese(tag));
+    }
+}

--- a/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
+++ b/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
@@ -4,7 +4,7 @@ namespace TokenBar.Core.Tests;
 
 // Covers the installer's boundary logic that is honestly testable from a net10
 // suite that also runs on macOS: SetupRunner.Quote (pure string), Install-
-// Request.Parse (pure argument parsing), SetupRunner.LogWrittenByThisRun
+// Request.Parse (pure argument parsing), SetupRunner.WrittenLog
 // (FileInfo + timestamps, cross-platform), and Strings.DetectChinese (a pure
 // tag -> bool function).
 //
@@ -124,27 +124,33 @@ public class InstallerBoundaryTests
         Assert.EndsWith(".log", path, StringComparison.Ordinal);
     }
 
-    // --- SetupRunner.LogWrittenByThisRun --------------------------------------
+    // --- SetupRunner.WrittenLog -----------------------------------------------
+
+    // This used to compare the file's last write against the moment the run
+    // started, to tell a leftover from a fresh log when every run shared one
+    // filename. NewLogPath removed that need, but the comparison was kept as a
+    // second line of defence — and against a name that cannot collide it
+    // carries no information and can still be false: %TEMP% on FAT or exFAT
+    // records write times to two-second granularity, and the clock can step
+    // backwards mid-install. Either would have made the Done page claim no log
+    // exists while the log explaining the failure sat right there.
 
     [Fact]
-    public void LogWrittenByThisRun_absent_file_is_null()
+    public void WrittenLog_absent_file_is_null()
     {
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-        Assert.Null(SetupRunner.LogWrittenByThisRun(path, DateTime.UtcNow));
+        Assert.Null(SetupRunner.WrittenLog(path));
     }
 
     [Fact]
-    public void LogWrittenByThisRun_two_days_stale_is_null()
+    public void WrittenLog_present_file_is_the_path()
     {
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        File.WriteAllText(path, "stale");
+        File.WriteAllText(path, "written");
         try
         {
-            var start = DateTime.UtcNow;
-            File.SetLastWriteTimeUtc(path, start.AddDays(-2));
-
-            Assert.Null(SetupRunner.LogWrittenByThisRun(path, start));
+            Assert.Equal(path, SetupRunner.WrittenLog(path));
         }
         finally
         {
@@ -152,35 +158,19 @@ public class InstallerBoundaryTests
         }
     }
 
+    // The false negative the timestamp comparison could produce, pinned from
+    // the other side: a log whose stamp predates the run is still this run's
+    // log, because no other run could have been given this name.
     [Fact]
-    public void LogWrittenByThisRun_one_second_before_start_is_null()
+    public void WrittenLog_ignores_the_timestamp_entirely()
     {
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        File.WriteAllText(path, "just before");
+        File.WriteAllText(path, "written, but with an older stamp");
         try
         {
-            var start = DateTime.UtcNow;
-            File.SetLastWriteTimeUtc(path, start.AddSeconds(-1));
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddDays(-2));
 
-            Assert.Null(SetupRunner.LogWrittenByThisRun(path, start));
-        }
-        finally
-        {
-            File.Delete(path);
-        }
-    }
-
-    [Fact]
-    public void LogWrittenByThisRun_written_after_start_returns_path()
-    {
-        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        var start = DateTime.UtcNow;
-        File.WriteAllText(path, "fresh");
-        try
-        {
-            File.SetLastWriteTimeUtc(path, start.AddSeconds(1));
-
-            Assert.Equal(path, SetupRunner.LogWrittenByThisRun(path, start));
+            Assert.Equal(path, SetupRunner.WrittenLog(path));
         }
         finally
         {

--- a/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
+++ b/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
@@ -55,6 +55,37 @@ public class InstallerBoundaryTests
         Assert.EndsWith("\"", quoted);
     }
 
+    // --- SetupRunner.NewLogPath -----------------------------------------------
+
+    // The log path used to be one fixed name, and two defects came out of that:
+    // a leftover from an earlier install passed an existence check, and two
+    // overlapping wrapper instances wrote the same file, where a timestamp
+    // proves "written after I started" but never "written by my child". No
+    // inference separates those; a name that cannot collide does.
+    [Fact]
+    public void NewLogPath_differs_between_runs()
+    {
+        var first = SetupRunner.NewLogPath();
+        var second = SetupRunner.NewLogPath();
+
+        // Same second, same process: whatever makes these differ has to be
+        // more than the timestamp, or two instances started together collide
+        // exactly when it matters.
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void NewLogPath_is_under_temp_and_recognisable()
+    {
+        var path = SetupRunner.NewLogPath();
+
+        Assert.Equal(
+            Path.GetFullPath(Path.GetTempPath()),
+            Path.GetFullPath(Path.GetDirectoryName(path)!) + Path.DirectorySeparatorChar);
+        Assert.StartsWith("syrtis-install-", Path.GetFileName(path), StringComparison.Ordinal);
+        Assert.EndsWith(".log", path, StringComparison.Ordinal);
+    }
+
     // --- SetupRunner.LogWrittenByThisRun --------------------------------------
 
     [Fact]

--- a/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
+++ b/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
@@ -170,6 +170,38 @@ public class InstallerBoundaryTests
         Assert.Equal("extra", request.Token);
     }
 
+    // The refusal path exists to protect the case where slice 1b puts this
+    // under Setup.exe's own filename and a script arrives carrying Setup's own
+    // options. It used to refuse those correctly but name the wrong token:
+    // "--installto D:\X" reported "D:\X" as the surplus argument, because both
+    // tokens are non-switches to a parser that only knows -s. A lone "-v" was
+    // reported as a missing setup file.
+    [Theory]
+    [InlineData(new[] { "--installto", "D:\\X" }, "--installto")]
+    [InlineData(new[] { "-v" }, "-v")]
+    [InlineData(new[] { "-l", "C:\\some.log" }, "-l")]
+    [InlineData(new[] { "--silent", "--installto", "D:\\X" }, "--installto")]
+    [InlineData(new[] { "setup.exe", "-t", "D:\\X" }, "-t")]
+    public void Parse_names_the_unsupported_switch_not_its_value(string[] args, string expected)
+    {
+        var request = InstallRequest.Parse(args);
+
+        Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+        Assert.Equal(RefusalReason.UnsupportedSwitch, request.Reason);
+        Assert.Equal(expected, request.Token);
+    }
+
+    // A Windows path never begins with '-', so the switch test is unambiguous;
+    // '/x' is a rooted path and must NOT be mistaken for a switch.
+    [Fact]
+    public void Parse_does_not_treat_a_slash_rooted_path_as_a_switch()
+    {
+        var request = InstallRequest.Parse(["/nonexistent/setup.exe"]);
+
+        Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+        Assert.Equal(RefusalReason.SetupNotFound, request.Reason);
+    }
+
     [Theory]
     [InlineData("-s")]
     [InlineData("--silent")]

--- a/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
+++ b/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
@@ -55,6 +55,44 @@ public class InstallerBoundaryTests
         Assert.EndsWith("\"", quoted);
     }
 
+    // --- PayloadIdentity.Choose ------------------------------------------------
+
+    // The Welcome page's sentence — "will install {product} version {version}"
+    // — is entirely about the payload, and both halves used to be read from
+    // this wrapper's own assembly. In slice 1a the setup file is whatever path
+    // was passed in, so the repo version stamped on the wrapper says nothing
+    // about it; the two matched during acceptance only because the same bumped
+    // tree produced both.
+    [Fact]
+    public void Choose_prefers_the_payload()
+    {
+        Assert.Equal("0.2.1", PayloadIdentity.Choose("0.2.1", "0.2.2", "?"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Choose_falls_back_to_the_wrapper_when_the_payload_is_silent(string? payload)
+    {
+        Assert.Equal("0.2.2", PayloadIdentity.Choose(payload, "0.2.2", "?"));
+    }
+
+    [Fact]
+    public void Choose_falls_back_to_the_constant_when_neither_answers()
+    {
+        Assert.Equal("?", PayloadIdentity.Choose(null, "  ", "?"));
+    }
+
+    // A blank version resource is ordinary in stub executables, and rendering
+    // it would put "version  " on screen, which reads as a bug rather than as
+    // a missing value.
+    [Fact]
+    public void Choose_trims_what_it_returns()
+    {
+        Assert.Equal("Syrtis", PayloadIdentity.Choose("  Syrtis  ", null, "?"));
+    }
+
     // --- SetupRunner.NewLogPath -----------------------------------------------
 
     // The log path used to be one fixed name, and two defects came out of that:

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -36,6 +36,23 @@
     <Compile Include="..\TokenBar.App\AppViews.cs" Link="AppViews.cs" />
     <Compile Include="..\TokenBar.App\AppLanguage.cs" Link="AppLanguage.cs" />
     <Compile Include="..\TokenBar.App\DrillDownSummary.cs" Link="DrillDownSummary.cs" />
+    <!-- Syrtis.Installer's boundary logic, pulled in for the same reason as
+         the App sources above: none of these five files references
+         System.Windows.Forms, so they compile as-is under net10. Deliberately
+         NOT included: InstallPath.cs. Its Path.IsPathRooted/GetPathRoot/
+         GetFullPath semantics are net48-specific (they throw on invalid
+         characters there; .NET Core does not) and this suite also runs on
+         macOS, where Path.IsPathRooted("C:\") is false. A test against it here
+         would be green for the wrong reason on Windows or red for the wrong
+         reason on macOS. That surface is covered instead by
+         Syrtis.Installer.exe's hidden self-check switch on the framework
+         that actually ships. See InstallerBoundaryTests.cs for the same
+         note next to the tests. -->
+    <Compile Include="..\Syrtis.Installer\ExitCodes.cs" Link="Installer\ExitCodes.cs" />
+    <Compile Include="..\Syrtis.Installer\InstallRequest.cs" Link="Installer\InstallRequest.cs" />
+    <Compile Include="..\Syrtis.Installer\SetupLocator.cs" Link="Installer\SetupLocator.cs" />
+    <Compile Include="..\Syrtis.Installer\SetupRunner.cs" Link="Installer\SetupRunner.cs" />
+    <Compile Include="..\Syrtis.Installer\Strings.cs" Link="Installer\Strings.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -50,6 +50,7 @@
          note next to the tests. -->
     <Compile Include="..\Syrtis.Installer\ExitCodes.cs" Link="Installer\ExitCodes.cs" />
     <Compile Include="..\Syrtis.Installer\InstallRequest.cs" Link="Installer\InstallRequest.cs" />
+    <Compile Include="..\Syrtis.Installer\PayloadIdentity.cs" Link="Installer\PayloadIdentity.cs" />
     <Compile Include="..\Syrtis.Installer\SetupLocator.cs" Link="Installer\SetupLocator.cs" />
     <Compile Include="..\Syrtis.Installer\SetupRunner.cs" Link="Installer\SetupRunner.cs" />
     <Compile Include="..\Syrtis.Installer\Strings.cs" Link="Installer\Strings.cs" />


### PR DESCRIPTION
Slice INSTALL-1a of the install wizard. The design and the four fresh plan reviews behind it are in `docs/proposals/install-1-wizard.md`.

## Why

What a user double-clicks today is Velopack's own `Setup.exe`: a bare progress splash, no welcome, no choice of location, no Back/Next/Cancel, no statement of what is about to happen or where. Every other Windows application asks.

## What this slice is, and is not

The wizard takes the path to a Velopack `Setup.exe` **as an argument**, so it is runnable and observable before any packaging work exists. Slice 1b embeds Setup.exe and wires it into packaging; slice 1c does CI and docs. **Nothing here touches an existing file** — no packaging script, no workflow, no existing project.

## Project shape — all of it load-bearing

| Choice | Why |
|---|---|
| `net48` WinForms, AnyCPU | It has to run on a machine with **no runtime installed** — it is the thing that installs the runtime-bearing app. |
| `Microsoft.NETFramework.ReferenceAssemblies` | Builds without Visual Studio targeting packs. The x64 build host has the 4.8.1 runtime and no targeting packs at all. |
| **Not** in `src/TokenBar.slnx` | Same reason `TokenBar.App` is not: the slnx is the macOS inner loop, `scripts/check.sh` restores it `--locked-mode` and builds it, and net48 WinForms cannot build there. Staying out is also what makes this slice's rollback — delete the directory — true. |
| PerMonitorV2 in **both** `app.manifest` and `App.config` | net48 WinForms needs the pair. This repository has already paid for a missing DPI manifest once. |

The repo-root `Directory.Build.props` reaches it like every project in the tree, so the assembly carries the repo's product and version identity and produces a committed `packages.lock.json`. Both are expected. `src/Directory.Build.targets` does not apply: every target in it is gated on the opt-in `TbNativePackagingEnabled`, which this project does not set.

## Design

Four pages in one 500x360 `FixedDialog`, `< Back` / `Next >` / `Cancel` right-aligned, collapsing to a single `Finish`.

| Page | Notes |
|---|---|
| Welcome | Back disabled |
| Location | defaults to `%LocalAppData%\Nyanako.Syrtis`, Browse, validates **as the user types** rather than on Next, and states the install is per-user and needs no administrator rights |
| Installing | indeterminate bar; **every** button disabled including Cancel and the title-bar close — killing Setup mid-install would leave a broken install |
| Done | Launch checkbox on success; exit code and log path on failure |

The progress bar is **indeterminate because `Setup.exe --silent` reports no progress**. Faking a percentage was rejected: #76 spent four rounds establishing that invented feedback is worse than honest absence.

`--silent` is a separate code path that never constructs a `System.Windows.Forms` type, so scripted installs keep working even though the wizard becomes a mandatory link in the interactive chain.

**Bilingual**, English and Traditional Chinese, from `CultureInfo.CurrentUICulture` with the same zh-Hant/zh-TW/zh-HK/zh-MO test `AppLanguage.Resolve` uses. It cannot share the app's i18n — `TokenBar.Core` is net10, this is net48 — so it carries its own twenty-entry table. An English installer for a localised app is a visible inconsistency, and twenty entries cost less than that.

## Verification

Builds clean on the x64 Windows host, Release, zero warnings and zero errors. No test project compiles this code, and no test could have found what the acceptance found, so the acceptance is three observations rather than a suite.

**A1 and A3, confirmed by the user at the machines.** The four pages, the button behaviour, Browse, an install to a non-default directory (x64); and the same AnyCPU executable launching and rendering on ARM64 Windows 11 (`win-arm64` and `win-arm64-lite` are half the published channels).

**A2, the decisive one**, from the app log after installing to `C:\SyrtisTest\Syrtis`:

```
14:26:26.423 update-download: verified v0.2.2
14:26:27.331 update-handoff: start v0.2.2        (+908 ms dwell, as designed)
14:26:27.491 update-handoff: started v0.2.2
14:27:30.434 <new process, PID 18764>
14:27:30.682 launch: tray up
14:27:31.900 update-check: none
C:\SyrtisTest\Syrtis -> 0.2.2.0
```

**`--installto` does not break the updater.** An app installed outside `%LocalAppData%` resolved its GitHub feed, downloaded, applied and restarted into 0.2.2. That was the risk the whole plan hung on; it is refuted, and the Browse button stays.

## Two findings worth carrying forward

**Running the exe with no arguments crashed** rather than exiting cleanly, over a non-interactive session. `MessageBox` needs a window station, which `Environment.UserInteractive` reports; without one it throws. Both the no-argument and bad-path cases now exit 1 with a message on either surface.

**The hand-off to restart took 63 seconds at the custom location**, against 4.5 seconds for the same 0.2.1-to-0.2.2 update at the default one, with no window on screen for any of it. #76's PR body calls that window "several seconds", which is now known to be wrong for at least one real install path — the user read the silence as a hang, correctly on the evidence they had. Likely Defender scanning a directory outside the usual application path; unconfirmed. It belongs to the update flow, not the wizard, and nothing in this slice would change it.
