### PR TITLE
fix(quota): divide equivalence by distance travelled, not range or displacement

### DIFF
--- a/src/TokenBar.App/QuotaLensProjection.cs
+++ b/src/TokenBar.App/QuotaLensProjection.cs
@@ -320,7 +320,8 @@ public static class QuotaLensProjection
         var displayRows = WindowHistoryText.Rows(
             cycles,
             [.. rows.Select(row => new WindowEquivalence.Cycle(
-                row.Cycle.UsedPercent, row.MineTokens, row.MineCost, row.Cycle.ObservedFraction))]);
+                row.Cycle.UsedPercent, row.MineTokens, row.MineCost, row.Cycle.ObservedFraction,
+                row.Cycle.RisingRuns))]);
 
         // Gated on the fetch's own outcome, not on whether QuotaHistory
         // itself landed: `declared` is computed from `messages`, which come

--- a/src/TokenBar.App/WindowHistoryText.cs
+++ b/src/TokenBar.App/WindowHistoryText.cs
@@ -283,5 +283,6 @@ public static class WindowHistoryText
         WindowEquivalence.Aggregate(
             declared,
             [.. shown.Select(row => new WindowEquivalence.Cycle(
-                row.Cycle.UsedPercent, row.SpanTokens, row.SpanCost, row.Cycle.ObservedFraction))]);
+                row.Cycle.UsedPercent, row.SpanTokens, row.SpanCost, row.Cycle.ObservedFraction,
+                row.Cycle.RisingRuns))]);
 }

--- a/src/TokenBar.Core.Tests/QuotaHistoryFoldTests.cs
+++ b/src/TokenBar.Core.Tests/QuotaHistoryFoldTests.cs
@@ -485,4 +485,95 @@ public class QuotaHistoryFoldTests
         Assert.Null(active.ResetAtMs);
         Assert.Single(active.Samples);
     }
+
+    // ── Consumed / RisingRuns (distance travelled, not range or displacement) ──
+
+    // The invariant that makes this whole change safe: a cycle whose readings
+    // only rise has runs = 1, and Consumed equals both the range (max - min)
+    // and the displacement (last - first). SpanAndPeakAreNotInterchangeable
+    // above already pins this — [40, 70, 100] still reads 60 — this states it
+    // directly for readings alone.
+    [Fact]
+    public void ConsumedOnAPurelyRisingSeriesEqualsRangeAndDisplacement()
+    {
+        double[] readings = [40, 70, 100];
+        Assert.Equal(60, QuotaHistoryFold.Consumed(readings));
+        Assert.Equal(1, QuotaHistoryFold.RisingRuns(readings));
+    }
+
+    // The doc comment's own worked example: a rise that only undoes a
+    // provider's downward correction still counts in full. Known
+    // overstatement — 45 where 40 was actually consumed — and not fixable
+    // from the readings alone.
+    [Fact]
+    public void ConsumedOverstatesWhenARiseUndoesADownwardCorrection()
+    {
+        double[] readings = [0, 40, 35, 40];
+        Assert.Equal(45, QuotaHistoryFold.Consumed(readings));
+        Assert.Equal(2, QuotaHistoryFold.RisingRuns(readings)); // 0->40, then 35->40
+    }
+
+    // The distinguishing case that disagreed between the live row and the
+    // pooled aggregate on macOS before this fix: two 3-point rises separated
+    // by a decline back to zero. Consumed sums both rises (6), but each rise
+    // is separately quantised, so RisingRuns must report 2, not 1 — a single
+    // 6-point measurement at +/-0.5 is a materially different claim from two
+    // 3-point measurements at +/-0.5 each.
+    [Fact]
+    public void TwoSeparatedRisesCountAsTwoRunsNotOne()
+    {
+        double[] readings = [0, 3, 0, 3];
+        Assert.Equal(6, QuotaHistoryFold.Consumed(readings));
+        Assert.Equal(2, QuotaHistoryFold.RisingRuns(readings));
+    }
+
+    // A plateau inside a rise is transparent: it neither starts nor ends a
+    // run. Deltas here are +3, 0, 0, +3 — one continuous rise, not two.
+    [Fact]
+    public void APlateauInsideARiseIsOneRunNotTwo()
+    {
+        double[] readings = [0, 3, 3, 3, 6];
+        Assert.Equal(6, QuotaHistoryFold.Consumed(readings));
+        Assert.Equal(1, QuotaHistoryFold.RisingRuns(readings));
+    }
+
+    // RisingRuns is NOT `1 + declines`. A single rise followed by a trailing
+    // decline is one run that contributed a rise, not two — macOS's first
+    // cut counted declines instead and got this case wrong.
+    [Fact]
+    public void RisingRunsIsNotOnePlusDeclines()
+    {
+        double[] readings = [0, 10, 5];
+        Assert.Equal(10, QuotaHistoryFold.Consumed(readings));
+        Assert.Equal(1, QuotaHistoryFold.RisingRuns(readings));
+    }
+
+    [Fact]
+    public void ReadingsThatNeverRiseHaveZeroRisingRuns()
+    {
+        double[] readings = [10, 10, 5, 5];
+        Assert.Equal(0, QuotaHistoryFold.Consumed(readings));
+        Assert.Equal(0, QuotaHistoryFold.RisingRuns(readings));
+    }
+
+    // Cycles() itself, not just the standalone functions: a cycle whose
+    // middle reading dips (a correction, not a reset) must report the
+    // travelled distance and the run count Consumed/RisingRuns compute, not
+    // the old range (40) or displacement (40) — both of which this exact
+    // reading sequence would have agreed on before this change.
+    [Fact]
+    public void CyclesReportsTravelledDistanceAndRunsAcrossADecline()
+    {
+        var cycle = Assert.Single(QuotaHistoryFold.Cycles(
+        [
+            Sample(ResetAt, ResetAt - FiveHours + 600, 0),
+            Sample(ResetAt, ResetAt - FiveHours + 1_200, 40),
+            Sample(ResetAt, ResetAt - FiveHours + 1_800, 35),
+            Sample(ResetAt, ResetAt - 600, 40),
+        ]));
+
+        Assert.Equal(45, cycle.UsedPercent); // 40 + max(0, -5) + 5 = 45, not 40
+        Assert.Equal(2, cycle.RisingRuns);
+        Assert.Equal(40, cycle.PeakUsedPercent); // peak is untouched by this change
+    }
 }

--- a/src/TokenBar.Core.Tests/WindowEquivalenceTests.cs
+++ b/src/TokenBar.Core.Tests/WindowEquivalenceTests.cs
@@ -268,6 +268,30 @@ public class WindowEquivalenceTests
         Assert.IsType<WindowEquivalence.Row.ScanFailed>(row);
     }
 
+    // The distinguishing case that disagreed between LiveRow and Aggregate on
+    // macOS before runs-scaling existed: two 3-point rises separated by a
+    // decline back to zero. Consumed sums both rises to 6 (>= the un-scaled
+    // MinimumDelta of 5), but each rise is separately quantised — 6 points
+    // measured as two 3-point rises does not clear the bar the way one
+    // undivided 6-point rise would. Must read Insufficient, not Ratio.
+    [Fact]
+    public void TwoSeparatedSubThresholdRisesAreRejectedAsInsufficientNotAdmitted()
+    {
+        var row = WindowEquivalence.LiveRow(
+            declared: true, attempt: WindowEquivalence.FetchOutcome.Succeeded,
+            [
+                new WindowEquivalence.Sample(0, 0),
+                new WindowEquivalence.Sample(1000, 3),
+                new WindowEquivalence.Sample(2000, 0),
+                new WindowEquivalence.Sample(3000, 3),
+            ],
+            [Message(500, 1000, 4.0)]);
+        var insufficient = Assert.IsType<WindowEquivalence.Row.Insufficient>(row);
+        Assert.Equal(6, insufficient.DeltaPercent);
+        // error = round(0.5 * 2 / 6 * 100) = 17, not round(0.5 * 1 / 6 * 100) = 8
+        Assert.Equal(17, insufficient.ErrorPercent);
+    }
+
     [Fact]
     public void IsRatioIsFalseForEveryOtherCase()
     {
@@ -331,8 +355,8 @@ public class WindowEquivalenceTests
     // ── Aggregate ────────────────────────────────────────────────────────
 
     private static WindowEquivalence.Cycle Cycle(
-        double delta, long tokens, double cost, double observed = 1.0) =>
-        new(DeltaPercent: delta, SpanTokens: tokens, SpanCost: cost, ObservedFraction: observed);
+        double delta, long tokens, double cost, double observed = 1.0, int runs = 1) =>
+        new(DeltaPercent: delta, SpanTokens: tokens, SpanCost: cost, ObservedFraction: observed, RisingRuns: runs);
 
     [Fact]
     public void UndeclaredWinsBeforeAnyCycleIsExamined()
@@ -403,6 +427,46 @@ public class WindowEquivalenceTests
         Assert.Equal(3, insufficient.DeltaPercent);
         // round(0.5 * 1 / 3 * 100) = 17
         Assert.Equal(17, insufficient.ErrorPercent);
+    }
+
+    // The mirror of TwoSeparatedSubThresholdRisesAreRejectedAsInsufficientNotAdmitted
+    // above, at the pooled site: the same [0, 3, 0, 3] shape, folded into one
+    // QuotaCycle with RisingRuns = 2. Before DeltaQualifies existed, the
+    // pooled admission filter compared only cycle.DeltaPercent >=
+    // MinimumDelta (6 >= 5, true) and admitted it as a 6-point cycle — the
+    // exact disagreement with the live row this port exists to close. Must
+    // fall through to the not-admitted branch here too.
+    [Fact]
+    public void PooledPathRejectsTheSameTwoSeparatedSubThresholdRisesTheLiveRowRejects()
+    {
+        var row = WindowEquivalence.Aggregate(declared: true, [Cycle(6, 500, 2.5, runs: 2)]);
+        var insufficient = Assert.IsType<WindowEquivalence.Row.Insufficient>(row);
+        Assert.Equal(6, insufficient.DeltaPercent);
+        // round(0.5 * 2 / 6 * 100) = 17, over `cycles` (this one, runs=2),
+        // not `admitted` (empty here by construction).
+        Assert.Equal(17, insufficient.ErrorPercent);
+    }
+
+    // DeltaQualifies directly: the single-rise half (runs=1) is unaffected —
+    // 5 is exactly MinimumDelta, so it clears; 4 does not. The scaled half:
+    // a 10-point delta over 2 runs needs 10 (2 * MinimumDelta) to clear, so 9
+    // fails where a single-run 9 would pass.
+    [Fact]
+    public void DeltaQualifiesScalesTheBarByRunsNotJustByDelta()
+    {
+        Assert.True(WindowEquivalence.DeltaQualifies(5, 1));
+        Assert.False(WindowEquivalence.DeltaQualifies(4, 1));
+        Assert.True(WindowEquivalence.DeltaQualifies(9, 1));
+        Assert.False(WindowEquivalence.DeltaQualifies(9, 2));
+        Assert.True(WindowEquivalence.DeltaQualifies(10, 2));
+    }
+
+    // delta > 0 is load-bearing: without it, runs == 0 would make the
+    // threshold zero and admit a cycle that never moved.
+    [Fact]
+    public void DeltaQualifiesRejectsZeroDeltaEvenWithZeroRuns()
+    {
+        Assert.False(WindowEquivalence.DeltaQualifies(0, 0));
     }
 
     // The distinction the plan calls out for the pooled path too: movement

--- a/src/TokenBar.Core/QuotaEquivalenceFold.cs
+++ b/src/TokenBar.Core/QuotaEquivalenceFold.cs
@@ -122,7 +122,8 @@ public static class QuotaEquivalenceFold
                 DeltaPercent: cycle.UsedPercent,
                 SpanTokens: tokens,
                 SpanCost: cost,
-                ObservedFraction: cycle.ObservedFraction));
+                ObservedFraction: cycle.ObservedFraction,
+                RisingRuns: cycle.RisingRuns));
         }
 
         return result;

--- a/src/TokenBar.Core/QuotaHistoryFold.cs
+++ b/src/TokenBar.Core/QuotaHistoryFold.cs
@@ -50,6 +50,11 @@ namespace TokenBar.Core;
 /// <param name="ObservedFraction">Fraction of the window the samples actually
 /// cover, 0…1. A cycle observed for eight minutes of five hours is not evidence
 /// about that cycle, and the UI has to be able to say so.</param>
+/// <param name="RisingRuns">How many separately measured rises
+/// <paramref name="UsedPercent"/> summed — see <see cref="QuotaHistoryFold.RisingRuns"/>.
+/// Defaults to 1 so a caller that predates this field still compiles and
+/// still gets the right answer for the ordinary case it was built for: a
+/// cycle whose readings only rise is exactly one run.</param>
 public sealed record QuotaCycle(
     long ResetAtMs,
     long StartMs,
@@ -58,7 +63,8 @@ public sealed record QuotaCycle(
     int SampleCount,
     double ObservedFraction,
     long FirstSampleMs,
-    long LastSampleMs)
+    long LastSampleMs,
+    int RisingRuns = 1)
 {
     /// <summary>
     /// How far back this cycle's evidence reaches — the earlier of where the
@@ -241,6 +247,130 @@ public static class QuotaHistoryFold
     /// report that it never had.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// How much allowance a run of readings records consuming: the distance
+    /// they travelled, summed over the rises between consecutive readings.
+    /// <para>
+    /// Neither the range nor the displacement, though on a cycle whose
+    /// readings only rise all three are the same number. They stop agreeing
+    /// the moment a reset falls inside the group: the readings return to
+    /// zero, so the displacement collapses toward nothing while the range
+    /// saturates at whatever the highest reading happened to be. Measured on
+    /// a real merged group — 8 by displacement, 85 by range, 93 actually
+    /// travelled. The numerator keeps every message from both sides of that
+    /// reset whichever denominator is used, so one that does not accumulate
+    /// makes the ratio report a multiple of the truth: 11.6x on that group,
+    /// which is where a card reading $2974.92 came from.
+    /// </para>
+    /// <para>
+    /// Only rises count, which keeps the property the range was chosen for.
+    /// Sampling starts whenever the app happens to be running, so a cycle
+    /// first seen at 40% must not claim the 40% nobody watched.
+    /// </para>
+    /// <para>
+    /// Order-dependent where the range was not: <paramref name="readings"/>
+    /// must already be sorted by sample time, or this silently returns a
+    /// wrong answer.
+    /// </para>
+    /// <para>
+    /// Every rise counts, including one that only undoes a provider's
+    /// downward correction: <c>[0, 40, 35, 40]</c> returns 45 where 40 was
+    /// consumed. That is a known overstatement and it is not fixable from
+    /// the readings — a decline does not say whether the quota was refilled
+    /// or the earlier number was wrong, and neither its size nor where it
+    /// lands separates the two. Measured across every series in a real
+    /// store: persistent drops run 2 to 100 points and bounce-backs 2 to 22,
+    /// fully overlapping; real resets land anywhere from 0% to 21%, with
+    /// bounce-backs landing at 0% as well.
+    /// </para>
+    /// <para>
+    /// The numerator has the twin of this, and it is left in place for the
+    /// same reason. A declining interval contributes nothing here while
+    /// every message inside it still counts above the line, so whatever was
+    /// consumed between the last reading before a reset and the reset
+    /// itself is divided by the rises around it. Excluding those messages
+    /// is right when the decline was a reset and wrong twice over when it
+    /// was a correction — numerator down, denominator already up — and the
+    /// paragraph above is the measurement saying the two cannot be told
+    /// apart. Bound, from the same store: 2 of 128 groups contain any
+    /// decline at all, declining intervals hold 0.17% of all observed time,
+    /// 4.08% in the worst single group and 0.92% in the merged group this
+    /// whole change was written for. Time, not messages — the message share
+    /// is NOT measured, and a gap denser than average carries
+    /// proportionally more.
+    /// </para>
+    /// <para>
+    /// It is kept because the bound is small and the alternative costs
+    /// more. Over 121 groups in that store, this and the range agreed on
+    /// 119 — every cycle whose readings only rise — and differed by at most
+    /// 3.5% on the two that had been refilled, where the range prices the
+    /// window at its widest excursion rather than at what it consumed. The
+    /// residual also leans the safe way: overstating the denominator
+    /// understates the ratio, so a quota reads as worth less rather than
+    /// more.
+    /// </para>
+    /// </summary>
+    public static double Consumed(IReadOnlyList<double> readings)
+    {
+        var total = 0.0;
+        for (var i = 1; i < readings.Count; i++)
+        {
+            total += Math.Max(0, readings[i] - readings[i - 1]);
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// How many separately measured rises <see cref="Consumed"/> summed: the
+    /// number of times the readings started going up after not going up.
+    /// Zero on readings that never rose.
+    /// <para>
+    /// The provider reports whole percents, so each rise carries the same
+    /// ±0.5 quantisation whether it spans 3 points or 90. Summing two rises
+    /// sums their uncertainty as well, and a ratio built on
+    /// <c>[0, 3, 0, 3]</c> is not a 6-point measurement at ±0.5 — it is two
+    /// 3-point measurements at ±0.5 each, neither of which clears the bar
+    /// on its own. Callers that quote an error or gate on a minimum delta
+    /// scale both by this count, so a group that crossed a reset does not
+    /// come out looking more precise than a group that did not.
+    /// </para>
+    /// <para>
+    /// A positive delta starts a run iff no earlier delta was positive, or
+    /// the most recent non-zero delta before it was negative. A zero delta
+    /// is transparent: a plateau inside a rise is still one measurement
+    /// span under the ±0.5-per-reading model, so it neither starts nor ends
+    /// a run. NOT <c>1 + declines</c> — macOS's first cut counted declines
+    /// instead, and it charged a trailing decline as a run that contributed
+    /// no rise.
+    /// </para>
+    /// </summary>
+    public static int RisingRuns(IReadOnlyList<double> readings)
+    {
+        var runs = 0;
+        var lastNonZeroWasNegative = true;
+        for (var i = 1; i < readings.Count; i++)
+        {
+            var before = readings[i - 1];
+            var after = readings[i];
+            if (after > before)
+            {
+                if (lastNonZeroWasNegative)
+                {
+                    runs++;
+                }
+
+                lastNonZeroWasNegative = false;
+            }
+            else if (after < before)
+            {
+                lastNonZeroWasNegative = true;
+            }
+        }
+
+        return runs;
+    }
+
     public static IReadOnlyList<QuotaCycle> Cycles(IReadOnlyList<QuotaHistorySample> samples)
     {
         var grouped = new Dictionary<long, List<QuotaHistorySample>>();
@@ -270,18 +400,19 @@ public static class QuotaHistoryFold
                 continue;
             }
 
+            var readings = sorted.Select(sample => sample.UsedPercent).ToList();
             var maximum = sorted.Max(sample => sample.UsedPercent);
-            var minimum = sorted.Min(sample => sample.UsedPercent);
             cycles.Add(new QuotaCycle(
                 ResetAtMs: resetAt * 1000,
                 StartMs: (resetAt - last.DurationSeconds) * 1000,
-                UsedPercent: maximum - minimum,
+                UsedPercent: Consumed(readings),
                 PeakUsedPercent: maximum,
                 SampleCount: sorted.Count,
                 ObservedFraction: Math.Clamp(
                     (double)(last.SampledAt - first.SampledAt) / last.DurationSeconds, 0, 1),
                 FirstSampleMs: first.SampledAt * 1000,
-                LastSampleMs: last.SampledAt * 1000));
+                LastSampleMs: last.SampledAt * 1000,
+                RisingRuns: RisingRuns(readings)));
         }
 
         return cycles.OrderByDescending(cycle => cycle.ResetAtMs).ToList();

--- a/src/TokenBar.Core/WindowEquivalence.cs
+++ b/src/TokenBar.Core/WindowEquivalence.cs
@@ -89,8 +89,45 @@ public static class WindowEquivalence
     /// <summary>How much relative error the displayed ratio may carry.</summary>
     public const double Tolerance = 0.10;
 
-    /// <summary>Derived, not chosen: ±0.5/Δ ≤ tolerance ⇒ Δ ≥ 5.</summary>
-    public static double MinimumDelta => QuantisationHalfStep / Tolerance;
+    /// <summary>
+    /// Derived, not chosen: ±0.5/Δ ≤ tolerance ⇒ Δ ≥ 5.
+    /// <para>
+    /// Internal on purpose. <see cref="DeltaQualifies"/> is the whole
+    /// admission rule and this is only its single-rise half; a caller
+    /// holding the bare number can write <c>delta &gt;= MinimumDelta</c> and
+    /// silently drop the run scaling, which is exactly what happened at two
+    /// sites in this file (<see cref="LiveRow"/> and <see cref="Aggregate"/>)
+    /// and took a review round to find on macOS. Keeping it internal makes
+    /// that comparison fail to compile outside this assembly rather than
+    /// fail review.
+    /// </para>
+    /// </summary>
+    internal static double MinimumDelta => QuantisationHalfStep / Tolerance;
+
+    /// <summary>
+    /// The one statement of whether a measured consumption is large enough
+    /// to divide by. <see cref="MinimumDelta"/> is the single-rise delta at
+    /// which the ±0.5 quantisation reaches <see cref="Tolerance"/>; a delta
+    /// summed over several rises carries that uncertainty once per rise, so
+    /// it has to clear the bar once per rise to make the same claim.
+    /// <para>
+    /// Two sites admit cycles — <see cref="LiveRow"/> and
+    /// <see cref="Aggregate"/> — and this rule used to be written out at
+    /// each of them. Scaling it at one and not the other is how
+    /// <c>[0, 3, 0, 3]</c> came to be rejected by the live row as two
+    /// sub-threshold rises and admitted by the pooled path as one 6-point
+    /// cycle in the same build. It lives here so that cannot recur.
+    /// </para>
+    /// <para>
+    /// <paramref name="delta"/> &gt; 0 is load-bearing, not defensive:
+    /// <see cref="QuotaHistoryFold.Consumed"/> returns a positive value
+    /// only when at least one rise exists, so a positive delta implies
+    /// <paramref name="runs"/> &gt;= 1 and the product below cannot be
+    /// zero. Without the guard, <paramref name="runs"/> == 0 would make the
+    /// threshold zero and admit a cycle that never moved.
+    /// </para>
+    /// </summary>
+    public static bool DeltaQualifies(double delta, int runs) => delta > 0 && delta >= MinimumDelta * runs;
 
     /// <summary>
     /// One row as displayed. An abstract record with sealed nested cases —
@@ -404,15 +441,36 @@ public static class WindowEquivalence
 
         var first = samples[0];
         var last = samples[^1];
-        var delta = last.UsedPercent - first.UsedPercent;
+
+        // The distance the readings travelled, not `last - first`. A reset
+        // inside the span returns them to zero, and the displacement then
+        // collapses while the numerator below keeps every message from both
+        // sides of it — which is how a window that consumed 93 points came
+        // to divide by 8 and report eleven times the true rate. One
+        // statement of the rule, shared with the pooled path in
+        // QuotaHistoryFold.Consumed.
+        var readings = samples.Select(sample => sample.UsedPercent).ToList();
+        var delta = QuotaHistoryFold.Consumed(readings);
         if (delta <= 0)
         {
             return new Row.NotMoved();
         }
 
+        // Every rise `Consumed` summed was quantised on its own, so both the
+        // error quoted below and the admission bar scale with how many
+        // there were. MinimumDelta is the single-rise delta at which the
+        // error reaches Tolerance; a group that crossed a reset has to
+        // clear it once per rise to make the same claim. Without this,
+        // `[0, 3, 0, 3]` read as a 6-point measurement at ±8% — two rises
+        // of 3 that each fell short, presented as one that did not.
+        var runs = QuotaHistoryFold.RisingRuns(readings);
+
         // Numerator and denominator must cover the same interval or the ratio
         // means nothing — hence the span between samples, not the whole
-        // window.
+        // window. Held exactly at the ends and approximately in the middle:
+        // a declining interval inside the span contributes to the numerator
+        // and not to Consumed — see QuotaHistoryFold.Consumed for why that
+        // is not fixed here.
         long tokens = 0;
         var cost = 0.0;
         foreach (var message in messages)
@@ -426,7 +484,7 @@ public static class WindowEquivalence
             cost += message.Cost;
         }
 
-        var error = RoundedInt(QuantisationHalfStep / delta * 100);
+        var error = RoundedInt(QuantisationHalfStep * runs / delta * 100);
 
         // "Recorded" means either kind of evidence. A provider row can carry a
         // cost with no token components, and the pooled path already admits
@@ -438,7 +496,7 @@ public static class WindowEquivalence
             return new Row.Unaccounted(delta);
         }
 
-        if (delta < MinimumDelta)
+        if (!DeltaQualifies(delta, runs))
         {
             return new Row.Insufficient(delta, error);
         }
@@ -473,7 +531,13 @@ public static class WindowEquivalence
     /// <param name="SpanCost">Same restriction as <paramref name="SpanTokens"/>.</param>
     /// <param name="ObservedFraction">The cycle's own
     /// <see cref="QuotaCycle.ObservedFraction"/>.</param>
-    public sealed record Cycle(double DeltaPercent, long SpanTokens, double SpanCost, double ObservedFraction);
+    /// <param name="RisingRuns">How many separately measured rises
+    /// <paramref name="DeltaPercent"/> sums; <see cref="DeltaQualifies"/>
+    /// scales its admission bar by it. Defaults to 1 so every existing
+    /// caller — a cycle whose readings only rise is exactly one run — still
+    /// compiles and still gets the right answer.</param>
+    public sealed record Cycle(
+        double DeltaPercent, long SpanTokens, double SpanCost, double ObservedFraction, int RisingRuns = 1);
 
     /// <summary>Below this the cycle was barely witnessed, so its delta
     /// describes a stretch the app mostly missed. <see cref="QuotaCycle"/>
@@ -553,7 +617,7 @@ public static class WindowEquivalence
         // that as "none of it recorded on this machine", which is false about
         // the one thing it could see.
         var admitted = cycles.Where(cycle =>
-            cycle.DeltaPercent >= MinimumDelta
+            DeltaQualifies(cycle.DeltaPercent, cycle.RisingRuns)
             && cycle.ObservedFraction >= MinimumObservedFraction
             && (cycle.SpanCost > 0 || cycle.SpanTokens > 0)).ToList();
 
@@ -582,9 +646,14 @@ public static class WindowEquivalence
                 return new Row.Unaccounted(anyMovement);
             }
 
+            // One half-step per RISE, summed over every cycle offered — not
+            // per cycle. A merged cycle carries several quantised rises and
+            // its error is that many half-steps wide. Over `cycles`, not
+            // `admitted`: inside this branch `admitted` is empty by
+            // construction, and a sum over it would quote ±0%.
             return new Row.Insufficient(
                 anyMovement,
-                RoundedInt(QuantisationHalfStep * cycles.Count / anyMovement * 100));
+                RoundedInt(QuantisationHalfStep * cycles.Sum(cycle => cycle.RisingRuns) / anyMovement * 100));
         }
 
         // Count, not size: these cycles each cleared `MinimumDelta` on their


### PR DESCRIPTION
Closes #82.

Windows divides the quota equivalence by **displacement** (`WindowEquivalence.cs`, `last − first`) and by **range** (`QuotaHistoryFold.cs`, `max − min`). Both should be **distance travelled**. Measured **12x wrong** on real data: across a reset the displacement collapses while the numerator keeps summing every message in the span.

It is also visible without a Mac to compare against. On the same Quota lens, the heatmap card already computes the sum of positive per-pair deltas (`QuotaHeatmap.cs:130`, correct) while the strip card's equivalence line beside it uses `last − first`. **The two cards contradict each other today.**

## Why this is one PR and not six

macOS fixed it as a six-commit family (`aad7fb97`, `c445c30b`, `5d2068ea`, `6b9fc24c`, `b960ac4f`, `26812481`), all of which landed behind our frozen oracle pin. Porting only the denominator would ship a half-rule and reproduce macOS's own round-four finding:

- the quoted error at the live row becomes **optimistic** — `0.5 / delta` treats a merged 6-point distance as one measurement at ±0.5, when `[0, 3, 0, 3]` is two 3-point rises at ±0.5 each;
- and two admission sites that agree today only by luck would start disagreeing. `WindowEquivalence.cs`'s live row and pooled aggregate both read the same `UsedPercent`; run-scale one and not the other and `[0, 3, 0, 3]` is **rejected by one path and admitted by the other in the same build**.

## What lands

- **`QuotaHistoryFold.Consumed(readings)`** = Σ max(0, rᵢ₊₁ − rᵢ). One statement of the denominator, called by both `WindowEquivalence.LiveRow` and `QuotaHistoryFold.Cycles`. Order-dependent: callers pass time-sorted readings, and the doc says so.
- **`RisingRuns(readings)`** — how many separately measured rises `Consumed` summed. A zero delta is transparent: a plateau inside a rise is one measurement span. **Not** `1 + declines`, which was macOS's first cut and charged a trailing decline as a run contributing no rise.
- **`RisingRuns` travels on `QuotaCycle` and `WindowEquivalence.Cycle`** (default 1, so every existing constructor compiles), rather than being recomputed at each reader.
- **`DeltaQualifies(delta, runs)` = `delta > 0 && delta >= MinimumDelta * runs`** — the only comparison against `MinimumDelta` anywhere. `delta > 0` is load-bearing, not defensive: without it `runs == 0` zeroes the threshold and admits a cycle that never moved.
- **`MinimumDelta` is now `internal`**, so a caller outside the module cannot spell the bare half-rule. Grepped first: four sites, all inside `WindowEquivalence.cs`, no `TokenBar.App` use — narrowing cost nothing.
- Live-row error is `QuantisationHalfStep * runs / delta * 100`; the insufficient branch sums half-steps over every rise instead of `cycles.Count`.

## The two known-imperfect edges, ported verbatim rather than dropped

These are the most valuable part of the macOS family for anyone reading this later.

**`Consumed` overstates** when a rise only undoes a provider's downward correction: `[0, 40, 35, 40]` returns 45 where 40 was consumed. Not fixable from the readings — a decline does not say whether the quota was refilled or the earlier number was wrong. Measured on macOS: 119 of 121 groups agreed with the range; the two that differed did so by at most 3.5%. The residual leans safe, because overstating the denominator understates the ratio.

**The numerator has the twin gap**: a declining interval contributes nothing to the denominator while every message inside it still counts above the line. Measured **in time, not messages** — declining intervals hold 0.17% of all observed time, 4.08% in the worst single group. The message share is **not** measured, and the comment says so rather than implying it is bounded too.

## Verification

`dotnet test` against `TokenBar.Core.Tests`: **1092 → 1103 passed**, same 3 pre-existing native-library failures before and after.

**Zero existing assertions changed.** That is the invariant doing its job: a cycle whose readings only rise has `runs = 1` and distance = range = displacement, so every clean cycle comes out byte-identical at every site. Only cycles containing a decline move.

11 new tests, all confirmed by hand-mutation with exact inverse reverts (never `git checkout --`):

- reverting `DeltaQualifies` to an unscaled `delta >= MinimumDelta` kills the three tests pinning the live-row / pooled disagreement, including `[0, 3, 0, 3]` rejected at **both** sites;
- reverting `Consumed` to plain displacement kills the four pinning travelled distance, including through `Cycles()`.

`QuotaHeatmap.cs:130` and `WindowCardGeometry.cs:68` were checked and deliberately **not** folded in: the heatmap needs each pairwise delta individually to weight across hours, and `HitZone.Consumed` is one opening/closing pair per zone. Neither is the aggregate sum `Consumed` returns.

The two `TokenBar.App` edits thread `RisingRuns` through existing construction sites; they are correct by inspection but not compiled here, since WinUI does not build on macOS. CI covers them.

Engine submodule untouched — this is Core-only and does not depend on the pending engine pin advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ