### PR TITLE
chore(release): bump the version contract to 0.3.0

### DIFF
--- a/.github/release-notes/v0.3.0.md
+++ b/.github/release-notes/v0.3.0.md
@@ -1,0 +1,66 @@
+# Syrtis v0.3.0
+
+**Your cost figures will change when you update, and your first launch will be slow.** Both are expected. Token counts are unchanged; what moved is cost, and it moved because the old numbers were wrong. Details below.
+
+## The Quota lens
+
+A new Quota view, and the largest addition since this port began.
+
+It shows what each of your subscriptions has left and how fast you are spending it: an overview strip and heatmap across every provider, then per-client window and history cards for the one you select, plus the Agent-limits card.
+
+Behind it is a usage-attribution subsystem. Local session usage does not say which subscription paid for it — a Claude Code session could be on your Pro plan or on API credit, and nothing in the transcript records which. Settings now has an Attribution page where you declare that once, and the Quota lens counts accordingly.
+
+## Your cost figures were wrong, and are now less wrong
+
+This release advances the shared parsing engine by 60 commits. Six of them change numbers you have already seen:
+
+- **Codex reasoning tokens were priced twice.** They are reported as a subset of output tokens, and were being charged as both.
+- **Claude `tool_result` input tokens were estimated from character counts** rather than counted.
+- **Claude 1-hour cache writes were billed at the 5-minute rate.** Anthropic charges 2x base input for the 1-hour TTL where a 5-minute write is 1.25x.
+- **A model priced through the fallback table could report different costs on two runs over the same data.** Candidates of equal length were taken in hash-iteration order.
+
+**Token counts have not changed. Only cost has.** And the direction is worth stating plainly: **Syrtis was under-counting what you spent.** It is not charging you more now — it was charging you too little before.
+
+## The quota equivalence line was 12x wrong
+
+The line reading *"this window's usage is worth about n of your allowance"* divided by the wrong thing. It measured the difference between the first and last quota reading, which collapses to nearly nothing across a reset while the usage above the line keeps counting every message in the span.
+
+Measured on real data, it was **off by a factor of 12**. It now measures the distance the readings actually travelled.
+
+The heatmap card on the same view was already computing this correctly, so before this release the two cards disagreed with each other about the same window.
+
+## Codex Spark's two windows are finally distinguishable
+
+Codex Spark's 5-hour and weekly allowances arrived with identical labels, so the tray's quota-source menu offered two entries you could not tell apart — and selecting one gave no indication which you had chosen.
+
+They are now qualified by length: **Codex Spark · Session** and **Codex Spark · Weekly**. When the provider withholds the length — which is exactly what happens on a fresh window reporting 100% remaining — the qualifier falls back to that row's own reset countdown.
+
+## One slow launch after updating
+
+The engine changes require rebuilding the parse cache, so **the first launch after this update takes noticeably longer**. Subsequent launches return to normal.
+
+**No history is lost.** The old cache format is migrated rather than discarded. That distinction matters most for Claude: once a conversation has been compacted, the cache holds the only copy of the turns that were rewritten out of the transcript.
+
+## Also in this release
+
+**Full Traditional Chinese interface** — the tray, dashboard, settings, number formats and time phrasing, selectable in Settings.
+
+**Reworked Settings window** with sidebar navigation, and the new Attribution page.
+
+**A Monthly view**, alongside Daily and Hourly.
+
+**Install wizard and in-app updates** — check for updates, watch the download, restart to apply.
+
+**New clients**: Junie and OCR.
+
+A new application icon.
+
+**Fixes**: horizontal scroll wheel in the dashboard; tray icon cropping and padding; flyout shortcut cycling; partial cost-coverage display; four quota cards that printed `$0.00` for usage with no price attached, where they now show a dash; the Models view listing one model several times because provider-split rows were never folded, which also meant Stats could name a provider shard as your favourite model; the Overview lens ignoring which client tab you had selected; and client names carrying a form factor they do not actually describe — `Cursor IDE` became `Cursor`, because that row covers IDE, agent and cloud usage alike.
+
+## Known limitations
+
+Present on the macOS build, not yet here: Discord Rich Presence, per-client tray items, Simplified Chinese, menu-bar font colour, the flat-heatmap chart mode, agent brand icons (clients render as coloured discs), the Agent-limits sparkline and chart layout, the Stats attribution-breakdown card, and support for multiple Claude accounts.
+
+## Channels
+
+Four installers: `win-x64`, `win-x64-lite`, `win-arm64`, `win-arm64-lite`. **Full** bundles the .NET 10 runtime and is the safe choice. **Lite** acquires it at install time and is only smaller if your machine already has .NET 10. A channel cannot be switched after installing without uninstalling first.

--- a/.github/release-notes/v0.3.0.md
+++ b/.github/release-notes/v0.3.0.md
@@ -1,6 +1,6 @@
 # Syrtis v0.3.0
 
-**Your cost figures will change when you update, and your first launch will be slow.** Both are expected. Token counts are unchanged; what moved is cost, and it moved because the old numbers were wrong. Details below.
+**Your numbers will change when you update, and your first launch will be slow.** Both are expected. Some token counts move as well as cost, and they move because the old ones were wrong. Details below.
 
 ## The Quota lens
 
@@ -19,7 +19,14 @@ This release advances the shared parsing engine by 60 commits. Six of them chang
 - **Claude 1-hour cache writes were billed at the 5-minute rate.** Anthropic charges 2x base input for the 1-hour TTL where a 5-minute write is 1.25x.
 - **A model priced through the fallback table could report different costs on two runs over the same data.** Candidates of equal length were taken in hash-iteration order.
 
-**Token counts have not changed. Only cost has.** And the direction is worth stating plainly: **Syrtis was under-counting what you spent.** It is not charging you more now — it was charging you too little before.
+Two of those change **token counts**, not just cost:
+
+- Claude input falls, because `tool_result` tokens were being estimated from characters and are now counted. Estimation ran high.
+- Codex output falls, because reasoning tokens were being carried in the output bucket *and* the reasoning bucket at once. They are now in one.
+
+The rest change cost only. The overall direction is worth stating plainly: **Syrtis was under-counting what you spent.** It is not charging you more now — it was charging you too little before.
+
+If you keep your own records, expect totals from before and after this update not to line up. That is the correction landing, not a new defect.
 
 ## The quota equivalence line was 12x wrong
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
   <PropertyGroup>
     <TbProductName>Syrtis</TbProductName>
     <Product>$(TbProductName)</Product>
-    <TbSemanticVersion>0.2.2</TbSemanticVersion>
-    <TbAssemblyVersion>0.2.2.0</TbAssemblyVersion>
+    <TbSemanticVersion>0.3.0</TbSemanticVersion>
+    <TbAssemblyVersion>0.3.0.0</TbAssemblyVersion>
     <Version>$(TbSemanticVersion)</Version>
     <PackageVersion>$(TbSemanticVersion)</PackageVersion>
     <InformationalVersion>$(TbSemanticVersion)</InformationalVersion>

--- a/scripts/build-app-artifact.ps1
+++ b/scripts/build-app-artifact.ps1
@@ -32,8 +32,8 @@ Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot "lib\MuiGuard.ps1")
 . (Join-Path $PSScriptRoot "lib\RuntimeConfig.ps1")
 
-$ExpectedSemanticVersion = "0.2.2"
-$ExpectedAssemblyVersion = "0.2.2.0"
+$ExpectedSemanticVersion = "0.3.0"
+$ExpectedAssemblyVersion = "0.3.0.0"
 $ExpectedDotnetVersion = "10.0.301"
 $ExpectedRustVersion = "1.96.1"
 

--- a/src/TokenBar.App/app.manifest
+++ b/src/TokenBar.App/app.manifest
@@ -2,7 +2,7 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <!-- Keep this checked template literal aligned with Directory.Build.props;
        the Phase 10 artifact verifier rejects drift. -->
-  <assemblyIdentity version="0.2.2.0" name="TokenBar.App" />
+  <assemblyIdentity version="0.3.0.0" name="TokenBar.App" />
 
   <!-- Without this the process runs DPI-virtualized: AppWindow coordinates
        live in a scaled-down space while the screen (and the low-level mouse


### PR DESCRIPTION
Version bump ahead of tagging `v0.3.0`. Hands-on acceptance passed on the x64 host against this exact tree — the built exe reports `ProductVersion 0.3.0` from `4ba4cc7`.

## Why this lands before the tag

`release.yml` refuses to publish when the tag and `Directory.Build.props` disagree, and its own comment says why: tagging `v0.3.0` on a tree that still reads `0.2.2` would publish 0.2.2 assets under a 0.3.0 release, and the mismatch would surface only when an installed client refused the update.

## The version is stated in three places, not one

Only the first is what the tag is checked against:

| Where | Checked by |
|---|---|
| `Directory.Build.props` — `TbSemanticVersion`, `TbAssemblyVersion` | `release.yml`'s "Tag must match the version contract" step |
| `scripts/build-app-artifact.ps1` — `$ExpectedSemanticVersion`, `$ExpectedAssemblyVersion` | asserted twice: against `Directory.Build.props` itself, and against the published App's `FileVersion`/`ProductVersion` |

Bumping only the props file leaves a green local build and fails the `build` job in CI. Grepped for every other statement before committing; the remaining hits are stale worktrees under `.claude/` and two comments quoting `0.2.2` as illustration.

## Why 0.3.0 and not 0.2.3

Forty-two merges since v0.2.2: the Quota lens and the usage-attribution subsystem, a new Monthly lens, the settings sidebar rework, full Traditional Chinese, the install wizard and in-app updater, and an engine advance that changes displayed cost figures.

## Why not 1.0.0

The Quota lens has never been in a release, so its first field report would arrive alongside the label. **Signing is deliberately not the reason** — the macOS build ad-hoc signs (`codesign --sign -`) and ships that way at v1.17.0, so requiring Authenticode here would hold this port to a standard the project does not use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9MnsHYT6Ftpq2an3LFeXZ