### PR TITLE
chore(crosscheck): advance the Swift oracle pin off a frozen August commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: Nanako0129/TokenBar
-          ref: 63084b2addad85a90763a6ef7226763dfda90640
+          ref: 6e7a4fbc924b9c639d16b041eeedb4de019fe42e
           path: tokenbar-mac
           submodules: recursive
       - uses: actions/checkout@v6

--- a/crosscheck/README.md
+++ b/crosscheck/README.md
@@ -14,7 +14,7 @@ diagnostic only because serializer formatting and line endings differ by host.
 |---|---|
 | Legacy `usage-pace.json` and `format.json` | macOS commit `2ed256ee` |
 | Provider quota pace v3 | CORE-X1N Native consumer baseline `704426e8df9acfb8e82fe4bf3b7ed3e5adbc2fea` |
-| Swift oracle actually run | macOS `63084b2addad85a90763a6ef7226763dfda90640` (the `ref:` in `crosscheck-swift`) |
+| Swift oracle actually run | macOS `6e7a4fbc924b9c639d16b041eeedb4de019fe42e` (the `ref:` in `crosscheck-swift`) |
 
 The first two rows are where each fixture was authored. The third is the macOS
 commit whose shipping Swift produces the expected outputs, and it advances
@@ -191,7 +191,7 @@ projection differences.
 
 Set `TOKENBAR_MAC_CANONICAL` to a clean recursive clone or worktree at the
 Swift oracle SHA
-`63084b2addad85a90763a6ef7226763dfda90640`. A Git archive is insufficient
+`6e7a4fbc924b9c639d16b041eeedb4de019fe42e`. A Git archive is insufficient
 because it does not contain submodule contents.
 
 `Package.swift` links `target/release/libtb_core_ffi.a` by a path relative to
@@ -201,7 +201,7 @@ unrelated checkout's `target/` artifact.
 
 ```bash
 export TOKENBAR_WINDOWS="$(pwd)"
-export TOKENBAR_MAC_CANONICAL="${TMPDIR:-/tmp}/tokenbar-mac-63084b2a"
+export TOKENBAR_MAC_CANONICAL="${TMPDIR:-/tmp}/tokenbar-mac-6e7a4fbc"
 
 (
   cd "$TOKENBAR_MAC_CANONICAL"


### PR DESCRIPTION
The `crosscheck-swift` job has run the macOS oracle at `63084b2a` since 2026-08-25 — 18 days. A frozen pin means macOS corrections **cannot** turn this gate red, which is the opposite of what the gate exists for.

`crosscheck/README.md:19-26` already states the rule this restores: the oracle SHA "advances whenever a cross-checked behavior is corrected on the authoritative side", because pinning at the authoring baseline "would freeze the gate against a macOS that no longer exists and hide every later divergence".

Advanced to `6e7a4fbc924b9c639d16b041eeedb4de019fe42e` (macOS `origin/main`, PR #315).

## The drift this was hiding

`git log 63084b2a..origin/main -- Sources/TokenBarCore` → **16 commits, 8 files, +473/−32**. Classified: **15 must eventually be ported, 0 turn this gate red, 0 irrelevant.**

| Family | Count | Status |
|---|---|---|
| Equivalence denominator | 6 | #82 — 12x wrong on real data |
| Codex Spark duplicate labels | 7 | macOS #286 — unfixed on ~6 Windows surfaces |
| Cost plausibility guard | 2 | absent on Windows |
| Account dimension | 1 | #83 — blocked, no multi-account support here |

## Why this is expected to stay green — verified, not assumed

- `git diff --stat 63084b2a..origin/main -- Sources/CrossCheckHarness Fixtures/CrossCheck` is **empty**. Neither the harness nor any fixture moved in the whole range.
- The three compared lanes are `format`, `usage-pace` (both under `all`) and `provider-quota-pace-v3`. None reaches `WindowEquivalence` or `QuotaHistory.cycles`, which is where all 16 commits land.
- `runProviderQuotaPaceV3` is the near miss and is safe on two independent counts: `lifecycleRows` iterates the **raw** `agent.windows` array, so the deliberate duplicate `Shared label` pair keeps its wire text; and `3dc28bea` repointed `canonicalSelection` at `rawCardWindows`, which is byte-identical to the old pin's `uniqueCardWindows`.
- The lanes feed the **same fixture JSON** to both implementations (`crosscheck/README.md:4-6`) rather than scanning live sources, so the engine pricing corrections inside macOS's own submodule advance do not enter the comparison.

If it does go red, the failure names exactly which cross-checked behaviour diverged — information worth having either way. A gate that cannot fail was reporting nothing.

## Scope

Two files, four lines. The three README statements of the SHA are updated with it: a pin stated in four places and advanced in one is how a document starts asserting a configuration the repository does not have.

No source, fixture or submodule change. `vendor/tokscale-core` stays at `4dd3533` — advancing the engine pin is separate work, blocked on `get_window_usage_with_source_context` not existing on engine `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ