### PR TITLE
feat(quota): export stored quota history and fold it into cycles

### DIFF
--- a/crates/tb_core_ffi/src/agent_quota_history.rs
+++ b/crates/tb_core_ffi/src/agent_quota_history.rs
@@ -338,8 +338,27 @@ pub(crate) struct ExportedSeries {
 /// the user's file to `quota-pace-history-v3.corrupt-{now}.json` on a parse or
 /// validation failure and takes the process plus exclusive file lock, with a
 /// possible `save_store_atomic` on the way out. Renaming the user's history is
-/// not an acceptable cost for drawing a card, so a parse failure is reported as
-/// an error envelope and the file is left exactly as found.
+/// not an acceptable cost for drawing a card, so a failure is reported as an
+/// error envelope and the file's contents, name and mtime are left as found.
+/// One thing does change, stated here rather than implied away: on unix
+/// `secure_open_regular_file` normalizes the mode to 0600, so a store left at
+/// 0644 comes back at 0600. That is the read primitive's pre-existing
+/// hardening, it only tightens, and it is measured by
+/// `export_history_leaves_a_corrupt_store_untouched`.
+///
+/// **Skipping the quarantine is not a licence to skip the validation.** Those
+/// are two separable things that `load_store_at_with_mode` happens to do
+/// together, and taking the whole path out took the check with it: a store that
+/// is syntactically valid JSON but violates the v3 invariants — a foreign
+/// `schema_version`, unordered or invalid series keys, a sample outside its own
+/// cycle bounds — would otherwise be exported as legitimate history and folded
+/// into cycles and heatmap cells that describe nothing. `validate_store` is a
+/// pure predicate over the deserialized value: no clock, no lock, no write.
+///
+/// `validate_store` and not `validate_store_at`: the latter additionally
+/// requires `last_activity_at <= now`, which a clock that has moved backwards
+/// violates through no fault of the data. A skewed clock should not blank the
+/// lens.
 ///
 /// The guarded read primitives are still used — `read_owner_only_with_mode`
 /// (which is `open_existing_owner_only_with_mode` +
@@ -360,6 +379,9 @@ fn export_history_at_with_mode(
         return Ok(Vec::new());
     };
     let store = serde_json::from_slice::<Store>(&bytes).map_err(|_| HistoryError::Read)?;
+    if !validate_store(&store) {
+        return Err(HistoryError::Read);
+    }
     Ok(store
         .series
         .iter()
@@ -6858,6 +6880,68 @@ mod tests {
             export_history_at_with_mode(StorageMode::Generic, &path),
             Ok(Vec::new())
         );
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// A foreign `schema_version` parses fine and means nothing this fold can
+    /// read. It is the shape the pending v3-to-v4 migration will actually
+    /// produce, so the export has to refuse it rather than describe it.
+    #[test]
+    fn export_history_refuses_a_store_from_another_schema() {
+        let (directory, path) = temp_path("export-schema");
+        let mut series = SeriesState::new(&key("acct"), 1_800_000_000);
+        series.samples = complete_cycle(1_800_000_000 - 5 * 3_600, 5 * 3_600, 40.0);
+        let store = Store {
+            schema_version: HISTORY_SCHEMA_VERSION + 1,
+            series: vec![series],
+        };
+        fs::write(&path, serde_json::to_vec(&store).unwrap()).unwrap();
+        let before = fs::read(&path).unwrap();
+
+        assert_eq!(
+            export_history_at_with_mode(StorageMode::Generic, &path),
+            Err(HistoryError::Read)
+        );
+        assert_eq!(fs::read(&path).unwrap(), before);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// Syntactically valid, semantically nonsense. Exporting this would put a
+    /// sample the writer would never have admitted in front of the fold, where
+    /// it becomes a cycle and a heatmap cell describing usage that never
+    /// happened — and it would do so silently, since nothing downstream
+    /// re-checks what the loader is supposed to have checked.
+    #[test]
+    fn export_history_refuses_a_store_with_an_out_of_range_sample() {
+        let (directory, path) = temp_path("export-invalid-sample");
+        let duration = 5 * 3_600;
+        let reset = 1_800_000_000;
+        let mut series = SeriesState::new(&key("acct"), reset);
+        series.samples = complete_cycle(reset - duration, duration, 40.0);
+        series.samples.push(quota_sample(
+            reset,
+            duration,
+            0.5,
+            250.0,
+            SampleOrigin::LiveV3,
+        ));
+        let store = Store {
+            schema_version: HISTORY_SCHEMA_VERSION,
+            series: vec![series],
+        };
+        fs::write(&path, serde_json::to_vec(&store).unwrap()).unwrap();
+        let before = fs::read(&path).unwrap();
+
+        assert_eq!(
+            export_history_at_with_mode(StorageMode::Generic, &path),
+            Err(HistoryError::Read)
+        );
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert!(!fs::read_dir(&directory).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with("quota-pace-history-v3.corrupt-")));
         fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/crates/tb_core_ffi/src/agent_quota_history.rs
+++ b/crates/tb_core_ffi/src/agent_quota_history.rs
@@ -346,6 +346,22 @@ pub(crate) struct ExportedSeries {
 /// hardening, it only tightens, and it is measured by
 /// `export_history_leaves_a_corrupt_store_untouched`.
 ///
+/// **`load_store_at_with_mode` carries four responsibilities and only two were
+/// meant to go.** Reaching past it dropped all four at once, and each of the two
+/// that were not supposed to go came back as a separate review finding:
+///
+/// | Responsibility | Intended |
+/// |---|---|
+/// | Quarantines the file on failure | dropped on purpose |
+/// | `save_store_atomic` on the way out | dropped on purpose |
+/// | `validate_store_at` | dropped by accident — see below |
+/// | Mutual exclusion against the writer, via the lock | dropped by accident — see `EXPORT_READ_ATTEMPTS` |
+///
+/// The lesson is worth more than either fix: removing a function because of one
+/// thing it does removes everything else it was doing, and only the reason for
+/// removing it gets thought about. Anything added here later should be checked
+/// against this table first.
+///
 /// **Skipping the quarantine is not a licence to skip the validation.** Those
 /// are two separable things that `load_store_at_with_mode` happens to do
 /// together, and taking the whole path out took the check with it: a store that
@@ -370,12 +386,49 @@ pub(crate) fn export_history() -> Result<Vec<ExportedSeries>, HistoryError> {
     export_history_at_with_mode(StorageMode::System, &path)
 }
 
+/// How many times the export re-reads a store that moved underneath it.
+///
+/// `read_owner_only_with_mode` verifies **after** reading that the handle it
+/// read is still the file at the path — `same_file` on unix, `verify_path_identity`
+/// under Windows secure storage. That check is written for a caller holding the
+/// history lock, where no writer can intervene. The export deliberately does not
+/// take the lock, so an ordinary recording transaction, which installs the new
+/// store with an atomic rename, turns a perfectly consistent read of the old
+/// file into an error and blanks the lens at random during normal refreshes.
+///
+/// Three attempts because a transaction replaces the file once; a retry lands on
+/// whichever side of the rename is now settled. This does not weaken the check
+/// it retries: every attempt re-opens and re-verifies from scratch, so a
+/// substituted path has to win the race on every attempt rather than on one.
+///
+/// Any read error retries, not just the identity one. The identity failure is an
+/// `InvalidInput` distinguished from its neighbour only by message text, and a
+/// guard that pins message text is a guard that gets relocated around. A
+/// genuinely persistent error costs two extra opens and then fails exactly as
+/// before.
+const EXPORT_READ_ATTEMPTS: usize = 3;
+
+fn read_store_bytes_with_retry(
+    mut read: impl FnMut() -> io::Result<Option<Vec<u8>>>,
+) -> io::Result<Option<Vec<u8>>> {
+    let mut attempt = 1;
+    loop {
+        match read() {
+            Ok(bytes) => return Ok(bytes),
+            Err(error) if attempt >= EXPORT_READ_ATTEMPTS => return Err(error),
+            Err(_) => attempt += 1,
+        }
+    }
+}
+
 fn export_history_at_with_mode(
     mode: StorageMode,
     path: &Path,
 ) -> Result<Vec<ExportedSeries>, HistoryError> {
     // No history file yet is an empty lens, not a failure.
-    let Some(bytes) = read_owner_only_with_mode(mode, path).map_err(|_| HistoryError::Read)? else {
+    let Some(bytes) = read_store_bytes_with_retry(|| read_owner_only_with_mode(mode, path))
+        .map_err(|_| HistoryError::Read)?
+    else {
         return Ok(Vec::new());
     };
     let store = serde_json::from_slice::<Store>(&bytes).map_err(|_| HistoryError::Read)?;
@@ -6881,6 +6934,45 @@ mod tests {
             Ok(Vec::new())
         );
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// The race this stands in for cannot be scheduled deterministically, so the
+    /// retry is tested as the decision it is: the read fails the way a store
+    /// replaced mid-read fails, and the export tries again instead of blanking.
+    #[test]
+    fn export_history_retries_a_store_replaced_underneath_it() {
+        let mut attempts = 0;
+        let result = read_store_bytes_with_retry(|| {
+            attempts += 1;
+            if attempts < EXPORT_READ_ATTEMPTS {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "quota pace artifact changed while opening",
+                ))
+            } else {
+                Ok(Some(b"{}".to_vec()))
+            }
+        });
+
+        assert_eq!(attempts, EXPORT_READ_ATTEMPTS);
+        assert_eq!(result.unwrap(), Some(b"{}".to_vec()));
+    }
+
+    /// The budget has to end. A path that keeps failing is reported, not retried
+    /// until something else times out.
+    #[test]
+    fn export_history_gives_up_after_the_read_attempt_budget() {
+        let mut attempts = 0;
+        let result = read_store_bytes_with_retry(|| {
+            attempts += 1;
+            Err::<Option<Vec<u8>>, io::Error>(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "denied",
+            ))
+        });
+
+        assert_eq!(attempts, EXPORT_READ_ATTEMPTS);
+        assert!(result.is_err());
     }
 
     /// A foreign `schema_version` parses fine and means nothing this fold can

--- a/crates/tb_core_ffi/src/agent_quota_history.rs
+++ b/crates/tb_core_ffi/src/agent_quota_history.rs
@@ -304,6 +304,90 @@ pub(crate) fn production_history_path() -> Option<PathBuf> {
     Some(directory.join(HISTORY_FILE_NAME))
 }
 
+/// One persisted sample as the quota lens consumes it: the stored fields plus
+/// the producer's own answer to "is this the cycle still running".
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ExportedSample {
+    pub(crate) reset_at: i64,
+    pub(crate) duration_seconds: i64,
+    pub(crate) duration_source: DurationSource,
+    pub(crate) used_percent: f64,
+    pub(crate) sampled_at: i64,
+    pub(crate) origin: SampleOrigin,
+    /// Never derivable downstream — see `is_active_group_sample`.
+    pub(crate) is_active_group: bool,
+}
+
+/// The store's own identity triple plus its raw samples. `cardId`/`label` are
+/// deliberately absent: they are not in the store, and joining them would turn
+/// a disk read into a network-dependent call. The consumer joins the label on
+/// `(clientId, paceStatus.windowKey)` from the live agent-usage payload.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ExportedSeries {
+    pub(crate) provider_id: String,
+    pub(crate) account_scope: String,
+    pub(crate) window_key: String,
+    pub(crate) samples: Vec<ExportedSample>,
+}
+
+/// Read the persisted history for the quota lens, mutating nothing.
+///
+/// Deliberately NOT `load_store_at_with_mode` or its wrapper: that quarantines
+/// the user's file to `quota-pace-history-v3.corrupt-{now}.json` on a parse or
+/// validation failure and takes the process plus exclusive file lock, with a
+/// possible `save_store_atomic` on the way out. Renaming the user's history is
+/// not an acceptable cost for drawing a card, so a parse failure is reported as
+/// an error envelope and the file is left exactly as found.
+///
+/// The guarded read primitives are still used — `read_owner_only_with_mode`
+/// (which is `open_existing_owner_only_with_mode` +
+/// `verify_open_regular_file_with_mode`) rather than a plain `fs::read`, so a
+/// substituted reparse point cannot feed whatever it points at into an exported
+/// payload.
+pub(crate) fn export_history() -> Result<Vec<ExportedSeries>, HistoryError> {
+    let path = production_history_path().ok_or(HistoryError::StorageUnavailable)?;
+    export_history_at_with_mode(StorageMode::System, &path)
+}
+
+fn export_history_at_with_mode(
+    mode: StorageMode,
+    path: &Path,
+) -> Result<Vec<ExportedSeries>, HistoryError> {
+    // No history file yet is an empty lens, not a failure.
+    let Some(bytes) = read_owner_only_with_mode(mode, path).map_err(|_| HistoryError::Read)? else {
+        return Ok(Vec::new());
+    };
+    let store = serde_json::from_slice::<Store>(&bytes).map_err(|_| HistoryError::Read)?;
+    Ok(store
+        .series
+        .iter()
+        .map(|series| ExportedSeries {
+            provider_id: series.provider_id.clone(),
+            account_scope: series.account_scope.clone(),
+            window_key: series.window_key.clone(),
+            samples: series
+                .samples
+                .iter()
+                .map(|sample| ExportedSample {
+                    reset_at: sample.reset_at,
+                    duration_seconds: sample.duration_seconds,
+                    duration_source: sample.duration_source,
+                    used_percent: sample.used_percent,
+                    sampled_at: sample.sampled_at,
+                    origin: sample.origin,
+                    // `None` means the window is inside no cycle, so nothing is
+                    // active — not "unknown".
+                    is_active_group: series
+                        .active_reset_at
+                        .is_some_and(|active| is_active_group_sample(active, sample)),
+                })
+                .collect(),
+        })
+        .collect())
+}
+
 /// Import only the legacy Codex records bound to the account ID used by the
 /// successful request. The caller supplies the already-resolved opaque scope;
 /// this API never turns a legacy raw key into a v3 scope.
@@ -1177,6 +1261,21 @@ fn normalize_sample_reset(reset_at: i64, duration_seconds: i64, sampled_at: i64)
         sampled_at,
         sampled_at.saturating_add(duration_seconds.max(1)),
     )
+}
+
+/// Whether a stored sample belongs to the cycle the window is still inside.
+///
+/// Both sides are normalized, and that is the whole point. `series.active_reset_at`
+/// holds the RAW provider value while every stored sample holds
+/// `normalize_sample_reset(...)`, so an exact comparison between them fails
+/// whenever the provider's reset is not already on the quantum — which is the
+/// ordinary case, not the exotic one (codex was off by 62s, grok by 19s). This
+/// predicate is the producer's own answer and is published per point so no
+/// consumer has to re-derive a quantization rule across the FFI boundary.
+pub(crate) fn is_active_group_sample(active_reset_at: i64, sample: &QuotaSample) -> bool {
+    validate_sample(sample)
+        && normalize_reset(sample.reset_at, sample.duration_seconds)
+            == normalize_reset(active_reset_at, sample.duration_seconds)
 }
 
 fn normalize_legacy_reset(reset_at: i64) -> i64 {
@@ -6685,6 +6784,80 @@ mod tests {
             .samples
             .iter()
             .all(|sample| sample.origin == SampleOrigin::ImportedV2));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// The whole point of not calling `load_store_at_with_mode`: a store this
+    /// call cannot parse must be left on disk exactly as found, with no
+    /// `quota-pace-history-v3.corrupt-*.json` beside it. This test fails if the
+    /// export is ever pointed back at the loader.
+    #[test]
+    fn export_history_leaves_a_corrupt_store_untouched() {
+        let (directory, path) = temp_path("export-corrupt");
+        fs::write(&path, b"{ not json").unwrap();
+        let before = fs::read(&path).unwrap();
+
+        let result = export_history_at_with_mode(StorageMode::Generic, &path);
+
+        assert_eq!(result, Err(HistoryError::Read));
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert!(!fs::read_dir(&directory).unwrap().any(|entry| entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with("quota-pace-history-v3.corrupt-")));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn export_history_reports_the_running_cycle_per_sample() {
+        let (directory, path) = temp_path("export-active");
+        let duration = 5 * 3_600;
+        // A reset 62s off the quantum — the ordinary case macOS measured, and
+        // the one an exact comparison against `active_reset_at` gets wrong.
+        let raw_reset = 1_800_000_000 + 62;
+        let closed_reset = raw_reset - duration;
+        let mut series = SeriesState::new(&key("acct"), 1_800_000_000);
+        series.active_reset_at = Some(raw_reset);
+        series.samples = complete_cycle(closed_reset, duration, 40.0);
+        series
+            .samples
+            .push(quota_sample(raw_reset, duration, 0.5, 12.0, SampleOrigin::LiveV3));
+        let store = Store {
+            schema_version: HISTORY_SCHEMA_VERSION,
+            series: vec![series],
+        };
+        fs::write(&path, serde_json::to_vec(&store).unwrap()).unwrap();
+
+        let exported = export_history_at_with_mode(StorageMode::Generic, &path).unwrap();
+
+        assert_eq!(exported.len(), 1);
+        assert_eq!(exported[0].provider_id, "copilot");
+        assert_eq!(exported[0].account_scope, "acct");
+        assert_eq!(exported[0].window_key, "premium_interactions.v1");
+        let active: Vec<bool> = exported[0]
+            .samples
+            .iter()
+            .map(|sample| sample.is_active_group)
+            .collect();
+        assert_eq!(active.iter().filter(|flag| **flag).count(), 1);
+        assert!(active.last().copied().unwrap());
+        // Serialized under the key the DTO requires.
+        let json = serde_json::to_value(&exported).unwrap();
+        assert!(json[0]["samples"][0]
+            .as_object()
+            .unwrap()
+            .contains_key("isActiveGroup"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn export_history_treats_a_missing_file_as_an_empty_lens() {
+        let (directory, path) = temp_path("export-missing");
+        assert_eq!(
+            export_history_at_with_mode(StorageMode::Generic, &path),
+            Ok(Vec::new())
+        );
         fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/crates/tb_core_ffi/src/lib.rs
+++ b/crates/tb_core_ffi/src/lib.rs
@@ -662,6 +662,25 @@ pub extern "C" fn tb_agent_usage() -> *mut c_char {
     })
 }
 
+/// Persisted quota-pace history, one entry per stored series:
+/// `[{providerId, accountScope, windowKey, samples: [...]}]`. Each sample is the
+/// stored record plus a producer-computed `isActiveGroup`, which the consumer
+/// cannot re-derive (see `is_active_group_sample`). Disk-bound and read-only:
+/// the store is never quarantined, locked, or saved on this path.
+#[no_mangle]
+pub extern "C" fn tb_quota_history() -> *mut c_char {
+    guarded("tb_quota_history", || {
+        envelope(
+            agent_quota_history::export_history()
+                .map_err(|error| error.to_string())
+                .and_then(|series| {
+                    serde_json::to_value(series)
+                        .map_err(|error| format!("serialize quota history: {error}"))
+                }),
+        )
+    })
+}
+
 /// Release a string returned by any tb_* entry point.
 ///
 /// # Safety

--- a/include/ctb.h
+++ b/include/ctb.h
@@ -99,6 +99,20 @@ char *tb_tokens_per_min(void);
 // Network-bound; per-provider failures are reported inside each snapshot.
 char *tb_agent_usage(void);
 
+// Persisted quota-pace history for the quota lens, one entry per stored series:
+// [{providerId, accountScope, windowKey, samples:[{resetAt, durationSeconds,
+//   durationSource, usedPercent, sampledAt, origin, isActiveGroup}]}].
+// Identity is the store's own triple; cardId/label are not in the store and are
+// joined consumer-side on (clientId, paceStatus.windowKey). `isActiveGroup` is
+// always emitted and is the producer's answer to whether the sample belongs to
+// the cycle still running — a consumer cannot derive it, because the series'
+// active reset is the raw provider value while stored samples are normalized.
+// Disk-bound (call off the UI thread) and strictly read-only: unlike the
+// recording path, this never quarantines, locks, or rewrites the store. A
+// missing history file is an empty array; an unparseable one is an error
+// envelope.
+char *tb_quota_history(void);
+
 // Release a string returned by any tb_* entry point.
 void tb_free(char *p);
 

--- a/src/TokenBar.Core.Tests/QuotaHeatmapTests.cs
+++ b/src/TokenBar.Core.Tests/QuotaHeatmapTests.cs
@@ -1,0 +1,158 @@
+using TokenBar.Interop;
+using Xunit;
+
+namespace TokenBar.Core.Tests;
+
+// Expectations transcribed from TokenBarCore/QuotaHeatmap.swift, not invented.
+public class QuotaHeatmapTests
+{
+    private const long FiveHours = 5 * 3_600;
+    private const long ResetAt = 1_767_330_000;
+
+    // A fixed +08:00 with no DST, so the local-versus-UTC assertions below say
+    // what they mean wherever the suite runs.
+    private static readonly TimeZoneInfo PlusEight = TimeZoneInfo.CreateCustomTimeZone(
+        "test-plus-eight", TimeSpan.FromHours(8), "test-plus-eight", "test-plus-eight");
+
+    private static QuotaHistorySample Sample(long resetAt, long sampledAt, double usedPercent) =>
+        new(
+            ResetAt: resetAt,
+            DurationSeconds: FiveHours,
+            DurationSource: QuotaHistoryDurationSource.Provider,
+            UsedPercent: usedPercent,
+            SampledAt: sampledAt,
+            Origin: QuotaHistorySampleOrigin.LiveV3,
+            IsActiveGroup: false);
+
+    // "A delta is spread across the hours its interval covers, weighted by the
+    // time in each" — and the days are LOCAL days: 23:30 and 00:30 UTC are two
+    // UTC dates and one local one at +08:00.
+    [Fact]
+    public void DeltasAreSpreadOverLocalHoursAndCountedAsOneLocalDay()
+    {
+        // 2026-01-01T23:30Z and 2026-01-02T00:30Z = 07:30 and 08:30 local, Friday.
+        var grid = QuotaHeatmapFold.Build(
+            [Sample(ResetAt, 1_767_310_200, 10), Sample(ResetAt, 1_767_313_800, 16)],
+            PlusEight);
+
+        const int friday = 4;
+        Assert.Equal(3, grid.Cells[friday][7], 9);
+        Assert.Equal(3, grid.Cells[friday][8], 9);
+        Assert.Equal(6, grid.Total, 9);
+        Assert.Equal(3, grid.Peak, 9);
+        Assert.Equal(0, grid.UnplacedPercent);
+        Assert.Equal(1, grid.ObservedDays);
+    }
+
+    // "Longer than this between two readings and the consumption between them is
+    // not placed at all."
+    [Fact]
+    public void APairStraddlingMoreThanSixHoursIsUnplaced()
+    {
+        var start = ResetAt - FiveHours;
+
+        var grid = QuotaHeatmapFold.Build(
+            [Sample(ResetAt, start, 10), Sample(ResetAt, start + QuotaHeatmapFold.MaximumGapSeconds + 1, 15)],
+            PlusEight);
+
+        Assert.Equal(0, grid.Total);
+        Assert.Equal(5, grid.UnplacedPercent, 9);
+    }
+
+    [Fact]
+    public void APairExactlySixHoursApartIsStillPlaced()
+    {
+        var start = ResetAt - FiveHours;
+
+        var grid = QuotaHeatmapFold.Build(
+            [Sample(ResetAt, start, 10), Sample(ResetAt, start + QuotaHeatmapFold.MaximumGapSeconds, 15)],
+            PlusEight);
+
+        Assert.Equal(5, grid.Total, 9);
+        Assert.Equal(0, grid.UnplacedPercent);
+    }
+
+    // "NOT !isEmpty. `total` counts only what the grid could place, so a window
+    // whose every reading pair straddles more than `maximumGapSeconds` has
+    // `total == 0` while having consumed real allowance."
+    [Fact]
+    public void HasMovementIsNotTotalAboveZero()
+    {
+        var start = ResetAt - FiveHours;
+        var unplacedOnly = QuotaHeatmapFold.Build(
+            [Sample(ResetAt, start, 10), Sample(ResetAt, start + QuotaHeatmapFold.MaximumGapSeconds + 1, 10.5)],
+            PlusEight);
+
+        Assert.True(unplacedOnly.IsEmpty);
+        Assert.Equal(0, unplacedOnly.Total);
+        // "Any positive value, not a full point."
+        Assert.True(unplacedOnly.HasMovement);
+
+        // A single reading moves nothing, so neither question is true of it.
+        var oneReading = QuotaHeatmapFold.Build([Sample(ResetAt, start, 10)], PlusEight);
+        Assert.True(oneReading.IsEmpty);
+        Assert.False(oneReading.HasMovement);
+        Assert.Equal(1, oneReading.ObservedDays);
+
+        // And a window with no observations at all.
+        var nothing = QuotaHeatmapFold.Build([], PlusEight);
+        Assert.False(nothing.HasMovement);
+        Assert.Equal(0, nothing.ObservedDays);
+        Assert.Equal(7, nothing.Cells.Count);
+        Assert.All(nothing.Cells, row =>
+        {
+            Assert.Equal(24, row.Count);
+            Assert.All(row, cell => Assert.Equal(0, cell));
+        });
+    }
+
+    // "Deltas are taken WITHIN a reset cycle, never across one: a reset drops the
+    // reading back to near zero, and the difference across that boundary is the
+    // whole previous cycle inverted, not consumption."
+    [Fact]
+    public void NoDeltaIsTakenAcrossAReset()
+    {
+        var older = ResetAt - FiveHours;
+
+        var grid = QuotaHeatmapFold.Build(
+        [
+            Sample(older, older - 3_600, 80),
+            Sample(ResetAt, older + 3_600, 5),
+            Sample(ResetAt, older + 7_200, 9),
+        ], PlusEight);
+
+        // Only the 5 -> 9 pair inside the newer cycle is consumption.
+        Assert.Equal(4, grid.Total, 9);
+    }
+
+    // "Negative means the reading went backwards inside one cycle — a refill, or
+    // a provider correction. Not consumption."
+    [Fact]
+    public void ABackwardsReadingIsNotConsumption()
+    {
+        var start = ResetAt - FiveHours;
+
+        var grid = QuotaHeatmapFold.Build(
+            [Sample(ResetAt, start, 40), Sample(ResetAt, start + 3_600, 10)],
+            PlusEight);
+
+        Assert.Equal(0, grid.Total);
+        Assert.False(grid.HasMovement);
+    }
+
+    // The running cycle is NOT excluded here: its consumption is real
+    // consumption, and the grid answers "when does the allowance move".
+    [Fact]
+    public void TheRunningCycleStillContributesToTheGrid()
+    {
+        var start = ResetAt - FiveHours;
+        var active = new[]
+        {
+            Sample(ResetAt, start, 10) with { IsActiveGroup = true },
+            Sample(ResetAt, start + 3_600, 17) with { IsActiveGroup = true },
+        };
+
+        Assert.Equal(7, QuotaHeatmapFold.Build(active, PlusEight).Total, 9);
+        Assert.Empty(QuotaHistoryFold.Cycles(active));
+    }
+}

--- a/src/TokenBar.Core.Tests/QuotaHistoryFoldTests.cs
+++ b/src/TokenBar.Core.Tests/QuotaHistoryFoldTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using TokenBar.Interop;
+using Xunit;
+
+namespace TokenBar.Core.Tests;
+
+// Expectations transcribed from TokenBarCore/QuotaHistory.swift and
+// QuotaCurve.swift, not invented.
+public class QuotaHistoryFoldTests
+{
+    private const long FiveHours = 5 * 3_600;
+    private const long ResetAt = 1_767_330_000;
+
+    private static QuotaHistorySample Sample(
+        long resetAt, long sampledAt, double usedPercent, bool isActiveGroup = false) =>
+        new(
+            ResetAt: resetAt,
+            DurationSeconds: FiveHours,
+            DurationSource: QuotaHistoryDurationSource.Provider,
+            UsedPercent: usedPercent,
+            SampledAt: sampledAt,
+            Origin: QuotaHistorySampleOrigin.LiveV3,
+            IsActiveGroup: isActiveGroup);
+
+    // "a cycle first seen at 40% and last seen at 100% consumed 60 points as far
+    // as this machine can tell, and reached the ceiling. Deriving 'never ran out'
+    // from the span called that cycle a quiet one."
+    [Fact]
+    public void SpanAndPeakAreNotInterchangeable()
+    {
+        var cycle = Assert.Single(QuotaHistoryFold.Cycles(
+        [
+            Sample(ResetAt, ResetAt - FiveHours + 600, 40),
+            Sample(ResetAt, ResetAt - FiveHours + 3_600, 70),
+            Sample(ResetAt, ResetAt - 600, 100),
+        ]));
+
+        Assert.Equal(60, cycle.UsedPercent);
+        Assert.Equal(100, cycle.PeakUsedPercent);
+        Assert.Equal(3, cycle.SampleCount);
+        Assert.Equal(ResetAt * 1000, cycle.ResetAtMs);
+        Assert.Equal((ResetAt - FiveHours) * 1000, cycle.StartMs);
+        Assert.Equal((ResetAt - FiveHours + 600) * 1000, cycle.FirstSampleMs);
+        Assert.Equal((ResetAt - 600) * 1000, cycle.LastSampleMs);
+        Assert.Equal((double)(FiveHours - 1_200) / FiveHours, cycle.ObservedFraction, 9);
+    }
+
+    // "The running cycle is excluded, and each point says for itself whether it
+    // is in it."
+    [Fact]
+    public void TheRunningCycleIsNotACycle()
+    {
+        var running = ResetAt + FiveHours;
+
+        var cycles = QuotaHistoryFold.Cycles(
+        [
+            Sample(ResetAt, ResetAt - FiveHours + 600, 10),
+            Sample(ResetAt, ResetAt - 600, 80),
+            Sample(running, running - FiveHours + 600, 5, isActiveGroup: true),
+            Sample(running, running - 600, 30, isActiveGroup: true),
+        ]);
+
+        var only = Assert.Single(cycles);
+        Assert.Equal(ResetAt * 1000, only.ResetAtMs);
+    }
+
+    // "Groups curve points into cycles, newest first."
+    [Fact]
+    public void CyclesComeBackNewestFirst()
+    {
+        var older = ResetAt - FiveHours;
+
+        var cycles = QuotaHistoryFold.Cycles(
+        [
+            Sample(older, older - FiveHours + 600, 20),
+            Sample(older, older - 600, 25),
+            Sample(ResetAt, ResetAt - FiveHours + 600, 10),
+            Sample(ResetAt, ResetAt - 600, 80),
+        ]);
+
+        Assert.Equal(new[] { ResetAt * 1000, older * 1000 }, cycles.Select(cycle => cycle.ResetAtMs).ToArray());
+    }
+
+    // "Rust always emits it, so an absent key is ABI drift. Defaulting it to
+    // false would render every point as finished history — the exact misreading
+    // this field exists to remove, arriving silently instead of as a decode
+    // failure."
+    [Fact]
+    public void APayloadMissingIsActiveGroupFailsToDecode()
+    {
+        Assert.Throws<JsonException>(() => TbCore.DecodeEnvelope<IReadOnlyList<QuotaHistorySeries>>(
+            """
+            {"ok":true,"data":[{"providerId":"codex","accountScope":"scope","windowKey":"weekly.v1",
+              "samples":[{"resetAt":1767330000,"durationSeconds":18000,"durationSource":"provider",
+                          "usedPercent":40.0,"sampledAt":1767320000,"origin":"liveV3"}]}]}
+            """));
+    }
+
+    [Fact]
+    public void TheFullPayloadDecodesThroughTheEnvelope()
+    {
+        var series = Assert.Single(TbCore.DecodeEnvelope<IReadOnlyList<QuotaHistorySeries>>(
+            """
+            {"ok":true,"data":[{"providerId":"codex","accountScope":"scope","windowKey":"weekly.v1",
+              "samples":[{"resetAt":1767330000,"durationSeconds":18000,"durationSource":"observed",
+                          "usedPercent":40.0,"sampledAt":1767320000,"origin":"importedV2",
+                          "isActiveGroup":true}]}]}
+            """));
+
+        Assert.Equal("codex", series.ProviderId);
+        Assert.Equal("scope", series.AccountScope);
+        Assert.Equal("weekly.v1", series.WindowKey);
+        var sample = Assert.Single(series.Samples);
+        Assert.Equal(QuotaHistoryDurationSource.Observed, sample.DurationSource);
+        Assert.Equal(QuotaHistorySampleOrigin.ImportedV2, sample.Origin);
+        Assert.True(sample.IsActiveGroup);
+    }
+}

--- a/src/TokenBar.Core/QuotaHeatmap.cs
+++ b/src/TokenBar.Core/QuotaHeatmap.cs
@@ -1,0 +1,193 @@
+using TokenBar.Interop;
+
+namespace TokenBar.Core;
+
+// Port of TokenBarCore/QuotaHeatmap.swift, comments included.
+
+/// <summary>
+/// When a window's allowance actually gets consumed, as a weekday-by-hour grid.
+/// <para>
+/// Built from the persisted samples alone — no message scan — so it costs the
+/// same read the rest of this lens already pays. The question it answers is not
+/// "when do I work", which the usage chart already covers, but "when does the
+/// allowance move", and those differ: a long cheap session and a short expensive
+/// one look the same in a message count and nothing alike here.
+/// </para>
+/// </summary>
+/// <param name="Cells"><c>[weekday][hour]</c> in percentage points of the
+/// window's allowance. Weekday 0 = Monday, hour 0…23. Always 7 x 24; an idle
+/// slot is 0, not absent.</param>
+/// <param name="Peak">The heaviest slot, and therefore the top of the colour
+/// ramp. Zero means nothing was placed, which the card must read as "no data"
+/// rather than dividing by it.</param>
+/// <param name="Total">Everything the grid accounts for.</param>
+/// <param name="UnplacedPercent">Consumption that was measured but could not be
+/// placed in time, because the gap between the two readings that bracket it is
+/// longer than <see cref="QuotaHeatmapFold.MaximumGapSeconds"/>. Reported rather
+/// than dropped silently: a large value means the grid is understating, and the
+/// card says so.</param>
+/// <param name="ObservedDays">Distinct local calendar days carrying at least one
+/// reading. The honest denominator for "is this enough to read a weekly rhythm" —
+/// a 168-slot grid over four days is mostly white space.</param>
+public sealed record QuotaHeatmap(
+    IReadOnlyList<IReadOnlyList<double>> Cells,
+    double Peak,
+    double Total,
+    double UnplacedPercent,
+    int ObservedDays)
+{
+    public static QuotaHeatmap Empty { get; } = new(
+        Cells: Enumerable.Range(0, 7).Select(_ => (IReadOnlyList<double>)new double[24]).ToList(),
+        Peak: 0, Total: 0, UnplacedPercent: 0, ObservedDays: 0);
+
+    public bool IsEmpty => Total <= 0;
+
+    /// <summary>
+    /// Whether the allowance moved at all, placed or not.
+    /// <para>
+    /// NOT <c>!IsEmpty</c>. <see cref="Total"/> counts only what the grid could
+    /// place, so a window whose every reading pair straddles more than
+    /// <see cref="QuotaHeatmapFold.MaximumGapSeconds"/> has <c>Total == 0</c>
+    /// while having consumed real allowance. Treating that as nothing dropped the
+    /// window from the picker and made the card report "no allowance movement
+    /// recorded yet" — the opposite of what happened, with the one line that
+    /// explains it unreachable behind the same condition.
+    /// </para>
+    /// <para>
+    /// Any positive value, not a full point. Readings are arbitrary finite
+    /// percentages, so a pair of readings seven hours apart moving 0.5 points is
+    /// movement this fold recorded and a <c>&gt;= 1</c> test would discard. The
+    /// one-point threshold belongs to the footnote, which is a question about
+    /// whether a line is worth drawing, not about whether anything happened.
+    /// </para>
+    /// </summary>
+    public bool HasMovement => !IsEmpty || UnplacedPercent > 0;
+}
+
+public static class QuotaHeatmapFold
+{
+    /// <summary>
+    /// Longer than this between two readings and the consumption between them is
+    /// not placed at all.
+    /// <para>
+    /// The provider reports a level, not an event, so all we ever know is that
+    /// some amount was spent between two readings. Spreading that across a
+    /// three-day gap would draw burn at 04:00 on days the machine was asleep — an
+    /// invented pattern, and the grid exists to show a pattern. Six hours is long
+    /// enough to cover a normal poll gap on a sparsely-sampled weekly window and
+    /// short enough that a spread stays inside one working session.
+    /// </para>
+    /// </summary>
+    public const long MaximumGapSeconds = 6 * 3_600;
+
+    /// <summary>
+    /// Consumption per weekday-hour slot.
+    /// <para>
+    /// Deltas are taken WITHIN a reset cycle, never across one: a reset drops the
+    /// reading back to near zero, and the difference across that boundary is the
+    /// whole previous cycle inverted, not consumption. Cycles are keyed by
+    /// <c>ResetAt</c>, which is what <see cref="QuotaHistoryFold"/> groups on too.
+    /// </para>
+    /// <para>
+    /// A delta is spread across the hours its interval covers, weighted by the
+    /// time in each, rather than charged to the reading that observed it. On a
+    /// window polled every minute the two are identical; on one polled hourly,
+    /// charging the observing reading would pile a whole hour of work onto the
+    /// minute it happened to be noticed.
+    /// </para>
+    /// </summary>
+    public static QuotaHeatmap Build(
+        IReadOnlyList<QuotaHistorySample> samples,
+        TimeZoneInfo? timeZone = null)
+    {
+        var zone = timeZone ?? TimeZoneInfo.Local;
+        var cells = new double[7][];
+        for (var weekday = 0; weekday < 7; weekday++)
+        {
+            cells[weekday] = new double[24];
+        }
+
+        var unplaced = 0.0;
+        // Local days, not `SampledAt / 86_400`. That divides UTC seconds into UTC
+        // dates, while every cell below is placed on the LOCAL weekday and hour —
+        // so away from UTC the denominator counted a different calendar from the
+        // grid it describes, splitting one local day either side of UTC midnight
+        // in two and merging two into one.
+        var days = new HashSet<long>();
+
+        foreach (var cycle in samples.GroupBy(sample => sample.ResetAt))
+        {
+            var sorted = cycle.OrderBy(sample => sample.SampledAt).ToList();
+            foreach (var sample in sorted)
+            {
+                days.Add(FloorDiv(LocalSeconds(sample.SampledAt, zone), 86_400));
+            }
+
+            for (var index = 1; index < sorted.Count; index++)
+            {
+                var previous = sorted[index - 1];
+                var current = sorted[index];
+                var delta = current.UsedPercent - previous.UsedPercent;
+                // Negative means the reading went backwards inside one cycle — a
+                // refill, or a provider correction. Not consumption, and not
+                // something to subtract from a neighbouring slot either.
+                if (delta <= 0)
+                {
+                    continue;
+                }
+
+                var span = current.SampledAt - previous.SampledAt;
+                if (span <= 0)
+                {
+                    continue;
+                }
+
+                if (span > MaximumGapSeconds)
+                {
+                    unplaced += delta;
+                    continue;
+                }
+
+                var cursor = previous.SampledAt;
+                while (cursor < current.SampledAt)
+                {
+                    var local = LocalSeconds(cursor, zone);
+                    var intoHour = local - FloorDiv(local, 3_600) * 3_600;
+                    // A zone offset that cannot advance the cursor would spin
+                    // forever; step at least one second and keep going.
+                    var segmentEnd = Math.Min(
+                        Math.Max(cursor + (3_600 - intoHour), cursor + 1),
+                        current.SampledAt);
+                    var day = FloorDiv(local, 86_400);
+                    // Weekday 0 = Monday. Unix day 0 was a Thursday, so +3 lands
+                    // it at index 3: a grid that starts on Sunday puts the two
+                    // quietest days at opposite ends and hides the weekend as a
+                    // block.
+                    var weekday = (int)(((day + 3) % 7 + 7) % 7);
+                    var hour = (int)(local - day * 86_400) / 3_600;
+                    cells[weekday][hour] += delta * (segmentEnd - cursor) / span;
+                    cursor = segmentEnd;
+                }
+            }
+        }
+
+        var flat = cells.SelectMany(row => row).ToList();
+        return new QuotaHeatmap(
+            Cells: cells,
+            Peak: flat.Count == 0 ? 0 : flat.Max(),
+            Total: flat.Sum(),
+            UnplacedPercent: unplaced,
+            ObservedDays: days.Count);
+    }
+
+    private static long LocalSeconds(long unixSeconds, TimeZoneInfo zone) =>
+        unixSeconds + (long)zone
+            .GetUtcOffset(DateTimeOffset.FromUnixTimeSeconds(unixSeconds))
+            .TotalSeconds;
+
+    private static long FloorDiv(long value, long divisor)
+    {
+        var quotient = Math.DivRem(value, divisor, out var remainder);
+        return remainder < 0 ? quotient - 1 : quotient;
+    }
+}

--- a/src/TokenBar.Core/QuotaHistoryFold.cs
+++ b/src/TokenBar.Core/QuotaHistoryFold.cs
@@ -1,0 +1,198 @@
+using TokenBar.Interop;
+
+namespace TokenBar.Core;
+
+// Port of TokenBarCore/QuotaHistory.swift's cycle fold, comments included: they
+// record the defect each rule exists to prevent.
+//
+// Deliberately NOT ported: `rows`, `spans`, `spanTotals` and `inScope`. That
+// half is the message join and depends on WindowMessage, UsageAttribution,
+// WindowEquivalence and ModelScope, none of which exist on Windows yet. Nor
+// QuotaOverviewFold.summaries, where the strip card's "ran out / never ran out"
+// lives; this fold ships the PeakUsedPercent it will read.
+
+/// <summary>One recorded reset cycle, derived from the persisted samples alone.</summary>
+/// <param name="ResetAtMs">Reset instant in ms. Doubles as the cycle's identity —
+/// the engine groups its samples by exactly this value.</param>
+/// <param name="UsedPercent">
+/// How much of the allowance this cycle consumed: the span between the lowest
+/// and highest reading in it, NOT the highest reading alone.
+/// <para>
+/// The distinction is not cosmetic. Sampling starts whenever the app happens to
+/// be running, so a cycle first observed at 40% used would report 40% as its
+/// consumption when the app only witnessed the last few points of it. The span
+/// is what this app can honestly claim to have seen.
+/// </para>
+/// <para>
+/// Note the floor this leaves: the store rejects <c>usedPercent == 0</c>, so a
+/// cycle's first reading is always above zero and the span necessarily omits
+/// whatever was consumed before it. That understates, and understating is the
+/// right direction — the alternative assumes the app witnessed a window it may
+/// have joined late.
+/// </para>
+/// </param>
+/// <param name="PeakUsedPercent">
+/// The highest absolute reading seen in this cycle.
+/// <para>
+/// Separate from <paramref name="UsedPercent"/>, which is the observed SPAN. The
+/// two answer different questions and only coincide when the app watched the
+/// cycle from zero: a cycle first seen at 40% and last seen at 100% consumed 60
+/// points as far as this machine can tell, and reached the ceiling. Deriving
+/// "never ran out" from the span called that cycle a quiet one.
+/// </para>
+/// </param>
+/// <param name="FirstSampleMs">First reading's instant. Carried because a ratio
+/// is only meaningful when its numerator and denominator cover the same
+/// interval, and the denominator is a span between two readings — not the whole
+/// window. Usage from a stretch the app was not running for would otherwise be
+/// counted against quota movement nobody observed.</param>
+/// <param name="LastSampleMs">Last reading's instant, same reason.</param>
+/// <param name="ObservedFraction">Fraction of the window the samples actually
+/// cover, 0…1. A cycle observed for eight minutes of five hours is not evidence
+/// about that cycle, and the UI has to be able to say so.</param>
+public sealed record QuotaCycle(
+    long ResetAtMs,
+    long StartMs,
+    double UsedPercent,
+    double PeakUsedPercent,
+    int SampleCount,
+    double ObservedFraction,
+    long FirstSampleMs,
+    long LastSampleMs)
+{
+    /// <summary>
+    /// How far back this cycle's evidence reaches — the earlier of where the
+    /// window is computed to have started and where sampling actually began.
+    /// <para>
+    /// Normally <see cref="StartMs"/>, since the first reading lands after the
+    /// window opens. They invert when the provider SHORTENS its reported
+    /// duration mid-cycle: <see cref="StartMs"/> is derived from the newest
+    /// sample's duration, so a window that went from seven days to five moves
+    /// its own start forward, past readings already taken. Bounding a message
+    /// scan at <see cref="StartMs"/> would then drop usage from before it while
+    /// <see cref="UsedPercent"/> — the span between the first and last reading —
+    /// still counts the movement those readings showed. Numerator short,
+    /// denominator whole.
+    /// </para>
+    /// </summary>
+    public long EvidenceStartMs => Math.Min(StartMs, FirstSampleMs);
+
+    public long DurationMs => ResetAtMs - StartMs;
+}
+
+public static class QuotaHistoryFold
+{
+    /// <summary>
+    /// Groups samples into cycles, newest first.
+    /// <para>
+    /// <c>DurationSeconds</c> is per sample rather than per cycle, so the
+    /// cycle's length is taken from its own newest sample: a window whose
+    /// provider changed its reported duration mid-cycle should be placed by what
+    /// it reports now, not by what it reported when sampling began.
+    /// </para>
+    /// <para>
+    /// Completed cycles only. The running cycle is excluded, and each sample says
+    /// for itself whether it is in it. Folding it in put the running cycle in a
+    /// strip captioned "past windows", let a partially observed span stand beside
+    /// completed ones, and let it count toward the three-cycle threshold the
+    /// equivalence needs — an estimate that would then change under the reader as
+    /// the cycle filled.
+    /// </para>
+    /// <para>
+    /// The first version took the series' <c>activeResetAt</c> and compared it to
+    /// each sample's <c>resetAt</c>. Those are not comparable values: the engine
+    /// publishes the RAW provider reset there while every stored <c>resetAt</c>
+    /// has been through <c>normalize_sample_reset</c>, so the exclusion silently
+    /// did nothing whenever the provider's reset was off the quantum — which is
+    /// most of the time. <c>IsActiveGroup</c> is the producer's own answer, so
+    /// there is no longer a parameter a caller can omit and no rule stated twice
+    /// in two languages.
+    /// </para>
+    /// <para>
+    /// Returns EVERY recorded cycle. The cap that bounds the message scan is
+    /// <see cref="Considered"/>, applied by the consumers that pay for a scan —
+    /// not here. Putting it here looked like the tidier place ("bound it once, at
+    /// the source") and was wrong: the overview fold derives LIFETIME facts from
+    /// this list — peak percent, never-exhausted, cycle count — and costs no scan
+    /// at all. A capped fold made a window that ran out thirty-three cycles ago
+    /// report that it never had.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<QuotaCycle> Cycles(IReadOnlyList<QuotaHistorySample> samples)
+    {
+        var grouped = new Dictionary<long, List<QuotaHistorySample>>();
+        foreach (var sample in samples)
+        {
+            if (sample.IsActiveGroup)
+            {
+                continue;
+            }
+
+            if (!grouped.TryGetValue(sample.ResetAt, out var group))
+            {
+                grouped[sample.ResetAt] = group = [];
+            }
+
+            group.Add(sample);
+        }
+
+        var cycles = new List<QuotaCycle>(grouped.Count);
+        foreach (var (resetAt, raw) in grouped)
+        {
+            var sorted = raw.OrderBy(sample => sample.SampledAt).ToList();
+            var first = sorted[0];
+            var last = sorted[^1];
+            if (last.DurationSeconds <= 0)
+            {
+                continue;
+            }
+
+            var maximum = sorted.Max(sample => sample.UsedPercent);
+            var minimum = sorted.Min(sample => sample.UsedPercent);
+            cycles.Add(new QuotaCycle(
+                ResetAtMs: resetAt * 1000,
+                StartMs: (resetAt - last.DurationSeconds) * 1000,
+                UsedPercent: maximum - minimum,
+                PeakUsedPercent: maximum,
+                SampleCount: sorted.Count,
+                ObservedFraction: Math.Clamp(
+                    (double)(last.SampledAt - first.SampledAt) / last.DurationSeconds, 0, 1),
+                FirstSampleMs: first.SampledAt * 1000,
+                LastSampleMs: last.SampledAt * 1000));
+        }
+
+        return cycles.OrderByDescending(cycle => cycle.ResetAtMs).ToList();
+    }
+
+    /// <summary>
+    /// The newest cycles a scan-paying surface may look at. Applied by the
+    /// consumers whose cost grows with the answer: the history card's cycle list,
+    /// which bounds the union scan through its oldest entry's
+    /// <see cref="QuotaCycle.EvidenceStartMs"/>, and the admitted set behind the
+    /// equivalence. Lifetime summaries deliberately do not call this.
+    /// </summary>
+    public static IReadOnlyList<QuotaCycle> Considered(IReadOnlyList<QuotaCycle> cycles) =>
+        cycles.Take(ConsideredCycles).ToList();
+
+    /// <summary>
+    /// How far back any cycle-derived surface reaches, in cycles.
+    /// <para>
+    /// The engine retains 128 cycles per series and this fold used to return all
+    /// of them, but nothing downstream wants that many: the history card draws 12
+    /// rows and the overview strip 16. The cost of the extra ones is not the
+    /// list, it is that the OLDEST cycle sets where the message scan starts —
+    /// <c>min(windowStart, cycles.last.startMs)</c> — so a 5-hour session window
+    /// at 128 cycles asked for a 26-day scan to render twelve rows, and a weekly
+    /// window walked that start backwards for ever.
+    /// </para>
+    /// <para>
+    /// 32, not the 16 the issue proposed. A sweep over real history on
+    /// 2026-08-21 put 16 on the cliff edge: two runs an hour apart, differing by
+    /// one newly completed cycle, landed on opposite sides of "here is the
+    /// number" and "we cannot say". 32 does not bite on any window there today
+    /// (the widest has 27), which is the point: it bounds the growth without
+    /// moving a number anyone reads.
+    /// </para>
+    /// </summary>
+    public const int ConsideredCycles = 32;
+}

--- a/src/TokenBar.Interop/NativeMethods.cs
+++ b/src/TokenBar.Interop/NativeMethods.cs
@@ -52,5 +52,8 @@ internal static partial class NativeMethods
     internal static partial nint tb_agent_usage();
 
     [LibraryImport(Lib)]
+    internal static partial nint tb_quota_history();
+
+    [LibraryImport(Lib)]
     internal static partial void tb_free(nint ptr);
 }

--- a/src/TokenBar.Interop/QuotaHistory.cs
+++ b/src/TokenBar.Interop/QuotaHistory.cs
@@ -1,0 +1,76 @@
+namespace TokenBar.Interop;
+
+// Persisted quota-pace history as `tb_quota_history` exports it (Swift port:
+// TokenBarCore/QuotaCurve.swift, whose `QuotaCurvePoint` is the same record
+// reached through a different export). Keys match the Rust serde camelCase
+// serialization exactly.
+
+/// <summary>Where a sample's window length came from. Same Rust
+/// <c>DurationSource</c> wire values as <see cref="UsagePaceDurationSource"/>;
+/// a separate type only because the two payloads decode independently.</summary>
+public enum QuotaHistoryDurationSource
+{
+    Provider,
+    Contract,
+    Observed,
+}
+
+/// <summary>Which writer recorded the sample. <c>ImportedV2</c> is the one-time
+/// schema-2 migration lane; everything the v3 writer records is
+/// <c>LiveV3</c>.</summary>
+public enum QuotaHistorySampleOrigin
+{
+    LiveV3,
+    ImportedV2,
+}
+
+/// <summary>
+/// One stored quota reading. <c>SampledAt</c> is the real observation time,
+/// never a grid position: phase-bucket admission decides <em>whether</em> a
+/// reading is kept, not when it was taken, so samples are unevenly spaced by
+/// construction.
+/// </summary>
+/// <param name="IsActiveGroup">
+/// Whether this sample belongs to the cycle still running — answered by the
+/// producer, never re-derived here.
+/// <para>
+/// The fold used to decide this by comparing <c>ResetAt</c> against the series'
+/// <c>activeResetAt</c>. Those are not comparable: <c>activeResetAt</c> is the
+/// RAW provider value and every stored <c>resetAt</c> has been through
+/// <c>normalize_sample_reset</c>, so the comparison silently failed whenever the
+/// provider's reset was not already on the quantum — the ordinary case, not the
+/// exotic one (codex off by 62s, grok by 19s). The running cycle was then listed
+/// under "past windows", stood beside completed spans as though comparable, and
+/// counted toward the three-cycle equivalence threshold while still filling.
+/// </para>
+/// <para>
+/// Required, not defaulted: Rust always emits it, so an absent key is ABI drift.
+/// Defaulting it to false would render every sample as finished history — the
+/// exact misreading this field exists to remove, arriving silently instead of as
+/// a decode failure. <see cref="TbCore"/>'s
+/// <c>RespectRequiredConstructorParameters</c> is what makes a parameter without
+/// a default behave that way.
+/// </para>
+/// </param>
+public sealed record QuotaHistorySample(
+    long ResetAt,
+    long DurationSeconds,
+    QuotaHistoryDurationSource DurationSource,
+    double UsedPercent,
+    long SampledAt,
+    QuotaHistorySampleOrigin Origin,
+    bool IsActiveGroup);
+
+/// <summary>
+/// One stored series and its raw samples. Identity is the store's own triple;
+/// the window's display label is not in the store and is joined consumer-side
+/// on <c>(clientId, PaceStatus.WindowKey)</c> against the live agent-usage
+/// payload. That label is a hint — a series with no matching live window keeps
+/// its identity and loses only the label, and two series landing on one live
+/// window stay separate.
+/// </summary>
+public sealed record QuotaHistorySeries(
+    string ProviderId,
+    string AccountScope,
+    string WindowKey,
+    IReadOnlyList<QuotaHistorySample> Samples);

--- a/src/TokenBar.Interop/TbCore.cs
+++ b/src/TokenBar.Interop/TbCore.cs
@@ -29,6 +29,8 @@ public static class TbCore
             new JsonStringEnumConverter<FilterParityStatus>(allowIntegerValues: false),
             new JsonStringEnumConverter<PricingMode>(allowIntegerValues: false),
             new JsonStringEnumConverter<CostCoverage>(allowIntegerValues: false),
+            new JsonStringEnumConverter<QuotaHistoryDurationSource>(allowIntegerValues: false),
+            new JsonStringEnumConverter<QuotaHistorySampleOrigin>(allowIntegerValues: false),
         },
     };
 
@@ -133,6 +135,13 @@ public static class TbCore
     /// Error, not thrown.</summary>
     public static AgentUsagePayload AgentUsage() =>
         Unwrap<AgentUsagePayload>(NativeMethods.tb_agent_usage());
+
+    /// <summary>Persisted quota-pace history, one entry per stored series.
+    /// Disk-bound (call off the UI thread) and strictly read-only: unlike the
+    /// recording path, this never quarantines, locks, or rewrites the store.
+    /// A missing history file decodes as an empty list.</summary>
+    public static IReadOnlyList<QuotaHistorySeries> QuotaHistory() =>
+        Unwrap<IReadOnlyList<QuotaHistorySeries>>(NativeMethods.tb_quota_history());
 
     /// <summary>
     /// Decodes the standard FFI envelope, returning the payload or throwing


### PR DESCRIPTION
Adds the read-only export of the persisted quota-pace history across the FFI boundary, plus the two C# folds that turn it into cycles and a heatmap. Data layer only — no XAML ships here. This unblocks the three Quota-lens cards, which become pure UI once this lands.

## The exported unit is raw samples, not a curve

`reconstruct_cycle_curve` was the obvious candidate and is the wrong one: it returns `Vec<f64>` of `GRID_POINT_COUNT` = 169 phase-resampled, monotonised points with synthetic endpoints and **no timestamps**, so a consumer cannot bucket by local hour or find a cycle boundary in it. The export is the raw `QuotaSample` list per series, keyed by the store's own triple `(providerId, accountScope, windowKey)`.

## Why every sample carries a producer-computed `isActiveGroup`

This is the constraint the whole shape is built around, and it is the one thing a consumer genuinely cannot derive. The series' `active_reset_at` holds the **raw** provider value while every stored `reset_at` has been through `normalize_sample_reset`, so an equality test between them fails whenever a provider's reset is not already on the quantum — the ordinary case, not the exotic one:

| Source | Offset from quantum |
|---|---|
| macOS, recorded in its own comment | codex 62 s, grok 19 s |
| This repo's x64 host, measured | `codex\|…\|main.weekly.v1` — `activeResetAt` 1788749479 vs three samples at 1788749400 → **79 s** |

Without the flag those three samples fold into a **fabricated completed cycle**: the window the user is still inside gets listed under past windows, stands beside completed spans as though comparable, and counts toward the three-cycle equivalence threshold while still filling.

The DTO makes the field required rather than defaulted. A missing key decoding to `false` would render every sample as finished history — precisely the misreading the field exists to remove — and would arrive silently instead of as a decode failure.

`is_active_group_sample` is ported verbatim with its comment from TokenBar-Native @ `a433e759`, `crates/tb_core_ffi/src/agent_quota_history.rs:2268-2272`. The `validate_sample(...) &&` guard is macOS's own, not an addition here.

## Reading must not touch the user's history

The export deliberately avoids `load_store_at_with_mode` and its wrapper: that path quarantines the file to `quota-pace-history-v3.corrupt-{now}.json` on parse or validation failure and takes the process plus exclusive file lock, with a possible `save_store_atomic` on the way out. Renaming a user's history as a side effect of reading it is not acceptable for an export.

Instead: `production_history_path()` → `read_owner_only_with_mode(StorageMode::System, …)` → `serde_json::from_slice::<Store>`. Missing file is an empty array; a parse failure is an error envelope.

Measured against a malformed store: contents, name, mtime and directory listing unchanged, no `corrupt-*`, no lock file. One thing does change and is stated rather than implied — on unix the shared `secure_open_regular_file` primitive normalizes the mode to 0600, so a store left at 0644 comes back at 0600. Pre-existing hardening in the read primitive, not introduced here, and it only tightens.

## C# side

- `TokenBar.Interop/QuotaHistory.cs` — `QuotaHistorySample` / `QuotaHistorySeries`.
- `TokenBar.Core/QuotaHistoryFold.cs` — `QuotaCycle`, `Cycles`, `Considered`. `usedPercent` is a span and `peakUsedPercent` an absolute reading; a cycle first observed at 40% and last at 100% has a span of 60, which is why they are not interchangeable.
- `TokenBar.Core/QuotaHeatmap.cs` — `QuotaHeatmapFold.Build`. Buckets by local weekday/hour via `TimeZoneInfo` while the store is UTC; a delta is spread weighted across the hours its interval covers; pairs more than six hours apart are unplaced and reach no bucket, which is why `HasMovement` is `!IsEmpty || UnplacedPercent > 0` rather than `!IsEmpty`.

Both folds are ported with their macOS comments, since those record the defect each rule exists to prevent.

**Deliberately absent, not stubbed:** `rows`, `spans`, `spanTotals` and `inScope` (they need `WindowMessage`, `UsageAttribution`, `WindowEquivalence`, `ModelScope` — none of which exist on Windows yet), and `QuotaOverviewFold.summaries` with its `neverExhausted = peak < 99` rule, which belongs to the strip-card slice.

## Known coupling for the pending v3→v4 engine port

Two things for whoever does that port. Both are engine-side and neither is fixable in this PR's consumer.

**1. The export refuses a newer store outright.** `Store` carries `deny_unknown_fields`, so a store written by a newer schema makes this export return an error envelope rather than partial data. Observed while testing: the macOS development store is already v4 and is rejected by the v3 loader. `validate_store` now also rejects a foreign `schema_version` explicitly, which is the better reason for the same refusal. **The export must be updated in the same slice as the schema**, or the lens goes blank on migrated machines.

**2. Cycle identity should be exported, not derived from `resetAt`.** Raised in review on this PR and deferred here on ownership. `normalize_reset` uses `quantum = clamp(duration_seconds / 100, 60, 300)`, so for a duration between 6000 and 30000 seconds the quantum varies continuously: a five-hour window revised to five hours five minutes moves 180 to 183 and can put the same raw reset in a different bucket, splitting one completed cycle into several. This is not a Windows-side defect — macOS keys `QuotaHistoryFold.cycles` on the same normalized value, and `QuotaCurvePoint` states the premise outright ("per point, not per cycle: one reset group can legitimately carry readings recorded under different window lengths"). The right answer is a stable identity published per sample the way `isActiveGroup` now is, so the rule is not written twice in two languages; deriving one in the C# fold alone would make the platforms disagree about how many cycles exist. It is also not yet reachable by the path that makes it common — the v4 supersede repair rewrites `duration_seconds` on an existing group, and that is exactly the work this section is addressed to.

## Verification

| Check | Result |
|---|---|
| `cargo test -p tb_core_ffi` (macOS) | 329 passed, 0 failed |
| `cargo test -p tb_core_ffi export_history` (Windows x64) | 3 passed |
| `dotnet test` (macOS, net10) | 752 passed, 0 failed |
| `dotnet test -c Release -p:Platform=x64` (Windows x64) | 752 passed, 0 failed |

Real-store round trip on the x64 host: 10 series in `quota-pace-history-v3.json` and 10 exported; 1282 samples in `claude|…|session.v1` and 1282 exported; all ten triples matching; file SHA-256 and `corrupt-*` count unchanged across the call.

Independent verification built the release cdylib and decoded a real Rust-produced payload with the real `TbCore` decoder rather than reasoning about the wire — all three `DurationSource` variants and both `SampleOrigin` variants round-trip, and a payload omitting `isActiveGroup` throws `JsonException` naming the field. Test expectations were traced back to `QuotaHistory.swift` / `QuotaHeatmap.swift` line by line; none assert on source text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ
