### PR TITLE
feat(install): ship the wizard as the Setup.exe, with Velopack's inside it

### DIFF
--- a/docs/proposals/install-1-wizard.md
+++ b/docs/proposals/install-1-wizard.md
@@ -219,6 +219,76 @@ is deliberately broken.
 
 ### INSTALL-1b — embed and package
 
+**Mechanism, settled 2026-08-31 over four review rounds and ten blockers.**
+Reading the pipeline first made the slice smaller than this document assumed:
+`write-package-evidence.ps1` validates the Setup.exe by **name and size only**
+— every structural check is on the nupkg — and `deployment-matrix` packages by
+calling `package-velopack.ps1` directly. So keeping the filename and staying
+under budget means neither that script nor CI changes. Full/win-x64 had 7.3 MB
+of headroom against a 450 KB wrapper.
+
+The wrapper replaces the Velopack Setup in `releases\` **before**
+`package-velopack.ps1`'s own budget assertion, so that assertion measures the
+file that ships. An explicit path still wins over the embedded payload, and a
+path that does not exist is still an error rather than being silently replaced
+— the payload is the default, not an override. The payload is materialised to
+a temp file immediately after parsing and before `WizardForm` is constructed,
+because the Welcome page reads the payload's product and version in that
+constructor; extracting any later would put the wrapper's own version on
+screen, which is what `PayloadIdentity` exists to prevent.
+
+**The pack refuses to emit a wrapper whose payload it did not just produce.**
+It reads the resource back out by reflection and compares SHA-256. Nothing
+else in the pipeline could catch a stale or cross-channel payload: the
+Full/win-x64 Setup at 83,721,388 bytes fits under the Full/win-arm64 budget of
+87,104,109, so an arm64-named installer carrying the x64 payload would pass
+every existing gate and reach half the published channels.
+
+**A quality regression taken deliberately: PerMonitorV2 is given up.**
+`App.config` ships as `<exe-name>.exe.config` and its
+`System.Windows.Forms.ApplicationConfigurationSection` entry is what actually
+makes WinForms DPI-aware — the manifest alone opts the *process* in and leaves
+WinForms laying out at 96 DPI. Renaming the wrapper to the Setup filename
+orphans that file even if it were copied, and the shipping form is one file by
+design; net48 has no programmatic substitute, `Application.SetHighDpiMode`
+being .NET Core 3.0+.
+
+Of the three possible outcomes the worst is the one that arrives by doing
+nothing: a DPI-aware process with an unaware WinForms **clips** at 150%. So
+**both** manifest declarations go — `dpiAwareness` (2016 schema) and
+`dpiAware` (2005 schema), the second of which alone keeps the process aware —
+and `gdiScaling` stays, since it is honoured only for a DPI-unaware process
+and is what makes the bitmap-scaled result acceptable. `App.config`'s entry is
+removed too, so the two-file dev build and the one-file shipped build are not
+two different DPI configurations.
+
+The result is soft at 150% but correctly sized and never clipped, which is
+what a great many installers look like. If that is judged unacceptable once
+seen, the honest alternatives are shipping two files or writing the wizard
+native, and both belong to 1c with the measurement in hand rather than to a
+guess now.
+
+**Result, 2026-08-31.** A full `package-velopack.ps1 -Rid win-x64` emits a
+wrapper of 84,596,224 bytes, inside the existing `Full|win-x64|setup` budget of
+91,040,173 with 6.4 MB to spare, so **neither budget map was edited** and
+`write-package-evidence.ps1` ran unmodified against it (exit 0,
+`setupName: Nyanako.Syrtis-win-x64-Setup.exe`, `setupBytes: 84596224`).
+Independently confirmed on the emitted file, without executing it: it loads as
+the managed assembly `Syrtis.Installer` and carries both resources —
+`syrtis.ico` at 419,110 bytes and `payload.setup.exe` at 83,726,516. Velopack's
+native Setup can satisfy neither. Extraction of the payload measures 62 ms.
+692 tests pass, up from 677.
+
+**Evidence status of the SHA-256 guard, stated precisely.** Its logic was
+executed — a deliberately mismatched payload produced the refusal and exit 1 —
+but in a harness mirroring the script's step, not in `package-velopack.ps1`
+itself, because injecting a wrong payload into the real script means editing
+the thing under test. The wiring was confirmed by reading: the hash is taken
+from `$setupPath` before the build, the build is given that same path, the
+resource is read back by reflection and compared, and the replacement and then
+the budget assertion follow. Logic executed, wiring read. That is less than
+end-to-end and is recorded as such rather than described as "the pack refuses".
+
 **Carried in from 1a.** The wizard is a WinExe, so it does not attach the
 parent's console: `--silent`'s diagnostic text reaches a caller that redirects
 (a pipe or file is inherited) but not a person typing in a real console window.

--- a/docs/proposals/install-1-wizard.md
+++ b/docs/proposals/install-1-wizard.md
@@ -279,6 +279,17 @@ the managed assembly `Syrtis.Installer` and carries both resources —
 native Setup can satisfy neither. Extraction of the payload measures 62 ms.
 692 tests pass, up from 677.
 
+**Both human acceptances passed, 2026-08-31**, confirmed by the user at the
+machines. On the x64 host, the packed wrapper double-clicked from a directory
+holding nothing else: the brandmark is there, the Welcome page names the packed
+version, and at 150% scaling the window is correctly sized and uncropped — so
+the PerMonitorV2 trade-off recorded above is accepted on evidence rather than on
+argument, and the two alternatives (two files, or a native wizard) stay unspent.
+On the ARM64 VM, the packed `win-arm64` wrapper launched and installed, and the
+app started afterwards. That closes the gate this slice could not close for
+itself: `win-arm64` and `win-arm64-lite` are half the published channels, and
+every automated check above ran only on x64.
+
 **Evidence status of the SHA-256 guard, stated precisely.** Its logic was
 executed — a deliberately mismatched payload produced the refusal and exit 1 —
 but in a harness mirroring the script's step, not in `package-velopack.ps1`

--- a/scripts/package-velopack.ps1
+++ b/scripts/package-velopack.ps1
@@ -515,24 +515,42 @@ if (-not (Test-Path -LiteralPath $wrapperExePath -PathType Leaf)) {
 # nothing here locks the file this script is about to overwrite), and refuse
 # to ship unless its embedded payload is byte-for-byte this invocation's own
 # Velopack Setup.exe.
-$wrapperAssembly = [Reflection.Assembly]::LoadFrom($wrapperExePath)
-$payloadStream = $wrapperAssembly.GetManifestResourceStream("Syrtis.Installer.payload.setup.exe")
-if ($null -eq $payloadStream) {
+#
+# The read happens in a CHILD PROCESS, and that is not incidental. Every
+# wrapper this script builds has the same assembly identity
+# ("Syrtis.Installer, Version=<repo version>"), and Assembly.LoadFrom loads
+# into the process-wide default context. Packing two RIDs from one PowerShell
+# session therefore failed the second one -- measured on the host:
+#
+#   Could not load file or assembly 'Syrtis.Installer, Version=0.2.2.0,
+#   Culture=neutral, PublicKeyToken=null'. Assembly with same name is
+#   already loaded
+#
+# A guard whose whole purpose is to catch a cross-channel payload was
+# rejecting a correct package for a reason that had nothing to do with it.
+# A fresh process cannot collide with anything; a collectible
+# AssemblyLoadContext would also work and is more moving parts for the same
+# answer.
+$readPayloadHash = @'
+param([string]$WrapperPath)
+$ErrorActionPreference = "Stop"
+$asm = [Reflection.Assembly]::LoadFrom($WrapperPath)
+$stream = $asm.GetManifestResourceStream("Syrtis.Installer.payload.setup.exe")
+if ($null -eq $stream) { exit 2 }
+$sha = [System.Security.Cryptography.SHA256]::Create()
+try { $bytes = $sha.ComputeHash($stream) } finally { $sha.Dispose(); $stream.Dispose() }
+[System.BitConverter]::ToString($bytes).Replace("-", "")
+'@
+$readerScript = Join-Path $wrapperBuildDir "read-payload-hash.ps1"
+Set-Content -LiteralPath $readerScript -Value $readPayloadHash -Encoding utf8
+$payloadSha256 = (& pwsh -NoProfile -NonInteractive -File $readerScript -WrapperPath $wrapperExePath) | Select-Object -Last 1
+if ($LASTEXITCODE -eq 2) {
     throw "Install wizard wrapper carries no embedded payload resource: $wrapperExePath"
 }
-try {
-    $sha256 = [System.Security.Cryptography.SHA256]::Create()
-    try {
-        $payloadHashBytes = $sha256.ComputeHash($payloadStream)
-        $payloadSha256 = [System.BitConverter]::ToString($payloadHashBytes).Replace("-", "")
-    }
-    finally {
-        $sha256.Dispose()
-    }
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($payloadSha256)) {
+    throw "Could not read the embedded payload from $wrapperExePath (exit $LASTEXITCODE)."
 }
-finally {
-    $payloadStream.Dispose()
-}
+$payloadSha256 = $payloadSha256.Trim()
 if ($payloadSha256 -ne $velopackSetupSha256) {
     throw ("Embedded payload SHA-256 mismatch: wrapper carries {0}, this invocation's Velopack Setup.exe is {1}. " -f `
         $payloadSha256, $velopackSetupSha256) + `

--- a/scripts/package-velopack.ps1
+++ b/scripts/package-velopack.ps1
@@ -480,6 +480,69 @@ $setupPath = Join-Path $releasesRoot $expectedSetupName
 if (-not (Test-Path -LiteralPath $setupPath -PathType Leaf)) {
     throw "Velopack releases missing expected Setup.exe: $expectedSetupName"
 }
+
+# Build the install wizard with THIS INVOCATION's Velopack Setup.exe embedded,
+# and replace the Setup.exe in $releasesRoot with that wrapper -- one file,
+# same name, before the size-budget assertion below, so that assertion
+# measures the file that actually ships. A per-channel intermediate directory
+# keeps this pack's wrapper build isolated from any other channel packed into
+# the same $outputRootResolved.
+#
+# The SHA-256 of the just-produced Velopack Setup.exe is captured BEFORE the
+# build, from $setupPath, which nothing has touched yet.
+$velopackSetupSha256 = (Get-FileHash -LiteralPath $setupPath -Algorithm SHA256).Hash
+
+$wrapperProject = Join-Path $repoRoot "src\Syrtis.Installer\Syrtis.Installer.csproj"
+$wrapperBuildDir = Join-Path $outputRootResolved ("installer-wrapper\{0}" -f $channel)
+Invoke-Captured -Command "dotnet" -Arguments @(
+    "build", $wrapperProject,
+    "-c", "Release",
+    "-p:SyrtisPayloadPath=$setupPath",
+    "-o", $wrapperBuildDir
+) -FailureMessage "Install wizard wrapper build failed"
+
+$wrapperExePath = Join-Path $wrapperBuildDir "Syrtis.Installer.exe"
+if (-not (Test-Path -LiteralPath $wrapperExePath -PathType Leaf)) {
+    throw "Install wizard wrapper build did not produce: $wrapperExePath"
+}
+
+# Nothing else in the pipeline would catch a stale or cross-channel payload:
+# write-package-evidence.ps1 validates the Setup.exe by name and size only,
+# and (measured) the Full/win-x64 Setup at 83,721,388 bytes fits under the
+# Full/win-arm64 budget of 87,104,109 -- so an arm64-named installer carrying
+# the x64 payload would pass every existing gate. Load the just-built wrapper
+# by reflection, from the intermediate directory (never from $setupPath, so
+# nothing here locks the file this script is about to overwrite), and refuse
+# to ship unless its embedded payload is byte-for-byte this invocation's own
+# Velopack Setup.exe.
+$wrapperAssembly = [Reflection.Assembly]::LoadFrom($wrapperExePath)
+$payloadStream = $wrapperAssembly.GetManifestResourceStream("Syrtis.Installer.payload.setup.exe")
+if ($null -eq $payloadStream) {
+    throw "Install wizard wrapper carries no embedded payload resource: $wrapperExePath"
+}
+try {
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $payloadHashBytes = $sha256.ComputeHash($payloadStream)
+        $payloadSha256 = [System.BitConverter]::ToString($payloadHashBytes).Replace("-", "")
+    }
+    finally {
+        $sha256.Dispose()
+    }
+}
+finally {
+    $payloadStream.Dispose()
+}
+if ($payloadSha256 -ne $velopackSetupSha256) {
+    throw ("Embedded payload SHA-256 mismatch: wrapper carries {0}, this invocation's Velopack Setup.exe is {1}. " -f `
+        $payloadSha256, $velopackSetupSha256) + `
+        "Refusing to ship a stale or cross-channel payload."
+}
+Write-Output ("Embedded payload verified: SHA-256 {0} matches this invocation's Velopack Setup.exe" -f $payloadSha256)
+
+Copy-Item -LiteralPath $wrapperExePath -Destination $setupPath -Force
+Write-Output ("Replaced {0} with the install wizard wrapper ({1} bytes)." -f $expectedSetupName, (Get-Item -LiteralPath $setupPath).Length)
+
 $setupBytes = [int64](Get-Item -LiteralPath $setupPath).Length
 $setupKey = "{0}|{1}|setup" -f $DeploymentMode, $Rid
 if (-not $nupkgSetupBudgetByModeRid.ContainsKey($setupKey)) {

--- a/src/Syrtis.Installer/App.config
+++ b/src/Syrtis.Installer/App.config
@@ -4,11 +4,12 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
 
-  <!-- Paired with app.manifest's dpiAwareness: this is the piece that
-       actually turns PerMonitorV2 on for a WinForms net48 app; the manifest
-       alone opts the process into the DPI story but leaves WinForms itself
-       unaware. Required for crisp rendering at 150% scaling. -->
-  <System.Windows.Forms.ApplicationConfigurationSection>
-    <add key="DpiAwareness" value="PerMonitorV2" />
-  </System.Windows.Forms.ApplicationConfigurationSection>
+  <!-- No DpiAwareness entry, as of slice 1b: app.manifest no longer declares
+       process-level DPI awareness either (see the comment there for why),
+       and the shipping wrapper's single-file form can't carry this file at
+       all — the .NET Framework looks for it as "<exe-name>.exe.config",
+       which the renamed "<packId>-<channel>-Setup.exe" never matches. Left
+       here it would give the two-file dev build a different DPI
+       configuration than every user's one-file build, which is the shape of
+       "works on my machine". -->
 </configuration>

--- a/src/Syrtis.Installer/EmbeddedPayload.cs
+++ b/src/Syrtis.Installer/EmbeddedPayload.cs
@@ -38,11 +38,49 @@ internal static class EmbeddedPayload
                 + $"-{Guid.NewGuid():N}".Substring(0, 9)
                 + ".exe");
 
-        using (var file = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
-        {
-            resource.CopyTo(file, 1 << 20);
-        }
-
+        StreamToNewFile(resource, tempPath);
         return tempPath;
+    }
+
+    /// <summary>Copy a stream to a path that does not yet exist, leaving
+    /// nothing behind if it cannot finish.
+    ///
+    /// <para>The cleanup is the point. FileStream creates the file before a
+    /// single byte is copied, so a failure part-way through — the disk filling
+    /// is the obvious one — leaves up to ~83 MB whose path the caller never
+    /// received and therefore cannot delete. In the disk-full case that is
+    /// perverse twice over: the leftover consumes the space whose absence
+    /// caused the failure, and every retry adds another one.</para>
+    ///
+    /// <para>Catching the exception and cleaning up after it are two separate
+    /// jobs. The commit before this one did the first and left the second
+    /// undone.</para>
+    ///
+    /// <para>Separate from <see cref="ExtractToTemp"/> and taking its source
+    /// as a parameter so a test can hand it a stream that throws mid-copy and
+    /// assert the file is gone. The failure this guards cannot be provoked
+    /// through the public entry point.</para></summary>
+    internal static void StreamToNewFile(Stream source, string destinationPath)
+    {
+        try
+        {
+            using var file = new FileStream(destinationPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            source.CopyTo(file, 1 << 20);
+        }
+        catch (Exception)
+        {
+            try
+            {
+                File.Delete(destinationPath);
+            }
+            catch (Exception)
+            {
+                // Best effort. The original failure is what the caller needs
+                // to hear about; a file we could not remove must not replace
+                // it with a less useful exception.
+            }
+
+            throw;
+        }
     }
 }

--- a/src/Syrtis.Installer/EmbeddedPayload.cs
+++ b/src/Syrtis.Installer/EmbeddedPayload.cs
@@ -1,0 +1,48 @@
+namespace Syrtis.Installer;
+
+/// <summary>Velopack's Setup.exe, embedded in this assembly as a managed
+/// resource by <c>scripts/package-velopack.ps1</c> when it builds the
+/// shipping wrapper. A plain `dotnet build` with no payload property (the
+/// 1a-style build, and every developer inner-loop build) carries no such
+/// resource, which is exactly what <see cref="HasPayload"/> tells apart —
+/// see <see cref="InstallRequest.Parse"/>, which takes that as a
+/// parameter rather than re-deriving it, for why.</summary>
+internal static class EmbeddedPayload
+{
+    private const string ResourceName = "Syrtis.Installer.payload.setup.exe";
+
+    /// <summary>Whether this build carries the embedded Setup.exe. False for
+    /// every net48 build made without the packing script's MSBuild property,
+    /// including the entire net10 test assembly — <c>Parse</c> is exercised
+    /// against both truth values explicitly rather than trusting this to
+    /// vary between test runs.</summary>
+    internal static bool HasPayload =>
+        typeof(EmbeddedPayload).Assembly.GetManifestResourceInfo(ResourceName) != null;
+
+    /// <summary>Streams the embedded payload out to a fresh, per-run temp
+    /// file and returns its path. Never materialises the ~83 MB resource in
+    /// memory — copied through a buffer instead, the same way any large file
+    /// copy is. Named the way <see cref="SetupRunner.NewLogPath"/> is and for
+    /// the same reason: a fixed name can collide between two overlapping
+    /// wrapper instances, or survive as a stale leftover from a previous
+    /// run.</summary>
+    internal static string ExtractToTemp()
+    {
+        using var resource = typeof(EmbeddedPayload).Assembly.GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException($"Embedded payload resource '{ResourceName}' is missing.");
+
+        var tempPath = Path.Combine(
+            Path.GetTempPath(),
+            $"syrtis-setup-{DateTime.UtcNow:yyyyMMdd-HHmmss}"
+                + $"-{System.Diagnostics.Process.GetCurrentProcess().Id}"
+                + $"-{Guid.NewGuid():N}".Substring(0, 9)
+                + ".exe");
+
+        using (var file = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        {
+            resource.CopyTo(file, 1 << 20);
+        }
+
+        return tempPath;
+    }
+}

--- a/src/Syrtis.Installer/InstallRequest.cs
+++ b/src/Syrtis.Installer/InstallRequest.cs
@@ -145,10 +145,18 @@ internal readonly struct InstallRequest
             return Refuse(RefusalReason.UnexpectedArgument, nonSwitchArgs[1], silentRequested);
         }
 
-        var candidate = nonSwitchArgs.FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(candidate))
+        // "No positional argument" and "a positional argument that is blank"
+        // are different things, and only the first may fall through to the
+        // payload. A script written as `Setup.exe "%SETUP_PATH%"` with the
+        // variable unset supplies an empty argument — treating that as "no
+        // argument given" would silently install the embedded payload instead
+        // of the setup that script named, and silently for real with
+        // --silent. That breaks this type's own stated rule: an explicit path
+        // is never replaced by the payload. Tested against Length rather than
+        // against the string, because the string cannot tell them apart.
+        if (nonSwitchArgs.Length == 0)
         {
-            // No explicit path was given: the payload, when embedded, is the
+            // Nothing was asked for: the payload, when embedded, is the
             // default. Without a payload this is unchanged from 1a —
             // NoSetupPath — so a plain 1a-style build still refuses cleanly.
             if (hasEmbeddedPayload)
@@ -157,6 +165,13 @@ internal readonly struct InstallRequest
                 return new InstallRequest(payloadKind, null, default, null, silentRequested);
             }
 
+            return Refuse(RefusalReason.NoSetupPath, null, silentRequested);
+        }
+
+        var candidate = nonSwitchArgs[0];
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            // Present but unusable. Refused whether or not a payload exists.
             return Refuse(RefusalReason.NoSetupPath, null, silentRequested);
         }
 

--- a/src/Syrtis.Installer/InstallRequest.cs
+++ b/src/Syrtis.Installer/InstallRequest.cs
@@ -73,8 +73,13 @@ internal readonly struct InstallRequest
 
     internal InstallRequestKind Kind { get; }
 
-    /// <summary>The resolved, existing setup path. Non-null exactly when
-    /// Kind is RunWizard or RunSilent.</summary>
+    /// <summary>The resolved, existing setup path an explicit argument
+    /// named, or null when Kind is RunWizard/RunSilent by way of the
+    /// embedded payload instead — see <see cref="Parse"/>'s
+    /// <c>hasEmbeddedPayload</c> parameter. Always null when Kind is Refuse
+    /// or SelfCheck. <c>Program</c> resolves the payload case with
+    /// <c>SetupPath ?? EmbeddedPayload.ExtractToTemp()</c> once, immediately
+    /// after Parse.</summary>
     internal string? SetupPath { get; }
 
     /// <summary>Meaningful only when Kind is Refuse.</summary>
@@ -94,7 +99,16 @@ internal readonly struct InstallRequest
     private static InstallRequest Refuse(RefusalReason reason, string? token, bool silentRequested) =>
         new(InstallRequestKind.Refuse, null, reason, token, silentRequested);
 
-    internal static InstallRequest Parse(string[] args)
+    /// <summary><paramref name="hasEmbeddedPayload"/> is a parameter, not an
+    /// ambient read of <see cref="EmbeddedPayload.HasPayload"/>, because the
+    /// net10 test assembly this method is exercised from never carries the
+    /// resource. An ambient check would leave every argument test green while
+    /// describing behaviour the shipping exe no longer has — the same
+    /// "green for the wrong reason" shape earlier findings in this file
+    /// exist to prevent. Only the no-positional-argument row is affected: an
+    /// explicit path, once given, always wins, whether or not a payload is
+    /// embedded.</summary>
+    internal static InstallRequest Parse(string[] args, bool hasEmbeddedPayload)
     {
         var silentRequested = args.Any(SetupLocator.IsSilentSwitch);
 
@@ -134,10 +148,21 @@ internal readonly struct InstallRequest
         var candidate = nonSwitchArgs.FirstOrDefault();
         if (string.IsNullOrWhiteSpace(candidate))
         {
+            // No explicit path was given: the payload, when embedded, is the
+            // default. Without a payload this is unchanged from 1a —
+            // NoSetupPath — so a plain 1a-style build still refuses cleanly.
+            if (hasEmbeddedPayload)
+            {
+                var payloadKind = silentRequested ? InstallRequestKind.RunSilent : InstallRequestKind.RunWizard;
+                return new InstallRequest(payloadKind, null, default, null, silentRequested);
+            }
+
             return Refuse(RefusalReason.NoSetupPath, null, silentRequested);
         }
 
-        // Reuses SetupLocator's own resolution (existence check + GetFullPath)
+        // An explicit path is an instruction and is honoured strictly: found
+        // or not, it is never silently replaced by the payload. Reuses
+        // SetupLocator's own resolution (existence check + GetFullPath)
         // rather than repeating it — the exact duplication this slice exists
         // to remove.
         var setupPath = SetupLocator.Locate(args);

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -7,15 +7,63 @@ internal static class Program
     [STAThread]
     private static int Main(string[] args)
     {
-        var request = InstallRequest.Parse(args);
-        return request.Kind switch
+        var request = InstallRequest.Parse(args, EmbeddedPayload.HasPayload);
+
+        // Resolved once, immediately after Parse and before WizardForm is
+        // constructed: WizardForm reads the payload's product and version in
+        // its constructor via ReadPayloadIdentity, so extracting any later
+        // (e.g. from the Installing page) would put the wrapper's own
+        // version on the Welcome page instead of the payload's. Only
+        // RunWizard/RunSilent ever reach here with SetupPath meaningful;
+        // Refuse and SelfCheck never call ResolveSetupPath.
+        if (request.Kind != InstallRequestKind.RunWizard && request.Kind != InstallRequestKind.RunSilent)
         {
-            InstallRequestKind.SelfCheck => SelfCheck.Run(),
-            InstallRequestKind.Refuse => Fail(request),
-            InstallRequestKind.RunSilent => RunSilent(request),
-            InstallRequestKind.RunWizard => RunGui(request),
-            _ => throw new InvalidOperationException($"Unknown request kind: {request.Kind}"),
-        };
+            return request.Kind switch
+            {
+                InstallRequestKind.SelfCheck => SelfCheck.Run(),
+                InstallRequestKind.Refuse => Fail(request),
+                _ => throw new InvalidOperationException($"Unknown request kind: {request.Kind}"),
+            };
+        }
+
+        var (setupPath, ownsFile) = ResolveSetupPath(request);
+        try
+        {
+            return request.Kind == InstallRequestKind.RunSilent
+                ? RunSilent(setupPath)
+                : RunGui(setupPath);
+        }
+        finally
+        {
+            if (ownsFile)
+            {
+                TryDelete(setupPath);
+            }
+        }
+    }
+
+    /// <summary>The path to hand both surfaces: an explicit argument's path
+    /// verbatim, or the embedded payload extracted to a fresh temp file when
+    /// none was given. <c>ownsFile</c> tells <c>Main</c> whether it is
+    /// responsible for deleting it — an explicit path is the caller's file,
+    /// never ours to remove.</summary>
+    private static (string SetupPath, bool OwnsFile) ResolveSetupPath(InstallRequest request) =>
+        request.SetupPath is { } explicitPath
+            ? (explicitPath, false)
+            : (EmbeddedPayload.ExtractToTemp(), true);
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception)
+        {
+            // Best-effort cleanup; a leftover ~83 MB temp file is a disk-space
+            // nuisance, not a correctness problem, and is not worth failing an
+            // otherwise-complete run over.
+        }
     }
 
     /// <summary>Report a startup problem on whichever surface exists, and
@@ -53,10 +101,8 @@ internal static class Program
     /// (ATTACH_PARENT_PROCESS), which cannot be verified from a remote session
     /// for the same reason the defect cannot be reproduced there, so it waits
     /// for 1b and a real console.</para></summary>
-    private static int RunSilent(InstallRequest request)
+    private static int RunSilent(string setupPath)
     {
-        var setupPath = request.SetupPath!;
-
         // Locate only proved the file is there. Windows can still refuse to
         // run it — quarantined between the check and here, blocked by policy,
         // permissions changed, or simply not an executable — and Process.Start
@@ -91,11 +137,11 @@ internal static class Program
         }
     }
 
-    private static int RunGui(InstallRequest request)
+    private static int RunGui(string setupPath)
     {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
-        Application.Run(new WizardForm(request.SetupPath!));
+        Application.Run(new WizardForm(setupPath));
         return ExitCodes.Ok;
     }
 

--- a/src/Syrtis.Installer/Program.cs
+++ b/src/Syrtis.Installer/Program.cs
@@ -26,7 +26,26 @@ internal static class Program
             };
         }
 
-        var (setupPath, ownsFile) = ResolveSetupPath(request);
+        string setupPath;
+        bool ownsFile;
+        try
+        {
+            (setupPath, ownsFile) = ResolveSetupPath(request);
+        }
+        catch (Exception ex)
+        {
+            // Extraction writes ~83 MB to %TEMP%, so it can fail for reasons
+            // that have nothing to do with the install: a full disk, a
+            // redirected or read-only TEMP, a policy that blocks writing
+            // executables there. Outside this try it threw past both surfaces'
+            // handlers — the wizard vanished with no dialog and --silent
+            // returned an unhandled CLR code instead of the LaunchFailed it
+            // documents. That is the defect Process.Start already taught this
+            // file, reappearing one layer up because a new step was added
+            // above the handlers rather than inside them.
+            return FailToStart(request, ex);
+        }
+
         try
         {
             return request.Kind == InstallRequestKind.RunSilent
@@ -40,6 +59,25 @@ internal static class Program
                 TryDelete(setupPath);
             }
         }
+    }
+
+    /// <summary>Report a failure that happened before either surface existed,
+    /// on whichever surface the request was headed for, and return the same
+    /// LaunchFailed code a failed Process.Start produces. The two are the same
+    /// thing to a caller: Setup never ran.</summary>
+    private static int FailToStart(InstallRequest request, Exception ex)
+    {
+        var message = Strings.ErrorPayloadUnavailable(ex.Message);
+        if (request.Kind == InstallRequestKind.RunWizard && Environment.UserInteractive)
+        {
+            MessageBox.Show(message, Strings.WindowTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        else
+        {
+            Console.Error.WriteLine(message);
+        }
+
+        return ExitCodes.LaunchFailed;
     }
 
     /// <summary>The path to hand both surfaces: an explicit argument's path

--- a/src/Syrtis.Installer/Strings.cs
+++ b/src/Syrtis.Installer/Strings.cs
@@ -42,6 +42,13 @@ internal static class Strings
         $"This installer does not support {arg}.\nUsage: Syrtis.Installer.exe [-s|--silent] <path-to-setup.exe>",
         $"此安裝程式不支援 {arg}。\n用法：Syrtis.Installer.exe [-s|--silent] <setup.exe 的路徑>");
 
+    /// <summary>The embedded payload could not be written out — a full disk, an
+    /// unwritable TEMP. Setup never ran, so this reports the same way a failed
+    /// launch does.</summary>
+    internal static string ErrorPayloadUnavailable(string reason) => T(
+        $"The setup files could not be prepared.\n{reason}",
+        $"無法準備安裝檔案。\n{reason}");
+
     internal static string ErrorSetupLaunchFailed(string path, string reason) => T(
         $"Could not start the setup file: {path}\n{reason}",
         $"無法啟動安裝檔：{path}\n{reason}");

--- a/src/Syrtis.Installer/Syrtis.Installer.csproj
+++ b/src/Syrtis.Installer/Syrtis.Installer.csproj
@@ -29,14 +29,28 @@
 
   <ItemGroup>
     <!-- Reuse TokenBar.App's brandmark rather than copying the binary: built
-         into this exe's own resources via ApplicationIcon below, and also
-         copied to the output directory (Link, not a physical copy in this
-         directory) so WizardForm can load it at runtime for the Welcome
-         page's large icon. -->
-    <Content Include="..\TokenBar.App\Assets\syrtis.ico" Link="syrtis.ico" CopyToOutputDirectory="PreserveNewest" />
+         into this exe's own Win32 resources via ApplicationIcon below (the
+         window/taskbar icon before WizardForm ever runs), and embedded a
+         second time as a managed resource under a fixed logical name so
+         WizardForm can load it at runtime for the window icon and the
+         Welcome page's 96x96 image. A loose CopyToOutputDirectory file (1a's
+         approach) does not survive package-velopack.ps1's wrapper swap: the
+         shipping form is one file, renamed and dropped alone into
+         `releases\`, so a loose companion would vanish silently. -->
+    <EmbeddedResource Include="..\TokenBar.App\Assets\syrtis.ico" LogicalName="Syrtis.Installer.syrtis.ico" />
   </ItemGroup>
   <PropertyGroup>
     <ApplicationIcon>..\TokenBar.App\Assets\syrtis.ico</ApplicationIcon>
   </PropertyGroup>
+
+  <!-- Velopack's Setup.exe, embedded only when package-velopack.ps1 passes
+       -p:SyrtisPayloadPath=<path-to-Setup.exe>. Absent that property (every
+       plain `dotnet build`, including CI's build/test steps and a developer's
+       inner loop) this ItemGroup is empty and the build stays the 1a-style
+       wrapper with no resource at all — EmbeddedPayload.HasPayload is false,
+       and InstallRequest.Parse behaves exactly as slice 1a specified. -->
+  <ItemGroup Condition="'$(SyrtisPayloadPath)' != ''">
+    <EmbeddedResource Include="$(SyrtisPayloadPath)" LogicalName="Syrtis.Installer.payload.setup.exe" />
+  </ItemGroup>
 
 </Project>

--- a/src/Syrtis.Installer/WizardForm.cs
+++ b/src/Syrtis.Installer/WizardForm.cs
@@ -66,10 +66,12 @@ internal sealed class WizardForm : Form
         MinimizeBox = false;
         StartPosition = FormStartPosition.CenterScreen;
         ClientSize = new Size(500, 360);
-        var iconPath = Path.Combine(AppContext.BaseDirectory, "syrtis.ico");
-        if (File.Exists(iconPath))
+        using (var iconStream = OpenBrandmarkIcon())
         {
-            try { Icon = new Icon(iconPath); } catch (ArgumentException) { /* corrupt/unreadable icon file: keep the default */ }
+            if (iconStream != null)
+            {
+                try { Icon = new Icon(iconStream); } catch (ArgumentException) { /* corrupt/unreadable icon resource: keep the default */ }
+            }
         }
 
         var root = new TableLayoutPanel
@@ -126,6 +128,18 @@ internal sealed class WizardForm : Form
 
         GoToStep(WizardStep.Welcome);
     }
+
+    /// <summary>The brandmark, embedded as a managed resource rather than
+    /// read as a loose <c>syrtis.ico</c> next to the exe. The shipping form
+    /// (built by <c>package-velopack.ps1</c>) is one file, so a loose
+    /// companion would vanish silently the moment the wrapper is renamed and
+    /// dropped alone into <c>releases\</c> — both call sites used to be
+    /// guarded by <see cref="File.Exists(string)"/>, which hid exactly that.
+    /// Null when the resource is somehow missing; callers treat that as "no
+    /// icon" rather than throwing, the same tolerance the old
+    /// <c>File.Exists</c> guard gave a missing loose file.</summary>
+    private static Stream? OpenBrandmarkIcon() =>
+        Assembly.GetExecutingAssembly().GetManifestResourceStream("Syrtis.Installer.syrtis.ico");
 
     /// <summary>Product name and version as declared by the setup file itself.
     /// Either may come back null: a file with no version resource, or an
@@ -222,22 +236,24 @@ internal sealed class WizardForm : Form
     {
         var layout = new TableLayoutPanel { ColumnCount = 1, RowCount = 3, Dock = DockStyle.Fill };
 
-        var iconPath = Path.Combine(AppContext.BaseDirectory, "syrtis.ico");
-        if (File.Exists(iconPath))
+        using (var iconStream = OpenBrandmarkIcon())
         {
-            try
+            if (iconStream != null)
             {
-                using var icon = new Icon(iconPath, new Size(96, 96));
-                var picture = new PictureBox
+                try
                 {
-                    Image = icon.ToBitmap(),
-                    SizeMode = PictureBoxSizeMode.Zoom,
-                    Size = new Size(96, 96),
-                    Margin = new Padding(0, 8, 0, 16),
-                };
-                layout.Controls.Add(picture);
+                    using var icon = new Icon(iconStream, new Size(96, 96));
+                    var picture = new PictureBox
+                    {
+                        Image = icon.ToBitmap(),
+                        SizeMode = PictureBoxSizeMode.Zoom,
+                        Size = new Size(96, 96),
+                        Margin = new Padding(0, 8, 0, 16),
+                    };
+                    layout.Controls.Add(picture);
+                }
+                catch (ArgumentException) { /* corrupt/unreadable icon resource: show no image */ }
             }
-            catch (ArgumentException) { /* corrupt/unreadable icon file: show no image */ }
         }
 
         var heading = new Label

--- a/src/Syrtis.Installer/app.manifest
+++ b/src/Syrtis.Installer/app.manifest
@@ -19,14 +19,29 @@
     </application>
   </compatibility>
 
-  <!-- Paired with the DpiAwareness entry in App.config's
-       System.Windows.Forms.ApplicationConfigurationSection: WinForms needs
-       both to render crisply under PerMonitorV2 scaling (e.g. 150%) instead
-       of being DPI-virtualized (blurry, GDI-scaled text and controls). -->
+  <!-- Deliberately DPI-unaware, as of slice 1b. PerMonitorV2 needed a second
+       piece to actually take effect in WinForms: App.config's
+       System.Windows.Forms.ApplicationConfigurationSection DpiAwareness
+       entry, read from "<exe-name>.exe.config" next to the exe. The shipping
+       wrapper built by package-velopack.ps1 is renamed to
+       "<packId>-<channel>-Setup.exe" and is one file by design, so that
+       config can never travel with it, and net48 has no programmatic
+       substitute (Application.SetHighDpiMode is .NET Core 3.0+).
+
+       Declaring awareness here without that companion is the worst of the
+       three outcomes: a DPI-aware *process* with DPI-unaware WinForms lays
+       out at 96 DPI and CLIPS at high scaling, which is worse than blurring.
+       Both awareness declarations are therefore removed — dpiAwareness
+       (2016 schema) AND dpiAware (2005 schema); the second alone is enough
+       to make the process per-monitor aware on Windows 8.1+, so dropping
+       only the first still clips.
+
+       gdiScaling stays, and only now does it do anything: it is honoured
+       only for a DPI-unaware process, so GDI text/primitives are redrawn at
+       the higher DPI (soft, not clipped) instead of being bitmap-stretched
+       with nothing at all. -->
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
       <gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</gdiScaling>
     </windowsSettings>
   </application>

--- a/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
+++ b/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
@@ -21,6 +21,18 @@ namespace TokenBar.Core.Tests;
 // No test in this file may read a Strings member whose value depends on
 // ambient culture. Only Strings.DetectChinese(tag) — which takes the tag as a
 // parameter rather than reading CultureInfo.CurrentUICulture — is referenced.
+//
+// InstallRequest.Parse takes "does a payload exist" as a bool parameter
+// rather than reading EmbeddedPayload.HasPayload ambiently, precisely so this
+// suite can cover both worlds — every InlineData/Theory pair marked "payload
+// world" below asserts against a literal true/false, not against this
+// assembly's own resources (which never carries the payload). That makes
+// `dotnet test` green here necessary but NOT evidence that the shipping
+// wrapper's payload is present, correct, or the one this pack run produced:
+// EmbeddedPayload.ExtractToTemp() and the resource itself are proven only on
+// the built artifact, by loading it with Assembly.LoadFrom and comparing its
+// SHA-256 against the Velopack Setup from the same pack invocation (see
+// package-velopack.ps1's post-pack verification step).
 public class InstallerBoundaryTests
 {
     // --- SetupRunner.Quote ---------------------------------------------------
@@ -180,18 +192,22 @@ public class InstallerBoundaryTests
 
     // --- InstallRequest.Parse -------------------------------------------------
 
-    [Fact]
-    public void Parse_self_check_alone_is_self_check_mode()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Parse_self_check_alone_is_self_check_mode(bool hasEmbeddedPayload)
     {
-        var request = InstallRequest.Parse(["--self-check"]);
+        var request = InstallRequest.Parse(["--self-check"], hasEmbeddedPayload);
 
         Assert.Equal(InstallRequestKind.SelfCheck, request.Kind);
     }
 
-    [Fact]
-    public void Parse_self_check_with_anything_else_is_a_refusal()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Parse_self_check_with_anything_else_is_a_refusal(bool hasEmbeddedPayload)
     {
-        var request = InstallRequest.Parse(["--self-check", "extra"]);
+        var request = InstallRequest.Parse(["--self-check", "extra"], hasEmbeddedPayload);
 
         Assert.Equal(InstallRequestKind.Refuse, request.Kind);
         Assert.Equal(RefusalReason.UnexpectedArgument, request.Reason);
@@ -205,14 +221,19 @@ public class InstallerBoundaryTests
     // tokens are non-switches to a parser that only knows -s. A lone "-v" was
     // reported as a missing setup file.
     [Theory]
-    [InlineData(new[] { "--installto", "D:\\X" }, "--installto")]
-    [InlineData(new[] { "-v" }, "-v")]
-    [InlineData(new[] { "-l", "C:\\some.log" }, "-l")]
-    [InlineData(new[] { "--silent", "--installto", "D:\\X" }, "--installto")]
-    [InlineData(new[] { "setup.exe", "-t", "D:\\X" }, "-t")]
-    public void Parse_names_the_unsupported_switch_not_its_value(string[] args, string expected)
+    [InlineData(new[] { "--installto", "D:\\X" }, "--installto", false)]
+    [InlineData(new[] { "-v" }, "-v", false)]
+    [InlineData(new[] { "-l", "C:\\some.log" }, "-l", false)]
+    [InlineData(new[] { "--silent", "--installto", "D:\\X" }, "--installto", false)]
+    [InlineData(new[] { "setup.exe", "-t", "D:\\X" }, "-t", false)]
+    [InlineData(new[] { "--installto", "D:\\X" }, "--installto", true)]
+    [InlineData(new[] { "-v" }, "-v", true)]
+    [InlineData(new[] { "-l", "C:\\some.log" }, "-l", true)]
+    [InlineData(new[] { "--silent", "--installto", "D:\\X" }, "--installto", true)]
+    [InlineData(new[] { "setup.exe", "-t", "D:\\X" }, "-t", true)]
+    public void Parse_names_the_unsupported_switch_not_its_value(string[] args, string expected, bool hasEmbeddedPayload)
     {
-        var request = InstallRequest.Parse(args);
+        var request = InstallRequest.Parse(args, hasEmbeddedPayload);
 
         Assert.Equal(InstallRequestKind.Refuse, request.Kind);
         Assert.Equal(RefusalReason.UnsupportedSwitch, request.Reason);
@@ -220,11 +241,15 @@ public class InstallerBoundaryTests
     }
 
     // A Windows path never begins with '-', so the switch test is unambiguous;
-    // '/x' is a rooted path and must NOT be mistaken for a switch.
-    [Fact]
-    public void Parse_does_not_treat_a_slash_rooted_path_as_a_switch()
+    // '/x' is a rooted path and must NOT be mistaken for a switch. An explicit
+    // path that does not exist is still SetupNotFound in both worlds — it is
+    // never silently replaced by the payload (precedence table row 3).
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Parse_does_not_treat_a_slash_rooted_path_as_a_switch(bool hasEmbeddedPayload)
     {
-        var request = InstallRequest.Parse(["/nonexistent/setup.exe"]);
+        var request = InstallRequest.Parse(["/nonexistent/setup.exe"], hasEmbeddedPayload);
 
         Assert.Equal(InstallRequestKind.Refuse, request.Kind);
         Assert.Equal(RefusalReason.SetupNotFound, request.Reason);
@@ -239,7 +264,7 @@ public class InstallerBoundaryTests
         var setupPath = CreateTempFile();
         try
         {
-            var request = InstallRequest.Parse([silentSwitch, setupPath]);
+            var request = InstallRequest.Parse([silentSwitch, setupPath], hasEmbeddedPayload: false);
 
             Assert.Equal(InstallRequestKind.RunSilent, request.Kind);
         }
@@ -249,30 +274,17 @@ public class InstallerBoundaryTests
         }
     }
 
-    [Fact]
-    public void Parse_silent_switch_before_path_works()
+    // Precedence table row 2: an explicit existing path wins in both worlds,
+    // and the payload plays no part when one is given.
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Parse_silent_switch_before_path_works(bool hasEmbeddedPayload)
     {
         var setupPath = CreateTempFile();
         try
         {
-            var request = InstallRequest.Parse(["-s", setupPath]);
-
-            Assert.Equal(InstallRequestKind.RunSilent, request.Kind);
-            Assert.Equal(Path.GetFullPath(setupPath), request.SetupPath);
-        }
-        finally
-        {
-            File.Delete(setupPath);
-        }
-    }
-
-    [Fact]
-    public void Parse_silent_switch_after_path_works()
-    {
-        var setupPath = CreateTempFile();
-        try
-        {
-            var request = InstallRequest.Parse([setupPath, "-s"]);
+            var request = InstallRequest.Parse(["-s", setupPath], hasEmbeddedPayload);
 
             Assert.Equal(InstallRequestKind.RunSilent, request.Kind);
             Assert.Equal(Path.GetFullPath(setupPath), request.SetupPath);
@@ -283,13 +295,36 @@ public class InstallerBoundaryTests
         }
     }
 
-    [Fact]
-    public void Parse_second_non_switch_argument_is_unexpected()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Parse_silent_switch_after_path_works(bool hasEmbeddedPayload)
     {
         var setupPath = CreateTempFile();
         try
         {
-            var request = InstallRequest.Parse([setupPath, "extra-token"]);
+            var request = InstallRequest.Parse([setupPath, "-s"], hasEmbeddedPayload);
+
+            Assert.Equal(InstallRequestKind.RunSilent, request.Kind);
+            Assert.Equal(Path.GetFullPath(setupPath), request.SetupPath);
+        }
+        finally
+        {
+            File.Delete(setupPath);
+        }
+    }
+
+    // Precedence table row 4: two positional arguments is always
+    // UnexpectedArgument, regardless of whether a payload is embedded.
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Parse_second_non_switch_argument_is_unexpected(bool hasEmbeddedPayload)
+    {
+        var setupPath = CreateTempFile();
+        try
+        {
+            var request = InstallRequest.Parse([setupPath, "extra-token"], hasEmbeddedPayload);
 
             Assert.Equal(InstallRequestKind.Refuse, request.Kind);
             Assert.Equal(RefusalReason.UnexpectedArgument, request.Reason);
@@ -301,43 +336,76 @@ public class InstallerBoundaryTests
         }
     }
 
+    // Precedence table row 1, "Without" column: no positional argument and no
+    // embedded payload is still NoSetupPath — the 1a-style build (a plain
+    // `dotnet build`, and the entire net10 test assembly) refuses exactly as
+    // slice 1a specified.
     [Fact]
-    public void Parse_no_path_at_all_is_no_setup_path()
+    public void Parse_no_path_at_all_is_no_setup_path_without_a_payload()
     {
-        var request = InstallRequest.Parse([]);
+        var request = InstallRequest.Parse([], hasEmbeddedPayload: false);
 
         Assert.Equal(InstallRequestKind.Refuse, request.Kind);
         Assert.Equal(RefusalReason.NoSetupPath, request.Reason);
     }
 
     [Fact]
-    public void Parse_no_path_with_only_silent_switch_is_no_setup_path()
+    public void Parse_no_path_with_only_silent_switch_is_no_setup_path_without_a_payload()
     {
-        var request = InstallRequest.Parse(["--silent"]);
+        var request = InstallRequest.Parse(["--silent"], hasEmbeddedPayload: false);
 
         Assert.Equal(InstallRequestKind.Refuse, request.Kind);
         Assert.Equal(RefusalReason.NoSetupPath, request.Reason);
     }
 
+    // Precedence table row 1, "With a payload embedded" column: this is the
+    // row that changes behaviour, and it is what makes `--silent` with no
+    // arguments at all work. SetupPath is null here — Program resolves it via
+    // EmbeddedPayload.ExtractToTemp(), which this net10 suite cannot exercise
+    // (see the class remarks: no embedded resource exists in this assembly).
     [Fact]
-    public void Parse_missing_setup_file_is_setup_not_found()
+    public void Parse_no_path_at_all_runs_the_wizard_from_the_payload_when_one_is_embedded()
+    {
+        var request = InstallRequest.Parse([], hasEmbeddedPayload: true);
+
+        Assert.Equal(InstallRequestKind.RunWizard, request.Kind);
+        Assert.Null(request.SetupPath);
+    }
+
+    [Fact]
+    public void Parse_no_path_with_silent_switch_runs_silently_from_the_payload_when_one_is_embedded()
+    {
+        var request = InstallRequest.Parse(["--silent"], hasEmbeddedPayload: true);
+
+        Assert.Equal(InstallRequestKind.RunSilent, request.Kind);
+        Assert.Null(request.SetupPath);
+    }
+
+    // Precedence table row 3: a path that does not exist is still an error in
+    // both worlds — never silently replaced by the payload.
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Parse_missing_setup_file_is_setup_not_found(bool hasEmbeddedPayload)
     {
         var missing = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-        var request = InstallRequest.Parse([missing]);
+        var request = InstallRequest.Parse([missing], hasEmbeddedPayload);
 
         Assert.Equal(InstallRequestKind.Refuse, request.Kind);
         Assert.Equal(RefusalReason.SetupNotFound, request.Reason);
         Assert.Equal(missing, request.Token);
     }
 
-    [Fact]
-    public void Parse_existing_path_without_silent_switch_is_run_wizard()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Parse_existing_path_without_silent_switch_is_run_wizard(bool hasEmbeddedPayload)
     {
         var setupPath = CreateTempFile();
         try
         {
-            var request = InstallRequest.Parse([setupPath]);
+            var request = InstallRequest.Parse([setupPath], hasEmbeddedPayload);
 
             Assert.Equal(InstallRequestKind.RunWizard, request.Kind);
             Assert.Equal(Path.GetFullPath(setupPath), request.SetupPath);

--- a/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
+++ b/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
@@ -105,6 +105,42 @@ public class InstallerBoundaryTests
         Assert.Equal("Syrtis", PayloadIdentity.Choose("  Syrtis  ", null, "?"));
     }
 
+    // A blank positional argument is an explicit path that happens to be
+    // empty, not the absence of one — `Setup.exe "%SETUP_PATH%"` with the
+    // variable unset. Falling through to the payload would silently install
+    // something other than what the script named, and silently for real under
+    // --silent, breaking the rule that an explicit path is never replaced by
+    // the payload.
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Parse_refuses_a_blank_path_even_with_a_payload(string blank)
+    {
+        var request = InstallRequest.Parse([blank], hasEmbeddedPayload: true);
+
+        Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+        Assert.Equal(RefusalReason.NoSetupPath, request.Reason);
+    }
+
+    [Fact]
+    public void Parse_refuses_a_blank_path_under_silent_with_a_payload()
+    {
+        var request = InstallRequest.Parse(["--silent", ""], hasEmbeddedPayload: true);
+
+        Assert.Equal(InstallRequestKind.Refuse, request.Kind);
+        Assert.Equal(RefusalReason.NoSetupPath, request.Reason);
+    }
+
+    // The row it must not be confused with: genuinely no positional argument.
+    [Fact]
+    public void Parse_uses_the_payload_when_no_argument_is_given()
+    {
+        var request = InstallRequest.Parse([], hasEmbeddedPayload: true);
+
+        Assert.Equal(InstallRequestKind.RunWizard, request.Kind);
+        Assert.Null(request.SetupPath);
+    }
+
     // --- EmbeddedPayload.StreamToNewFile ---------------------------------------
 
     // FileStream creates the file before a byte is copied, so a failure

--- a/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
+++ b/src/TokenBar.Core.Tests/InstallerBoundaryTests.cs
@@ -105,6 +105,74 @@ public class InstallerBoundaryTests
         Assert.Equal("Syrtis", PayloadIdentity.Choose("  Syrtis  ", null, "?"));
     }
 
+    // --- EmbeddedPayload.StreamToNewFile ---------------------------------------
+
+    // FileStream creates the file before a byte is copied, so a failure
+    // part-way leaves up to ~83 MB whose path the caller never received and
+    // therefore cannot delete. In the disk-full case the leftover consumes the
+    // space whose absence caused the failure, and every retry adds another.
+    [Fact]
+    public void StreamToNewFile_removes_the_partial_file_when_the_copy_throws()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var source = new ThrowingStream(failAfterBytes: 8);
+
+        Assert.Throws<IOException>(() => EmbeddedPayload.StreamToNewFile(source, path));
+        Assert.False(File.Exists(path), $"partial file left behind at {path}");
+    }
+
+    [Fact]
+    public void StreamToNewFile_writes_the_whole_stream_when_it_succeeds()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var payload = new byte[4096];
+        new Random(1).NextBytes(payload);
+        try
+        {
+            EmbeddedPayload.StreamToNewFile(new MemoryStream(payload), path);
+
+            Assert.Equal(payload, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>Yields some bytes, then fails — the shape of a disk filling
+    /// up rather than of a stream that was never readable.</summary>
+    private sealed class ThrowingStream(int failAfterBytes) : Stream
+    {
+        private int _remaining = failAfterBytes;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_remaining <= 0)
+            {
+                throw new IOException("simulated mid-copy failure");
+            }
+
+            var n = Math.Min(count, _remaining);
+            Array.Clear(buffer, offset, n);
+            _remaining -= n;
+            return n;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     // --- SetupRunner.NewLogPath -----------------------------------------------
 
     // The log path used to be one fixed name, and two defects came out of that:

--- a/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
+++ b/src/TokenBar.Core.Tests/TokenBar.Core.Tests.csproj
@@ -48,6 +48,7 @@
          Syrtis.Installer.exe's hidden self-check switch on the framework
          that actually ships. See InstallerBoundaryTests.cs for the same
          note next to the tests. -->
+    <Compile Include="..\Syrtis.Installer\EmbeddedPayload.cs" Link="Installer\EmbeddedPayload.cs" />
     <Compile Include="..\Syrtis.Installer\ExitCodes.cs" Link="Installer\ExitCodes.cs" />
     <Compile Include="..\Syrtis.Installer\InstallRequest.cs" Link="Installer\InstallRequest.cs" />
     <Compile Include="..\Syrtis.Installer\PayloadIdentity.cs" Link="Installer\PayloadIdentity.cs" />


### PR DESCRIPTION
Slice INSTALL-1b. The user downloads **one file**, meets SmartScreen **once**, and no published asset name changes: `package-velopack.ps1` builds the wizard with Velopack's `Setup.exe` embedded and replaces the Setup in `releases\` with it.

Design and the four review rounds behind it are in `docs/proposals/install-1-wizard.md`.

## Reading the pipeline first made this small

| Assumption | Reality |
|---|---|
| `write-package-evidence.ps1` needs changing | **No.** It validates the Setup by name and size only — every structural check is on the nupkg. Ran unmodified, exit 0. |
| CI needs changing | **No.** `deployment-matrix` packages by calling `package-velopack.ps1` directly. |
| Both size budget maps need updating | **No.** x64 84,596,224 / 91,040,173 · arm64 80,744,960 / 87,104,109. |

## Four blockers that would have shipped

Ten came out of review; these four survive only because someone looked.

**A cross-channel payload would have passed every gate.** The Full/win-x64 Setup at 83,721,388 bytes fits under the Full/win-arm64 budget of 87,104,109, and nothing in the pipeline hashes the Setup against anything — an arm64-named installer carrying the x64 payload would have reached half the published channels silently. The pack now hashes the Velopack Setup **before** the build, reads the resource back out of the wrapper by reflection, and refuses on mismatch. Observed running on both channels, with different hashes.

**The icon would have vanished.** `syrtis.ico` was a loose file beside the exe and both load sites are `File.Exists`-guarded, so a lone `Setup.exe` would have lost the window icon and the Welcome brandmark **with no error**. Embedded now; confirmed present in the emitted artifact at 419,110 bytes.

**The Welcome page would have shown the wrapper's version.** `WizardForm` reads the payload's identity in its **constructor**, so extraction had to happen before construction, not at the Installing page.

**The proposed proof could have performed a real install.** Running the emitted file with `--self-check` assumes Velopack's Setup rejects unknown switches; if it ignores them it installs and exits 0, which looks exactly like a pass. The check is now to load the file as a managed assembly and enumerate its payload resource — it cannot run anything.

## Payload presence is a parameter, not an ambient check

`InstallRequest.Parse(args, hasEmbeddedPayload)`. The net10 test assembly never carries the resource, so checking for it directly would have left every argument test green while describing behaviour the shipping exe no longer has — the failure INSTALL-1a2 exists to prevent, one slice later.

Only the no-positional-argument row branches on it. An explicit path still wins, and a path that does not exist is still `SetupNotFound` rather than being silently replaced by the payload.

## PerMonitorV2 is given up, deliberately

`App.config` ships as `<exe-name>.exe.config`; its `ApplicationConfigurationSection` entry is what actually makes WinForms DPI-aware, the manifest alone opts only the *process* in. The rename to the Setup filename orphans it, the shipping form is one file, and net48 has no programmatic substitute.

Of three outcomes the worst arrives by doing nothing: a DPI-aware process with an unaware WinForms lays out at 96 DPI and **clips** at 150%. So **both** manifest declarations go — `dpiAwareness` (2016) and `dpiAware` (2005), the second of which alone keeps the process aware — and `gdiScaling` stays, honoured only for a DPI-unaware process and now doing something for the first time. `App.config`'s entry goes too, so the dev build and every user's build are not two different DPI configurations.

Soft at 150%, correctly sized. A real regression against 1a, taken with its alternatives written down. **The user confirmed at 150% that the window is correctly sized and uncropped**, so the alternatives stay unspent.

## Verification

692 tests pass, up from 677; the precedence table is covered in both payload worlds, and the test file records that green there is not evidence about the shipped payload. Payload extraction measures 62 ms for 83.7 MB.

Both human acceptances passed at the machines: on x64, the wrapper double-clicked from a directory holding nothing else shows the brandmark, names the packed version, and is uncropped at 150%; on the ARM64 VM the packed `win-arm64` wrapper launched, installed, and the app started. That gate matters because half the published channels are ARM64 and every automated check ran only on x64.

**One evidence gap, stated rather than papered over.** The SHA-256 guard's *failure* path was exercised in a harness mirroring the script's step, not in `package-velopack.ps1` itself — injecting a wrong payload into the real script means editing the thing under test. Its *success* path was observed running in the real script on both channels. Logic executed, wiring observed on the good path only.
