### PR TITLE
fix(quota): qualify Codex Spark's identical window labels

### DIFF
--- a/src/TokenBar.App/WindowCardText.cs
+++ b/src/TokenBar.App/WindowCardText.cs
@@ -87,7 +87,7 @@ public static class WindowCardText
     /// One tab per window the client is CURRENTLY reporting, each carrying
     /// the running cycle a stored series has for it.
     /// <para>
-    /// Enumerated from the live side — <see cref="AgentUsageSnapshot.UniqueCardWindows"/>
+    /// Enumerated from the live side — <c>AgentUsageSnapshot.UniqueCardWindows</c>
     /// — the same shape as macOS's <c>uniqueCardWindows</c>-driven
     /// <c>candidates</c> list, and for the same reason: the live payload names
     /// each window once, with the provider's own label, while the store can

--- a/src/TokenBar.Core.Tests/AgentUsageQualifierTests.cs
+++ b/src/TokenBar.Core.Tests/AgentUsageQualifierTests.cs
@@ -1,0 +1,261 @@
+using System.Text.Json;
+using TokenBar.Interop;
+using Xunit;
+
+namespace TokenBar.Core.Tests;
+
+// Issue #286 — Codex Spark's 5-hour and weekly windows carry the same label.
+// Ported from TokenBarCore/SelfTest.swift's Codex Spark block (the fixture is
+// the macOS oracle's own fixture, not derived from this port).
+public class AgentUsageQualifierTests
+{
+    public AgentUsageQualifierTests() => Localization.Load("en", AppContext.BaseDirectory);
+
+    private static AgentUsagePayload Decode(string json) =>
+        JsonSerializer.Deserialize<AgentUsagePayload>(
+            json, new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+
+    // The exact macOS SelfTest.swift fixture (lines 5056-5074): two Spark
+    // windows the engine names identically, beside an ordinary "Weekly" window
+    // that happens to share the secondary's period. Pins collision-not-period
+    // (the "Weekly" entry is untouched despite sharing a period with the
+    // qualified secondary), the engine's own vocabulary, and that no identity
+    // moves.
+    [Fact]
+    public void SparkWindowLabelsMatchMacOsSelfTestFixture()
+    {
+        var payload = Decode(
+            """
+            {"generatedAt":"now","agents":[
+              {"clientId":"codex","source":"fixture","updatedAt":"now",
+               "windows":[
+                 {"cardId":"additional.deadbeef.primary.v1","label":"Codex Spark",
+                  "usedPercent":0,"remainingPercent":100,"windowMinutes":300,
+                  "resetsAt":"2030-07-09T00:00:00Z",
+                  "paceStatus":{"state":"learningHistory","windowKey":"additional.deadbeef.primary.v1",
+                  "durationSeconds":18000,"durationSource":"provider","completeCycles":3}},
+                 {"cardId":"additional.deadbeef.secondary.v1","label":"Codex Spark",
+                  "usedPercent":0,"remainingPercent":100,"windowMinutes":10080,
+                  "resetsAt":"2030-07-14T00:00:00Z",
+                  "paceStatus":{"state":"learningHistory","windowKey":"additional.deadbeef.secondary.v1",
+                  "durationSeconds":604800,"durationSource":"provider","completeCycles":2}},
+                 {"cardId":"weekly.v1","label":"Weekly","usedPercent":40,"remainingPercent":60,
+                  "windowMinutes":10080,"resetsAt":"2030-07-14T00:00:00Z",
+                  "paceStatus":{"state":"learningHistory","windowKey":"weekly.v1",
+                  "durationSeconds":604800,"durationSource":"contract","completeCycles":5}}
+               ]}
+            ]}
+            """);
+
+        var agent = payload.Agents[0];
+        var windows = agent.UniqueCardWindows;
+
+        Assert.Equal(
+            new[] { "Codex Spark · Session", "Codex Spark · Weekly", "Weekly" },
+            windows.Select(w => w.Label));
+
+        // Qualifying a label changes no identity and no wire value.
+        Assert.Equal(
+            new[] {
+                "additional.deadbeef.primary.v1", "additional.deadbeef.secondary.v1", "weekly.v1",
+            },
+            windows.Select(w => w.CardId));
+        Assert.Equal(
+            new[] {
+                "additional.deadbeef.primary.v1", "additional.deadbeef.secondary.v1", "weekly.v1",
+            },
+            windows.Select(w => w.PaceStatus.WindowKey));
+        Assert.Equal(
+            new[] { "Codex Spark", "Codex Spark", "Weekly" }, agent.Windows.Select(w => w.Label));
+
+        // Each qualified option still resolves to its own window.
+        Assert.Equal(
+            604_800,
+            QuotaResolver.Resolve(payload, "codex|additional.deadbeef.secondary.v1")!
+                .Window.DurationSeconds);
+    }
+
+    // Only one of two same-labelled windows has duration evidence — the
+    // sibling is still learning its own (learningDuration) and carries no
+    // resetsAt either, so no tier names both and qualification falls to
+    // ordinals. This is the ordering the migration protection exists for:
+    // RawCardWindows (read by QuotaResolver) must NOT see this qualification,
+    // because a persisted "codex|Codex Spark" selection that matched both
+    // windows before must not silently migrate to whichever one qualification
+    // happened to leave nameable.
+    [Fact]
+    public void MixedDurationAvailabilityFallsToOrdinalAndProtectsMigration()
+    {
+        var payload = Decode(
+            """
+            {"generatedAt":"now","agents":[
+              {"clientId":"codex","source":"fixture","updatedAt":"now",
+               "windows":[
+                 {"cardId":"additional.deadbeef.primary.v1","label":"Codex Spark",
+                  "usedPercent":0,"remainingPercent":100,"windowMinutes":300,
+                  "resetsAt":"2030-07-09T00:00:00Z",
+                  "paceStatus":{"state":"learningHistory","windowKey":"additional.deadbeef.primary.v1",
+                  "durationSeconds":18000,"durationSource":"provider","completeCycles":3}},
+                 {"cardId":"additional.deadbeef.secondary.v1","label":"Codex Spark",
+                  "usedPercent":0,"remainingPercent":100,
+                  "resetsAt":"2030-07-09T00:00:00Z",
+                  "paceStatus":{"state":"learningDuration",
+                  "windowKey":"additional.deadbeef.secondary.v1",
+                  "durationSource":"observed","completeCycles":0}}
+               ]}
+            ]}
+            """);
+
+        var agent = payload.Agents[0];
+        Assert.Equal(
+            new[] { "Codex Spark · 1", "Codex Spark · 2" },
+            agent.UniqueCardWindows.Select(w => w.Label));
+        Assert.Equal(
+            new[] { "Codex Spark", "Codex Spark" }, agent.RawCardWindows.Select(w => w.Label));
+
+        Assert.Equal(
+            "codex|Codex Spark", QuotaResolver.CanonicalSelection(payload, "codex|Codex Spark"));
+        Assert.Null(QuotaResolver.Resolve(payload, "codex|Codex Spark"));
+    }
+
+    private static string[] SparkPairLabels(long first, long second)
+    {
+        var json =
+            """
+            {"generatedAt":"now","agents":[
+              {"clientId":"codex","source":"fixture","updatedAt":"now",
+               "windows":[
+                 {"cardId":"a.v1","label":"Codex Spark","usedPercent":0,
+                  "remainingPercent":100,"windowMinutes":__firstMin__,
+                  "resetsAt":"2030-07-09T00:00:00Z",
+                  "paceStatus":{"state":"learningHistory","windowKey":"a.v1",
+                  "durationSeconds":__first__,"durationSource":"provider","completeCycles":1}},
+                 {"cardId":"b.v1","label":"Codex Spark","usedPercent":0,
+                  "remainingPercent":100,"windowMinutes":__secondMin__,
+                  "resetsAt":"2030-07-09T00:00:00Z",
+                  "paceStatus":{"state":"learningHistory","windowKey":"b.v1",
+                  "durationSeconds":__second__,"durationSource":"provider","completeCycles":1}}
+               ]}
+            ]}
+            """
+            .Replace("__firstMin__", (first / 60).ToString())
+            .Replace("__secondMin__", (second / 60).ToString())
+            .Replace("__first__", first.ToString())
+            .Replace("__second__", second.ToString());
+        return Decode(json).Agents[0].UniqueCardWindows.Select(w => w.Label).ToArray();
+    }
+
+    [Fact]
+    public void DifferingDurationsBelowTheLargestUnitStillProduceDifferentNames() =>
+        Assert.Equal(
+            new[] { "Codex Spark · 1h", "Codex Spark · 1h 30m" }, SparkPairLabels(3_600, 5_400));
+
+    [Fact]
+    public void EngineVocabularyLengthsUseSessionAndWeekly() =>
+        Assert.Equal(
+            new[] { "Codex Spark · Session", "Codex Spark · Weekly" },
+            SparkPairLabels(18_000, 604_800));
+
+    // Two windows of one period have no period to be told apart by, so the
+    // length tier is refused and the reset tier is asked — these carry no
+    // reset either, so the ordinal is what remains.
+    [Fact]
+    public void DurationsThatRenderIdenticallyFallToOrdinal() =>
+        Assert.Equal(new[] { "Codex Spark · 1", "Codex Spark · 2" }, SparkPairLabels(90, 119));
+
+    // A generated name must also avoid a label some OTHER window already
+    // carries — uniqueness inside the repeated group says nothing about the
+    // rest of the card view.
+    [Fact]
+    public void GeneratedNameStepsOverALabelAnotherWindowAlreadyCarries()
+    {
+        var payload = Decode(
+            """
+            {"generatedAt":"now","agents":[
+              {"clientId":"codex","source":"fixture","updatedAt":"now",
+               "windows":[
+                 {"cardId":"a.v1","label":"Foo","usedPercent":0,"remainingPercent":100},
+                 {"cardId":"b.v1","label":"Foo","usedPercent":0,"remainingPercent":100},
+                 {"cardId":"c.v1","label":"Foo · 1","usedPercent":0,"remainingPercent":100}
+               ]}
+            ]}
+            """);
+
+        var labels = payload.Agents[0].UniqueCardWindows.Select(w => w.Label).ToArray();
+        Assert.Equal(3, labels.Distinct().Count());
+        Assert.Contains("Foo · 1", labels);
+    }
+
+    // The state issue #286 was actually filed from: Codex reports a window
+    // with no usage yet as unavailable(invalidEvidence), which clears the
+    // duration AND windowMinutes, so both rows arrive at 100% remaining with
+    // no length at all. The reset each row already displays is what
+    // separates them (tier 2). Durations chosen with wide margins (5h, 7d) so
+    // the few milliseconds between building resetsAt here and the qualifier
+    // reading DateTimeOffset.UtcNow cannot cross a minute boundary.
+    [Fact]
+    public void DurationUnavailablePairIsNamedByReset()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var soon = now.AddHours(5).ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        var later = now.AddDays(7).ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        var payload = Decode(
+            """
+            {"generatedAt":"now","agents":[
+              {"clientId":"codex","source":"fixture","updatedAt":"now",
+               "windows":[
+                 {"cardId":"additional.deadbeef.primary.v1","label":"Codex Spark",
+                  "usedPercent":0,"remainingPercent":100,"resetsAt":"__soon__",
+                  "paceStatus":{"state":"unavailable",
+                  "windowKey":"additional.deadbeef.primary.v1",
+                  "completeCycles":0,"reason":"invalidEvidence"}},
+                 {"cardId":"additional.deadbeef.secondary.v1","label":"Codex Spark",
+                  "usedPercent":0,"remainingPercent":100,"resetsAt":"__later__",
+                  "paceStatus":{"state":"unavailable",
+                  "windowKey":"additional.deadbeef.secondary.v1",
+                  "completeCycles":0,"reason":"invalidEvidence"}}
+               ]}
+            ]}
+            """
+            .Replace("__soon__", soon)
+            .Replace("__later__", later));
+
+        Assert.Equal(
+            new[] { "Codex Spark · 5h", "Codex Spark · 7d" },
+            payload.Agents[0].UniqueCardWindows.Select(w => w.Label));
+    }
+
+    // The qualifier and the countdown beside it must round the same way: a
+    // reset one second inside five hours must not read "4h 59m" in the name
+    // while the row's own countdown says "Resets in 5h".
+    [Fact]
+    public void QualifierRoundingMatchesTheCountdownRounding()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var nearlyFiveHours = now.AddSeconds(5 * 3_600 - 1).ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        var sevenDays = now.AddDays(7).ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        var payload = Decode(
+            """
+            {"generatedAt":"now","agents":[
+              {"clientId":"codex","source":"fixture","updatedAt":"now",
+               "windows":[
+                 {"cardId":"a.v1","label":"Codex Spark","usedPercent":0,
+                  "remainingPercent":100,"resetsAt":"__nearlyFiveHours__",
+                  "paceStatus":{"state":"unavailable","windowKey":"a.v1",
+                  "completeCycles":0,"reason":"invalidEvidence"}},
+                 {"cardId":"b.v1","label":"Codex Spark","usedPercent":0,
+                  "remainingPercent":100,"resetsAt":"__sevenDays__",
+                  "paceStatus":{"state":"unavailable","windowKey":"b.v1",
+                  "completeCycles":0,"reason":"invalidEvidence"}}
+               ]}
+            ]}
+            """
+            .Replace("__nearlyFiveHours__", nearlyFiveHours)
+            .Replace("__sevenDays__", sevenDays));
+
+        var window = payload.Agents[0].UniqueCardWindows[0];
+        Assert.Equal("Codex Spark · 5h", window.Label);
+        Assert.Equal(
+            "Resets in 5h", UsagePace.ResetText(window.ResetsAt!, DateTimeOffset.UtcNow));
+    }
+}

--- a/src/TokenBar.Core/AgentUsageQualifier.cs
+++ b/src/TokenBar.Core/AgentUsageQualifier.cs
@@ -1,0 +1,205 @@
+using TokenBar.Interop;
+
+namespace TokenBar.Core;
+
+// Card-view label qualification — port of TokenBarCore/AgentUsage.swift's
+// `uniqueCardWindows` / `qualifyingRepeatedLabels` / `windowPeriod` (issue
+// #286).
+//
+// Codex reports its Spark allowance as one additional limit carrying both a
+// primary and a secondary window — 5 hours and 7 days — and the engine names
+// both of them "Codex Spark" because the label belongs to the limit, not the
+// window. The two rows are different windows with different card IDs, reset
+// schedules and histories, so every surface that drew the label alone offered
+// two identical, indistinguishable choices.
+//
+// Defined here rather than alongside <see cref="AgentUsageSnapshot"/> in
+// TokenBar.Interop: composing a qualified label needs the localization
+// vocabulary (<see cref="Localization"/>, <see cref="UsagePace"/>), and
+// TokenBar.Interop does not and should not depend on TokenBar.Core. A C# 14
+// extension property keeps the call site identical to an instance property —
+// none of the six render sites that already read
+// <c>agent.UniqueCardWindows</c> need to change.
+public static class AgentUsageQualifier
+{
+    extension(AgentUsageSnapshot agent)
+    {
+        /// <summary>
+        /// The card view every consumer draws from: <see
+        /// cref="AgentUsageSnapshot.RawCardWindows"/> with a label repeated
+        /// across windows disambiguated by <see cref="QualifyingRepeatedLabels"/>.
+        /// No card ID, window key or persisted selection changes — only the
+        /// <c>Label</c> text a repeated-label window carries.
+        /// </summary>
+        public IReadOnlyList<UsageWindow> UniqueCardWindows =>
+            QualifyingRepeatedLabels(agent.RawCardWindows, DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>
+    /// Appends a qualifier to a label that another window in the same card
+    /// view also carries. A label that appears once is returned untouched, so
+    /// every existing single-window presentation is unchanged.
+    ///
+    /// Three sources of evidence, tried in order, because the FIRST one can be
+    /// withdrawn by the provider at exactly the moment the rows are otherwise
+    /// indistinguishable:
+    ///
+    /// 1. <c>DurationSeconds</c> — the window's own length, named in the app's
+    ///    vocabulary (Session, Weekly, or the span).
+    /// 2. <c>ResetsAt</c> — the span until this row's own reset. A Codex
+    ///    window with no usage yet resolves to <c>unavailable(invalidEvidence)</c>,
+    ///    which clears the duration AND window minutes, so a pair reported at
+    ///    100% remaining — the state issue #286 was filed from — carries no
+    ///    length at all. The countdown is what the row already displays, and
+    ///    it is true by construction rather than a period inferred from one.
+    /// 3. Position in the card view — a deterministic ordinal. Reached only
+    ///    when a group has neither lengths nor resets that separate it, and
+    ///    present because #286 requires that unusable duration evidence still
+    ///    yields a unique name rather than the identical pair it reports.
+    ///
+    /// A tier is taken only when it names EVERY window of the group and names
+    /// them all differently; two windows of one period would otherwise be
+    /// handed a distinction that is not there. The reservation set spans the
+    /// whole card view, not just the group being qualified: a label of a
+    /// window that is NOT being qualified is reserved too, and the ordinal
+    /// walks past anything already used, because a provider really can emit a
+    /// separator-shaped label that collides with a generated one.
+    /// </summary>
+    internal static IReadOnlyList<UsageWindow> QualifyingRepeatedLabels(
+        IReadOnlyList<UsageWindow> windows, DateTimeOffset now)
+    {
+        var counts = new Dictionary<string, int>();
+        foreach (var window in windows)
+        {
+            counts[window.Label] = counts.GetValueOrDefault(window.Label) + 1;
+        }
+        if (!counts.Values.Any(count => count > 1))
+        {
+            return windows;
+        }
+
+        // What a window that is NOT being qualified will render as. A
+        // generated name has to avoid these too: a snapshot holding two "Foo"
+        // windows and one already labelled "Foo · 1" would otherwise be given
+        // a second "Foo · 1", and uniqueness inside the group says nothing
+        // about that.
+        var untouched = new HashSet<string>(
+            windows.Where(window => counts[window.Label] == 1).Select(window => window.Label));
+
+        string Compose(string label, string qualifier) =>
+            "{0} · {1}".Localized(label.Localized(), qualifier);
+
+        Dictionary<string, List<string>> Tier(Func<UsageWindow, string?> candidate)
+        {
+            var byLabel = new Dictionary<string, List<string>>();
+            foreach (var window in windows)
+            {
+                if (counts[window.Label] <= 1)
+                {
+                    continue;
+                }
+                var value = candidate(window);
+                if (value is null)
+                {
+                    byLabel[window.Label] = [];
+                    continue;
+                }
+                if (byLabel.TryGetValue(window.Label, out var empty) && empty.Count == 0)
+                {
+                    continue;
+                }
+                if (!byLabel.TryGetValue(window.Label, out var list))
+                {
+                    list = [];
+                    byLabel[window.Label] = list;
+                }
+                list.Add(value);
+            }
+
+            return byLabel
+                .Where(entry =>
+                    entry.Value.Count == counts[entry.Key] &&
+                    entry.Value.Distinct().Count() == entry.Value.Count &&
+                    entry.Value.All(value => !untouched.Contains(Compose(entry.Key, value))))
+                .ToDictionary(entry => entry.Key, entry => entry.Value);
+        }
+
+        var byLength = Tier(window =>
+            window.DurationSeconds is { } duration && duration > 0 ? WindowPeriod(duration) : null);
+
+        // The SAME span the countdown in the row prints, rounding included:
+        // UsagePace.DurationText alone rounds to the nearest minute while the
+        // countdown takes minutes up, which put "4h 59m" in a name beside
+        // "Resets in 5h" in the same row for the first half of every minute.
+        var byReset = Tier(window =>
+            window.ResetsAt is { } resetsAt && UsagePace.ParseRfc3339(resetsAt) is { } reset
+                ? UsagePace.SpanText(reset, now)
+                : null);
+
+        // The occurrence index within its own repeated-label group: the
+        // position each tier's candidates were collected at, and the seed for
+        // the ordinal the last tier falls back to. The ordinal walks forward
+        // past anything already on screen, so it is unique against the whole
+        // output rather than only against its own group.
+        var taken = new Dictionary<string, int>();
+        var used = new HashSet<string>(untouched);
+        var result = new List<UsageWindow>(windows.Count);
+        foreach (var window in windows)
+        {
+            if (counts[window.Label] <= 1)
+            {
+                result.Add(window);
+                continue;
+            }
+
+            var index = taken.GetValueOrDefault(window.Label);
+            taken[window.Label] = index + 1;
+
+            string? name = null;
+            if (byLength.TryGetValue(window.Label, out var lengthNames))
+            {
+                name = Compose(window.Label, lengthNames[index]);
+            }
+            else if (byReset.TryGetValue(window.Label, out var resetNames))
+            {
+                name = Compose(window.Label, resetNames[index]);
+            }
+
+            if (name is null || used.Contains(name))
+            {
+                var ordinal = index + 1;
+                while (used.Contains(Compose(window.Label, ordinal.ToString())))
+                {
+                    ordinal += 1;
+                }
+                name = Compose(window.Label, ordinal.ToString());
+            }
+
+            used.Add(name);
+            result.Add(window with { Label = name });
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// What kind of window this is, in the vocabulary the app already uses.
+    ///
+    /// The engine names Codex's MAIN rate limit from exactly these two
+    /// lengths — 18,000s => "Session", 604,800s => "Weekly" in
+    /// <c>codex_windows</c> — and deliberately keys on the length rather than
+    /// on which slot carried it. A Spark allowance arrives in the same two
+    /// shapes, so it reads with the same two words rather than in a second
+    /// vocabulary of its own; both are already translated. Any other length
+    /// falls back to the span itself, through the same formatter used
+    /// elsewhere — deliberately not a truncation to the largest unit, which
+    /// would render one hour and ninety minutes identically and rebuild the
+    /// ambiguity being removed.
+    /// </summary>
+    private static string WindowPeriod(long seconds) => seconds switch
+    {
+        18_000 => "Session".Localized(),
+        604_800 => "Weekly".Localized(),
+        _ => UsagePace.DurationText(seconds),
+    };
+}

--- a/src/TokenBar.Core/QuotaResolver.cs
+++ b/src/TokenBar.Core/QuotaResolver.cs
@@ -42,7 +42,15 @@ public static class QuotaResolver
             return selection;
         }
 
-        var windows = agent.UniqueCardWindows;
+        // The RAW card view: a persisted pre-v3 selection holds the label the
+        // provider sent, and whether that label was ambiguous is a fact about
+        // what the provider sent. UniqueCardWindows qualifies a repeated
+        // label with its window's duration, which can leave exactly one
+        // window still carrying the raw text and migrate a selection that
+        // used to match two. Card IDs are identical in both views, so the
+        // value this returns is unchanged for every selection that was
+        // already unique.
+        var windows = agent.RawCardWindows;
         var exact = windows.FirstOrDefault(w => w.CardId == parsed.Value.Value);
         if (exact is not null)
         {

--- a/src/TokenBar.Core/UsagePace.cs
+++ b/src/TokenBar.Core/UsagePace.cs
@@ -121,18 +121,37 @@ public sealed record UsagePace(
     /// lookup key.</summary>
     public static string NowText => "duration.now".LocalizedKey("now");
 
+    /// <summary>How long until <paramref name="reset"/>, under the countdown's
+    /// own rounding: seconds are floored, then minutes are taken UP. Null once
+    /// the reset has passed.
+    ///
+    /// Not inlined into <see cref="ResetText"/>, because a second caller names
+    /// a window by the same span — the qualifier for a repeated card label in
+    /// <c>AgentUsageQualifier</c>. <see cref="DurationText"/> alone rounds to
+    /// the NEAREST minute, so deriving the span twice put "4h 59m" in a row's
+    /// name beside "Resets in 5h" in the same row for the first half of every
+    /// minute. One contract, one implementation.</summary>
+    public static string? SpanText(DateTimeOffset reset, DateTimeOffset now)
+    {
+        var seconds = Math.Floor(UnixSeconds(reset) - UnixSeconds(now));
+        if (seconds <= 0)
+        {
+            return null;
+        }
+
+        // Truncation toward zero is the ceiling here because seconds > 0,
+        // matching Swift's Int((seconds + 59) / 60) on a positive Double.
+        var minutes = (int)((seconds + 59) / 60);
+        return DurationText(minutes * 60d);
+    }
+
     /// <summary>Localized countdown matching the Rust <c>resetText</c> rounding
     /// contract, ported from Format.swift's resetText(for:now:). The payload's
     /// own <c>resetText</c> is a compatibility field the engine renders in
     /// English; deriving the visible text from the structured timestamp instead
     /// is what lets the quota card follow the selected UI language. Returns
     /// null when the timestamp will not parse, so provider metadata that is not
-    /// a countdown keeps its own text.
-    ///
-    /// Two roundings, both load-bearing: floor on the raw seconds, then a
-    /// ceiling to whole minutes before DurationText applies its own
-    /// away-from-zero rounding. One second remaining must read as a minute, not
-    /// as "now".</summary>
+    /// a countdown keeps its own text.</summary>
     public static string? ResetText(string resetsAt, DateTimeOffset now)
     {
         if (ParseRfc3339(resetsAt) is not { } reset)
@@ -140,16 +159,9 @@ public sealed record UsagePace(
             return null;
         }
 
-        var seconds = Math.Floor(UnixSeconds(reset) - UnixSeconds(now));
-        if (seconds <= 0)
-        {
-            return "Resets now".Localized();
-        }
-
-        // Truncation toward zero is the ceiling here because seconds > 0,
-        // matching Swift's Int((seconds + 59) / 60) on a positive Double.
-        var minutes = (int)((seconds + 59) / 60);
-        return "Resets in {0}".Localized(DurationText(minutes * 60d));
+        return SpanText(reset, now) is { } span
+            ? "Resets in {0}".Localized(span)
+            : "Resets now".Localized();
     }
 
     /// <summary>The countdown to show for a window: derived from the

--- a/src/TokenBar.Interop/AgentUsage.cs
+++ b/src/TokenBar.Interop/AgentUsage.cs
@@ -749,9 +749,24 @@ public sealed record AgentUsageSnapshot(
         }
     }
 
-    /// <summary>Order-preserving unique card view; first duplicate wins.</summary>
+    /// <summary>
+    /// Order-preserving card view with the provider's labels exactly as they
+    /// arrived; first duplicate card ID wins.
+    ///
+    /// For the pre-v3 label migration in <c>QuotaResolver</c>, and only for it
+    /// — everything else wants <c>UniqueCardWindows</c> (the qualified view,
+    /// an extension property in <c>TokenBar.Core</c> because it needs the
+    /// localization vocabulary this project does not depend on). That
+    /// migration accepts a persisted label only when ONE window carries it,
+    /// and qualification can break a tie it is supposed to refuse: two windows
+    /// sharing a label where only one has duration evidence — a sibling still
+    /// in <c>learningDuration</c> — leave exactly one raw label behind, so a
+    /// persisted label that matched both before would now migrate to whichever
+    /// window happened to lack a duration. Ambiguity is a property of what the
+    /// provider sent, so it has to be read from what the provider sent.
+    /// </summary>
     [JsonIgnore]
-    public IReadOnlyList<UsageWindow> UniqueCardWindows
+    public IReadOnlyList<UsageWindow> RawCardWindows
     {
         get
         {


### PR DESCRIPTION
Ports macOS issue #286's fix family. Codex Spark's 5-hour and weekly windows carry the **same label**, so the UI cannot tell them apart — Windows renders `["Codex Spark", "Codex Spark", "Weekly"]` today.

The engine computes `additional_limit_label` once per limit (`"Codex Spark"` for any limit whose name contains "spark") and passes the same label into both slots. Distinct `window_key`s, identical label. `UniqueCardWindows` deduplicated by `CardId` only, so both survived and every consumer drew the label verbatim — the window-card tabs, the Settings picker, the tray quota-source menu, the dashboard, `QuotaLensData`, `QuotaSummary`.

In the tray's quota-source menu that is not a cosmetic defect: **two identically-named entries is a broken control**, because you cannot tell which one you selected.

## The rule, and what the fixture encodes

Qualification triggers on **label collision, never on period collision**. A label appearing once is returned untouched — which is why the macOS selftest fixture expects a bare `"Weekly"` as its third entry *even though that window shares `durationSeconds: 604800` with the Spark secondary window*. It is also what keeps every existing single-window presentation byte-identical.

Three tiers, tried in order, all-or-nothing per repeated-label group:

1. the window's own `durationSeconds`, named in the app's vocabulary — 18000 → `Session`, 604800 → `Weekly`, the same two tokens the engine already emits as Codex's main rate-limit labels;
2. the span to that row's own `resetsAt`;
3. a positional ordinal.

A tier is taken only when it names **every** window of the group, names them all **differently**, and collides with none of the reserved labels. Two windows of one period therefore get no length qualifier rather than both being handed the same one.

**The reservation set is the whole card view**, not the group: a snapshot holding two `Foo` windows beside one already labelled `Foo · 1` must not generate a second `Foo · 1`. Providers do emit separator-shaped labels — Antigravity's read `Gemini Models · Weekly Limit Remaining` — so this is not hypothetical.

**Tier 2 is the case #286 was actually filed from.** A Spark pair at 100% remaining is `unavailable(invalidEvidence)`, which clears duration *and* window minutes, so tier 1 cannot fire at all. The countdown is what the row already displays and is true by construction rather than a period inferred from one.

## Ported as the end state, not seven commits

`ab8a6bec`, `3dc28bea`, `46d53d60`, `fcc00a9f`, `637c38eb`, `4a99b078`, `46bb7b49` — five are successive corrections to the first, and every intermediate is known-wrong. `46d53d60` exists because truncating the span to its largest unit made 3600s and 5400s both render `1h`, rebuilding the ambiguity being removed; `46bb7b49` exists because the original checked distinctness only *inside* each group.

## Ordering, and the one non-obvious constraint

1. `UsagePace.SpanText` extracted out of `ResetText`, so the qualifier and the countdown share one implementation. Previously the qualifier would have rounded to the nearest minute while the countdown floors-then-ceilings — putting `Codex Spark · 4h 59m` beside `Resets in 5h` in the same row for the first half of every minute.
2. `RawCardWindows` added and `QuotaResolver`'s pre-v3 label migration repointed at it, **before** qualification exists. Reversed, an intermediate build silently migrates an ambiguous persisted selection to whichever window happens to lack a duration. Ambiguity is a property of what the provider sent, so it must be read from what the provider sent.
3. Then the qualifier itself.

## A deviation from the plan, with its reason

The qualified view lives in a new `src/TokenBar.Core/AgentUsageQualifier.cs`, not in `AgentUsage.cs` where the record is. `TokenBar.Interop` cannot depend on `TokenBar.Core`, where `Localization` and `UsagePace` live, so the qualifier had to move. It is exposed back as a **C# 14 extension property**, which keeps all six render call sites reading `agent.UniqueCardWindows` with no syntax change — verified unedited by grep. The one App-side line in this diff is a doc-comment `<see cref>` → `<c>`, because the member is no longer declared on the record.

**CI is the real test of that choice.** The extension-property syntax was verified to compile against SDK 10.0.302 locally, but this repo pins 10.0.301 with `rollForward: disable`, and every consumer is in `TokenBar.App`, which does not build on macOS.

## Verification

`dotnet test`: **1103 → 1111** passed (same 3 pre-existing native-library load failures either side). **Zero existing assertions changed value** — that is rule 1 doing its job.

8 new tests, all hand-mutation verified with exact inverse reverts: the exact macOS fixture, the duration-unavailable tier, the ordinal tier, rounding parity between qualifier and countdown, and collision avoidance against a reserved label.

**One thing I am flagging rather than claiming.** The brief framed the `RawCardWindows`-before-qualification ordering as protecting a reproducible migration bug. Under the correct all-or-nothing group semantics no mutation could be constructed that makes the two views produce different `CanonicalSelection` results — `compose()` never reproduces the bare original label for any window in a group of more than one, so they are provably equivalent here. The split is still correct to keep: it is what the Swift specifies, and it becomes the difference between right and wrong the moment anyone weakens the qualifier to per-window. But it is not red/green testable as implemented, and saying otherwise would be asserting a guard that does not currently guard.

No new user-facing strings; the required tokens already exist in `strings-zh-Hant.json`. Engine submodule untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ