### PR TITLE
chore(engine): advance the tokscale-core pin off the stranded branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -221,6 +227,37 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -713,6 +750,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +995,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,7 +1168,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1176,7 +1259,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1205,7 +1288,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1329,7 +1412,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1691,6 +1774,8 @@ dependencies = [
  "chrono",
  "dirs",
  "fs2",
+ "jiff",
+ "jiff-tzdb",
  "libc",
  "once_cell",
  "rayon",
@@ -1705,6 +1790,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "unicode-normalization",
  "walkdir",
  "zstd",
 ]
@@ -1730,7 +1816,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -1802,6 +1888,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "untrusted"

--- a/vendor/ENGINE.md
+++ b/vendor/ENGINE.md
@@ -21,15 +21,46 @@ app consumer advances its reviewed pin.
 > must pass review in `tokscale-core`; this repository then advances only the
 > reviewed gitlink and runs the Windows consumer gates.
 
-## v1.13 source-context and retained-token alignment
+## Current pin: `d6512f5`, the window-usage reconciliation
 
-The reviewed pin is the immutable GitHub merge commit for tokscale-core PR #12,
-following the source-context foundation in PR #10. The Windows FFI captures the
-engine-owned context once per process and routes graph, report, parse,
+The reviewed pin is the immutable GitHub merge commit for tokscale-core
+PR #27, which reconciled two divergent implementations of `get_window_usage`
+and landed `get_window_usage_with_source_context` — the entry point
+`crates/tb_core_ffi` calls and the reason this pin could not advance before.
+The previous gitlink, `4dd3533`, sat on the branch `feat/window-usage-export`,
+one commit past merge-base `6a9de8c` and 60 behind the engine's `main`.
+
+**This advance is not cache-neutral for this consumer.** `CACHE_FORMAT_VERSION`
+moves 3 to 4 and per-client parser identities move with it (Codex 4 to 6,
+Claude 2 to 4), so existing installs take a migration on first launch. The
+engine's `mod format3` migrates format-3 shards rather than discarding them,
+which matters beyond cold-start cost: for Claude the cache is the only copy of
+turns a compacting rewrite removed from the transcript.
+
+Displayed figures change, because the stranded branch was producing different
+ones. Measured over a fixed five-hour window on a real corpus, the old pin
+returned 42 rows / `input=206039` / `cost=9.684641` where this pin returns
+26 / `189822` / `12.186039`; the token lanes other than input are identical.
+The arriving fixes include Codex reasoning tokens no longer priced twice,
+Claude `tool_result` input no longer char-estimated, Claude 1-hour cache
+writes priced at their own rate, and deterministic ordering for
+equal-length pricing fallbacks.
+
+Two behaviour changes arrive with the reconciled export: an empty or inverted
+window returns an empty row list rather than an error, and the window scan's
+client filter is aligned to the aggregate paths (inert here — this consumer
+passes `clients: None`).
+
+## Historical: v1.13 source-context and retained-token alignment
+
+Superseded by the section above; retained because it records what an earlier
+pin established, not what is built today. At that pin — the merge commit for
+tokscale-core PR #12, following the source-context foundation in PR #10 — the
+Windows FFI captured the engine-owned context once per process and routed graph, report, parse,
 source-token, and live-tail work through the context-aware APIs. The engine
-source token now includes report-visible retained-only Claude cache state while
-keeping its cache schema and public interfaces unchanged. This consumer slice
-advances only the reviewed gitlink and its provenance record.
+source token includes report-visible retained-only Claude cache state, and that
+slice kept the cache schema and public interfaces unchanged — a statement about
+that advance, not about the current one, which does change the cache format.
 
 ## Ownership
 

--- a/vendor/ENGINE.md
+++ b/vendor/ENGINE.md
@@ -10,12 +10,12 @@ app consumer advances its reviewed pin.
 |---|---|
 | Path | `vendor/tokscale-core` |
 | Repository | `https://github.com/Nanako0129/tokscale-core.git` |
-| Reviewed pin | `6a9de8ca5b35ed96e5c56e219e9b95a98633372d` |
-| TokenBar alignment | `v1.12.0` → `v1.13.1` |
-| Engine alignment | `84e0d66413d4e0d87b734f66f7a848b3bc323258` → `6a9de8ca5b35ed96e5c56e219e9b95a98633372d` |
+| Reviewed pin | `d6512f5ae62c2be6751ed93adb9391ffe3f91579` |
+| TokenBar alignment | `v1.17.0` (engine `8a88602b`) → ahead of it; macOS `main` pins `3eec5846`, both ancestors of this pin |
+| Engine alignment | `4dd3533f15874711283a415db1febf2a60629b12` → `d6512f5ae62c2be6751ed93adb9391ffe3f91579` |
 | Native consumer baseline | `704426e8df9acfb8e82fe4bf3b7ed3e5adbc2fea` |
 | Windows pre-migration baseline | `68e2541c5e9adb14a47433f8b25e26b0be84d1fc` |
-| Upstream and local-patch ledger | Immutable [`UPSTREAM.md`](https://github.com/Nanako0129/tokscale-core/blob/6a9de8ca5b35ed96e5c56e219e9b95a98633372d/UPSTREAM.md) |
+| Upstream and local-patch ledger | Immutable [`UPSTREAM.md`](https://github.com/Nanako0129/tokscale-core/blob/d6512f5ae62c2be6751ed93adb9391ffe3f91579/UPSTREAM.md) |
 
 > **Warning:** Do not edit shared source on a consumer branch. Engine changes
 > must pass review in `tokscale-core`; this repository then advances only the


### PR DESCRIPTION
The pin has sat at `4dd3533` on `feat/window-usage-export` — one commit past merge-base `6a9de8c`, and **60 commits behind** the engine's `main`. It could not advance until now: `crates/tb_core_ffi` calls `get_window_usage_with_source_context`, which did not exist on `main` (engine PR #15 landed only the plain entry point), so every re-pin failed to compile. [tokscale-core#27](https://github.com/Nanako0129/tokscale-core/pull/27) reconciled the two divergent implementations and landed the wrapper.

Advanced to **`d6512f5`**.

## The app's numbers change, and that is the point

Six fixes that move displayed figures arrive with this. Each verified absent from the old pin and present in the new one with `git merge-base --is-ancestor`, not read off a changelog:

| commit | what it fixes |
|---|---|
| `0235ef1` | Codex reasoning tokens **priced twice** |
| `c3ff6ce` | its cached-shard invalidation — without it the fix reaches nobody who already has a cache |
| `f4ed192` | Claude `tool_result` input tokens **char-estimated** |
| `550b66a` + `a04a6db` | Claude 1-hour cache writes billed at the 5-minute rate |
| `dee192e` | a fallback-priced model returned **different costs on two runs of the same data** |

**Measured end to end, not argued.** One fixed five-hour window over the real corpus (`from = 1_789_084_800_000`), full row fold:

| | old pin `4dd3533` | new pin `d6512f5` |
|---|---|---|
| rows | 42 | **26** |
| input | 206039 | **189822** |
| cost | 9.684641 | **12.186039** |
| output / cache_read / cache_write / reasoning | identical | identical |

The new figures match, byte for byte, a separate measurement of the engine's own `main` implementation taken before this change. So the window card has been reporting a **superset of rows** — extra `output=0` tool-result rows — and a cost roughly 20% low. Both came from the stranded branch, not from anything in this repository.

A fixed window matters for that comparison: the corpus is live, so a wall-clock window measures a different span on each run. I made that mistake once producing these numbers.

## Not pin-only for this consumer — flagging it rather than burying it

`CACHE_FORMAT_VERSION` moves **3 → 4**, and per-client parser identities move with it (Codex 4 → 6, Claude 2 → 4). **Existing users take a cache migration on first launch.**

Worth stating precisely because the same advance IS pin-only for the macOS consumer: the difference is which side of the divergence each pin was sitting on, not the contents of the advance.

`mod format3` is present upstream, so format-3 shards are **migrated rather than discarded**. That matters beyond cold-start cost — for Claude the cache is the only copy of turns a compacting rewrite removed from the transcript, so discarding would be deleting.

## Behaviour changes arriving with the reconciled export

Both documented in engine #27 and in that repo's `UPSTREAM.md` row:

- an empty or inverted window returns an **empty row list rather than an error**. This repo already depends on that (`crates/tb_core_ffi/src/window_usage.rs`, `empty_range_returns_empty_list_not_an_error`).
- the window scan's client filter is aligned to the aggregate paths — **inert here**, since this consumer passes `clients: None`.

## Verification

`cargo build -p tb_core_ffi` clean (44 pre-existing dead-code warnings, unchanged). `cargo test -p tb_core_ffi` **342 passed, 0 failed**.

`Cargo.lock` moves with the pin — a genuine dependency change the new engine brings, not noise. Without it, CI's `--locked` build fails.

CI is the real test here: this is 60 engine commits arriving at once, and the `crosscheck-swift` job runs the Swift oracle against the same fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ